### PR TITLE
feat: seal active trace segments on demand

### DIFF
--- a/dial9-core/src/buffer.rs
+++ b/dial9-core/src/buffer.rs
@@ -3,6 +3,8 @@ use dial9_trace_format::encoder::{Encoder, RawEncoder};
 use crate::clock::clock_pair;
 use crate::collector::Batch;
 use crate::format::{ClockSyncEvent, SegmentMetadataEvent};
+#[cfg(feature = "pipeline")]
+use crate::fs::CheckpointGuard;
 use crate::fs::{ActiveHandle, Fs, RemoveReason};
 use crate::primitives::fs;
 use crate::rate_limit::rate_limited;
@@ -842,15 +844,8 @@ impl<M: BufferMode> SegmentWriter<M> {
     /// recording gate, so a busy capture-stop request has no lifecycle side
     /// effects.
     #[cfg(feature = "pipeline")]
-    pub(crate) fn reserve_checkpoint(&self) -> std::io::Result<()> {
-        if self.fs.try_reserve_checkpoint() {
-            Ok(())
-        } else {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::WouldBlock,
-                "another current-data checkpoint is still active",
-            ))
-        }
+    pub(crate) fn reserve_checkpoint(&self) -> std::io::Result<CheckpointGuard> {
+        CheckpointGuard::reserve(&self.fs)
     }
 
     /// Protect the current ring snapshot, then seal a non-empty active
@@ -859,7 +854,10 @@ impl<M: BufferMode> SegmentWriter<M> {
     /// the disk segment's pipeline pass; this prevents the checkpoint's own
     /// rotation from evicting data it is about to dispatch.
     #[cfg(feature = "pipeline")]
-    pub(crate) fn checkpoint_segments(&mut self) -> std::io::Result<Vec<u32>> {
+    pub(crate) fn seal_checkpoint(
+        &mut self,
+        mut checkpoint: CheckpointGuard,
+    ) -> std::io::Result<CheckpointGuard> {
         if matches!(self.state, WriterState::Finished) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::BrokenPipe,
@@ -882,14 +880,12 @@ impl<M: BufferMode> SegmentWriter<M> {
         } else {
             self.fs.protect_memory_checkpoint_segments(current_index)
         };
+        checkpoint.track(protected);
 
-        if self.has_real_events
-            && let Err(error) = self.rotate_strict()
-        {
-            self.fs.release_checkpoint_segments(&protected);
-            return Err(error);
+        if self.has_real_events {
+            self.rotate_strict()?;
         }
-        Ok(protected)
+        Ok(checkpoint)
     }
 
     /// Re-apply the disk budget after the worker finishes checkpoint segments
@@ -900,16 +896,6 @@ impl<M: BufferMode> SegmentWriter<M> {
             self.evict_oldest()?;
         }
         Ok(())
-    }
-
-    #[cfg(feature = "pipeline")]
-    pub(crate) fn release_checkpoint_segments(&self, indices: &[u32]) {
-        self.fs.release_checkpoint_segments(indices);
-    }
-
-    #[cfg(feature = "pipeline")]
-    pub(crate) fn finish_checkpoint(&self) {
-        self.fs.finish_checkpoint();
     }
 
     #[cfg(test)]

--- a/dial9-core/src/buffer.rs
+++ b/dial9-core/src/buffer.rs
@@ -771,8 +771,9 @@ impl<M: BufferMode> SegmentWriter<M> {
         }
         // If even the current file alone exceeds total budget, stop writing.
         // Protected checkpoint segments may temporarily occupy the pipeline's
-        // in-flight reserve; they become evictable as soon as the worker loads
-        // them and must not make the active writer look irrecoverably full.
+        // in-flight reserve; they remain protected across retries and become
+        // evictable only after a terminal pipeline outcome or dump cleanup.
+        // They must not make the active writer look irrecoverably full.
         if self.total_size() > self.max_total_size && self.closed_files.is_empty() {
             self.state = WriterState::Finished;
         }
@@ -1324,6 +1325,39 @@ mod tests {
             writer.rotate_segment().unwrap(),
             "the recovered writer remains usable"
         );
+    }
+
+    #[cfg(feature = "pipeline")]
+    #[test]
+    fn terminal_checkpoint_removal_reconciles_disk_budget() {
+        let dir = TempDir::new().unwrap();
+        let max_total_size = single_event_file_size();
+        let mut writer = DiskBuffer::builder()
+            .base_path(dir.path())
+            .max_file_size(u64::MAX)
+            .max_total_size(max_total_size)
+            .rotation_period(Duration::MAX)
+            .build()
+            .unwrap();
+        writer.write_encoded_batch(&test_batch()).unwrap();
+
+        let checkpoint = writer.reserve_checkpoint().unwrap();
+        let (checkpoint, post_seal_error) = writer.seal_checkpoint(checkpoint).unwrap();
+        assert!(post_seal_error.is_none());
+        assert_eq!(writer.closed_files.len(), 1);
+        assert!(writer.total_size() > max_total_size);
+
+        let sealed = writer.closed_files.front().unwrap().0.clone();
+        writer.fs.remove_sealed(&sealed, RemoveReason::Terminal);
+        drop(checkpoint);
+
+        writer.enforce_checkpoint_budget().unwrap();
+        assert!(
+            writer.closed_files.is_empty(),
+            "terminal removal must discard the writer's stale retention entry"
+        );
+        assert!(writer.total_size() <= max_total_size);
+        assert!(!writer.is_closed());
     }
 
     #[test]

--- a/dial9-core/src/buffer.rs
+++ b/dial9-core/src/buffer.rs
@@ -716,13 +716,26 @@ impl<M: BufferMode> SegmentWriter<M> {
             return Ok(());
         }
         // Always keep at least the current file.
-        while self.total_size() > self.max_total_size && !self.closed_files.is_empty() {
-            if let Some((seg_ref, _size)) = self.closed_files.pop_front() {
+        while self.total_size() > self.max_total_size {
+            #[cfg(feature = "pipeline")]
+            let evict_pos = self
+                .closed_files
+                .iter()
+                .position(|(segment, _)| !self.fs.checkpoint_segment_is_protected(segment.index()));
+            #[cfg(not(feature = "pipeline"))]
+            let evict_pos = (!self.closed_files.is_empty()).then_some(0);
+            let Some(evict_pos) = evict_pos else {
+                break;
+            };
+            if let Some((seg_ref, _size)) = self.closed_files.remove(evict_pos) {
                 self.fs.remove_sealed(&seg_ref, RemoveReason::Eviction);
             }
         }
         // If even the current file alone exceeds total budget, stop writing.
-        if self.total_size() > self.max_total_size {
+        // Protected checkpoint segments may temporarily occupy the pipeline's
+        // in-flight reserve; they become evictable as soon as the worker loads
+        // them and must not make the active writer look irrecoverably full.
+        if self.total_size() > self.max_total_size && self.closed_files.is_empty() {
             self.state = WriterState::Finished;
         }
         Ok(())
@@ -808,7 +821,7 @@ impl<M: BufferMode> SegmentWriter<M> {
     /// Seal a non-empty current segment immediately and continue writing into
     /// a fresh segment. The flush loop performs the required thread-local
     /// drain before calling this.
-    #[cfg(any(feature = "pipeline", test))]
+    #[cfg(test)]
     pub(crate) fn rotate_segment(&mut self) -> std::io::Result<bool> {
         if matches!(self.state, WriterState::Finished) {
             return Err(std::io::Error::new(
@@ -821,6 +834,82 @@ impl<M: BufferMode> SegmentWriter<M> {
         }
         self.rotate_strict()?;
         Ok(true)
+    }
+
+    /// Reserve the sole current-data checkpoint snapshot.
+    ///
+    /// Reservation happens before source sampling or a capture-stop closes the
+    /// recording gate, so a busy capture-stop request has no lifecycle side
+    /// effects.
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn reserve_checkpoint(&self) -> std::io::Result<()> {
+        if self.fs.try_reserve_checkpoint() {
+            Ok(())
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::WouldBlock,
+                "another current-data checkpoint is still active",
+            ))
+        }
+    }
+
+    /// Protect the current ring snapshot, then seal a non-empty active
+    /// fragment. The caller must hold the checkpoint reservation. Protection
+    /// lasts until the triggered worker takes each memory segment or finishes
+    /// the disk segment's pipeline pass; this prevents the checkpoint's own
+    /// rotation from evicting data it is about to dispatch.
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn checkpoint_segments(&mut self) -> std::io::Result<Vec<u32>> {
+        if matches!(self.state, WriterState::Finished) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "dial9 trace writer is closed",
+            ));
+        }
+
+        let current_index = self.has_real_events.then_some(self.next_index - 1);
+        let protected = if M::IS_DISK {
+            let mut indices: Vec<u32> = self
+                .closed_files
+                .iter()
+                .map(|(segment, _)| segment.index())
+                .collect();
+            if let Some(index) = current_index {
+                indices.push(index);
+            }
+            self.fs.protect_disk_checkpoint_segments(&indices);
+            indices
+        } else {
+            self.fs.protect_memory_checkpoint_segments(current_index)
+        };
+
+        if self.has_real_events
+            && let Err(error) = self.rotate_strict()
+        {
+            self.fs.release_checkpoint_segments(&protected);
+            return Err(error);
+        }
+        Ok(protected)
+    }
+
+    /// Re-apply the disk budget after the worker finishes checkpoint segments
+    /// and releases their short-lived eviction protection.
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn enforce_checkpoint_budget(&mut self) -> std::io::Result<()> {
+        if self.fs.checkpoint_budget_dirty() {
+            self.evict_oldest()?;
+        }
+        Ok(())
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn release_checkpoint_segments(&self, indices: &[u32]) {
+        self.fs.release_checkpoint_segments(indices);
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn finish_checkpoint(&self) {
+        self.fs.finish_checkpoint();
     }
 
     #[cfg(test)]

--- a/dial9-core/src/buffer.rs
+++ b/dial9-core/src/buffer.rs
@@ -594,6 +594,7 @@ impl<M: BufferMode> SegmentWriter<M> {
     /// Automatic rotation remains best-effort for compatibility. Explicit
     /// checkpoints use this strict path because their acknowledgement must not
     /// claim a segment was sealed after data failed to reach the backend.
+    #[cfg(any(feature = "pipeline", test))]
     fn rotate_strict(&mut self) -> std::io::Result<()> {
         self.rotate_with_flush_policy(true)
     }
@@ -638,8 +639,10 @@ impl<M: BufferMode> SegmentWriter<M> {
         };
 
         // Seal the current segment. If `.active` was removed externally
-        // (disk only: operator, log rotation, container teardown) abandon the
-        // segment and start a fresh one.
+        // (disk only: operator, log rotation, container teardown), recover by
+        // starting a fresh one. Explicit checkpoints still return the
+        // `NotFound` after recovery so they never acknowledge missing data.
+        let mut abandoned_error = None;
         match self.fs.seal(handle, &self.active_path, current_index) {
             Ok(seg_ref) => {
                 if M::IS_DISK {
@@ -654,6 +657,9 @@ impl<M: BufferMode> SegmentWriter<M> {
                         self.active_path.display()
                     );
                 });
+                if strict_flush {
+                    abandoned_error = Some(e);
+                }
             }
             Err(e) => {
                 // state is already Finished from mem::replace above
@@ -685,7 +691,10 @@ impl<M: BufferMode> SegmentWriter<M> {
             "rotated to new trace segment"
         );
         self.evict_oldest()?;
-        Ok(())
+        match abandoned_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
     }
 
     /// Total size across all closed + active segments (disk mode only).
@@ -774,6 +783,7 @@ impl<M: BufferMode> SegmentWriter<M> {
         self.has_real_events && time_source().instant().as_std() >= self.next_drain_time
     }
 
+    #[cfg(any(feature = "pipeline", test))]
     pub(crate) fn is_closed(&self) -> bool {
         matches!(self.state, WriterState::Finished)
     }
@@ -798,6 +808,7 @@ impl<M: BufferMode> SegmentWriter<M> {
     /// Seal a non-empty current segment immediately and continue writing into
     /// a fresh segment. The flush loop performs the required thread-local
     /// drain before calling this.
+    #[cfg(any(feature = "pipeline", test))]
     pub(crate) fn rotate_segment(&mut self) -> std::io::Result<bool> {
         if matches!(self.state, WriterState::Finished) {
             return Err(std::io::Error::new(
@@ -1161,6 +1172,37 @@ mod tests {
             .rotate_segment()
             .expect_err("checkpoint rotation must propagate its final flush failure");
         assert_eq!(error.kind(), std::io::ErrorKind::Other);
+    }
+
+    #[test]
+    fn explicit_rotation_reports_missing_active_after_recovery() {
+        let dir = TempDir::new().unwrap();
+        let mut writer = DiskBuffer::builder()
+            .base_path(dir.path())
+            .max_file_size(1024 * 1024)
+            .max_total_size(8 * 1024 * 1024)
+            .rotation_period(Duration::MAX)
+            .build()
+            .unwrap();
+        writer.write_encoded_batch(&test_batch()).unwrap();
+        let missing = writer.current_active_path().to_owned();
+        std::fs::remove_file(&missing).unwrap();
+
+        let error = writer
+            .rotate_segment()
+            .expect_err("a checkpoint must not acknowledge a missing active segment");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound);
+        assert!(
+            !writer.is_closed(),
+            "the writer should recover with a fresh active segment"
+        );
+        assert!(writer.current_active_path().exists());
+
+        writer.write_encoded_batch(&test_batch()).unwrap();
+        assert!(
+            writer.rotate_segment().unwrap(),
+            "the recovered writer remains usable"
+        );
     }
 
     #[test]

--- a/dial9-core/src/buffer.rs
+++ b/dial9-core/src/buffer.rs
@@ -586,6 +586,19 @@ impl<M: BufferMode> SegmentWriter<M> {
     }
 
     fn rotate(&mut self) -> std::io::Result<()> {
+        self.rotate_with_flush_policy(false)
+    }
+
+    /// Rotate while propagating every buffered-write failure to the caller.
+    ///
+    /// Automatic rotation remains best-effort for compatibility. Explicit
+    /// checkpoints use this strict path because their acknowledgement must not
+    /// claim a segment was sealed after data failed to reach the backend.
+    fn rotate_strict(&mut self) -> std::io::Result<()> {
+        self.rotate_with_flush_policy(true)
+    }
+
+    fn rotate_with_flush_policy(&mut self, strict_flush: bool) -> std::io::Result<()> {
         if matches!(self.state, WriterState::Finished) {
             return Ok(());
         }
@@ -605,17 +618,24 @@ impl<M: BufferMode> SegmentWriter<M> {
             return Ok(());
         };
 
-        // Best-effort flush. If the underlying file is gone the buffered bytes
-        // are already lost; proceed to rotate rather than erroring.
-        let _ = raw.flush();
+        if strict_flush {
+            raw.flush()?;
+        } else {
+            // Automatic rotation is best-effort. If the underlying file is
+            // gone the buffered bytes are already lost; proceed to rotate
+            // rather than repeatedly retrying a permanently broken segment.
+            let _ = raw.flush();
+        }
         let closed_size = raw.bytes_written();
         let current_index = self.next_index - 1;
 
         // Extract the ActiveHandle for sealing.
         let bw: BufWriter<ActiveHandle> = raw.into_inner();
-        let handle: ActiveHandle = bw
-            .into_inner()
-            .unwrap_or_else(|e| e.into_inner().into_parts().0);
+        let handle: ActiveHandle = match bw.into_inner() {
+            Ok(handle) => handle,
+            Err(error) if strict_flush => return Err(error.into_error()),
+            Err(error) => error.into_inner().into_parts().0,
+        };
 
         // Seal the current segment. If `.active` was removed externally
         // (disk only: operator, log rotation, container teardown) abandon the
@@ -754,6 +774,10 @@ impl<M: BufferMode> SegmentWriter<M> {
         self.has_real_events && time_source().instant().as_std() >= self.next_drain_time
     }
 
+    pub(crate) fn is_closed(&self) -> bool {
+        matches!(self.state, WriterState::Finished)
+    }
+
     pub(crate) fn drained(&mut self) -> std::io::Result<bool> {
         if !self.has_real_events {
             return Ok(false);
@@ -769,6 +793,36 @@ impl<M: BufferMode> SegmentWriter<M> {
         // Periodic drain without rotation; advance the drain timer.
         self.next_drain_time = now + self.drain_interval;
         Ok(false)
+    }
+
+    /// Seal a non-empty current segment immediately and continue writing into
+    /// a fresh segment. The flush loop performs the required thread-local
+    /// drain before calling this.
+    pub(crate) fn rotate_segment(&mut self) -> std::io::Result<bool> {
+        if matches!(self.state, WriterState::Finished) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "dial9 trace writer is closed",
+            ));
+        }
+        if !self.has_real_events {
+            return Ok(false);
+        }
+        self.rotate_strict()?;
+        Ok(true)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn fail_after_flushes_for_test(
+        &mut self,
+        successful_flushes: usize,
+    ) -> std::io::Result<()> {
+        self.state =
+            Self::prepare_segment(BufWriter::new(crate::fs::ActiveHandle::FailAfterFlushes {
+                bytes: Vec::new(),
+                successful_flushes,
+            }))?;
+        Ok(())
     }
 
     /// Finalize the writer: flush, seal the active segment, and prevent further
@@ -1083,6 +1137,30 @@ mod tests {
             metadata.len() > 0,
             "file should not be empty after writing an event"
         );
+    }
+
+    #[test]
+    fn explicit_rotation_propagates_final_flush_failure() {
+        let dir = TempDir::new().unwrap();
+        let mut writer = DiskBuffer::builder()
+            .base_path(dir.path())
+            .max_file_size(1024 * 1024)
+            .max_total_size(8 * 1024 * 1024)
+            .rotation_period(Duration::MAX)
+            .build()
+            .unwrap();
+        writer.fail_after_flushes_for_test(1).unwrap();
+        writer.write_encoded_batch(&test_batch()).unwrap();
+
+        // Model flush_once succeeding, followed by metadata being buffered for
+        // the explicit checkpoint. The strict rotation must report the second
+        // flush failure rather than sealing and acknowledging success.
+        writer.flush().unwrap();
+        writer.write_current_segment_metadata().unwrap();
+        let error = writer
+            .rotate_segment()
+            .expect_err("checkpoint rotation must propagate its final flush failure");
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
     }
 
     #[test]

--- a/dial9-core/src/buffer.rs
+++ b/dial9-core/src/buffer.rs
@@ -239,6 +239,22 @@ enum WriterState {
     Finished,
 }
 
+struct RotationFailure {
+    error: std::io::Error,
+    #[cfg_attr(not(feature = "pipeline"), allow(dead_code))]
+    sealed: bool,
+}
+
+impl RotationFailure {
+    fn new(error: std::io::Error, sealed: bool) -> Self {
+        Self { error, sealed }
+    }
+
+    fn before_seal(error: std::io::Error) -> Self {
+        Self::new(error, false)
+    }
+}
+
 #[bon::bon]
 impl SegmentWriter<Disk> {
     /// Create a `DiskBufferBuilder` for advanced configuration.
@@ -589,6 +605,7 @@ impl<M: BufferMode> SegmentWriter<M> {
 
     fn rotate(&mut self) -> std::io::Result<()> {
         self.rotate_with_flush_policy(false)
+            .map_err(|failure| failure.error)
     }
 
     /// Rotate while propagating every buffered-write failure to the caller.
@@ -597,11 +614,11 @@ impl<M: BufferMode> SegmentWriter<M> {
     /// checkpoints use this strict path because their acknowledgement must not
     /// claim a segment was sealed after data failed to reach the backend.
     #[cfg(any(feature = "pipeline", test))]
-    fn rotate_strict(&mut self) -> std::io::Result<()> {
+    fn rotate_strict(&mut self) -> Result<(), RotationFailure> {
         self.rotate_with_flush_policy(true)
     }
 
-    fn rotate_with_flush_policy(&mut self, strict_flush: bool) -> std::io::Result<()> {
+    fn rotate_with_flush_policy(&mut self, strict_flush: bool) -> Result<(), RotationFailure> {
         if matches!(self.state, WriterState::Finished) {
             return Ok(());
         }
@@ -615,14 +632,21 @@ impl<M: BufferMode> SegmentWriter<M> {
 
         // Take ownership of the encoder (state is Finished until new segment opens).
         let WriterState::Active {
-            writer: mut raw, ..
+            writer: mut raw,
+            need_metadata,
         } = std::mem::replace(&mut self.state, WriterState::Finished)
         else {
             return Ok(());
         };
 
         if strict_flush {
-            raw.flush()?;
+            if let Err(error) = raw.flush() {
+                self.state = WriterState::Active {
+                    writer: raw,
+                    need_metadata,
+                };
+                return Err(RotationFailure::before_seal(error));
+            }
         } else {
             // Automatic rotation is best-effort. If the underlying file is
             // gone the buffered bytes are already lost; proceed to rotate
@@ -632,12 +656,18 @@ impl<M: BufferMode> SegmentWriter<M> {
         let closed_size = raw.bytes_written();
         let current_index = self.next_index - 1;
 
-        // Extract the ActiveHandle for sealing.
+        // Strict rotation flushed the BufWriter above. Extract without a
+        // second fallible flush so a transient error cannot consume it.
+        // Automatic rotation retains its historical best-effort retry.
         let bw: BufWriter<ActiveHandle> = raw.into_inner();
-        let handle: ActiveHandle = match bw.into_inner() {
-            Ok(handle) => handle,
-            Err(error) if strict_flush => return Err(error.into_error()),
-            Err(error) => error.into_inner().into_parts().0,
+        let handle: ActiveHandle = if strict_flush {
+            debug_assert!(bw.buffer().is_empty());
+            bw.into_parts().0
+        } else {
+            match bw.into_inner() {
+                Ok(handle) => handle,
+                Err(error) => error.into_inner().into_parts().0,
+            }
         };
 
         // Seal the current segment. If `.active` was removed externally
@@ -645,8 +675,10 @@ impl<M: BufferMode> SegmentWriter<M> {
         // starting a fresh one. Explicit checkpoints still return the
         // `NotFound` after recovery so they never acknowledge missing data.
         let mut abandoned_error = None;
+        let mut segment_sealed = false;
         match self.fs.seal(handle, &self.active_path, current_index) {
             Ok(seg_ref) => {
+                segment_sealed = true;
                 if M::IS_DISK {
                     self.closed_files.push_back((seg_ref, closed_size));
                 }
@@ -665,7 +697,7 @@ impl<M: BufferMode> SegmentWriter<M> {
             }
             Err(e) => {
                 // state is already Finished from mem::replace above
-                return Err(e);
+                return Err(RotationFailure::before_seal(e));
             }
         }
 
@@ -676,13 +708,16 @@ impl<M: BufferMode> SegmentWriter<M> {
         // parent directory was removed underneath us, any other failure
         // leaves state = Finished so the writer stops cleanly rather than
         // retrying every drain cycle.
-        let handle: ActiveHandle = self.fs.create_segment(&new_path)?;
+        let handle: ActiveHandle = self
+            .fs
+            .create_segment(&new_path)
+            .map_err(|error| RotationFailure::new(error, segment_sealed))?;
 
         self.state = match Self::prepare_segment(BufWriter::new(handle)) {
             Ok(s) => s,
             Err(e) => {
                 let _ = self.fs.remove_active(&new_path);
-                return Err(e);
+                return Err(RotationFailure::new(e, segment_sealed));
             }
         };
         self.active_path = new_path;
@@ -692,9 +727,10 @@ impl<M: BufferMode> SegmentWriter<M> {
             segment_index = self.next_index - 1,
             "rotated to new trace segment"
         );
-        self.evict_oldest()?;
+        self.evict_oldest()
+            .map_err(|error| RotationFailure::new(error, segment_sealed))?;
         match abandoned_error {
-            Some(error) => Err(error),
+            Some(error) => Err(RotationFailure::before_seal(error)),
             None => Ok(()),
         }
     }
@@ -834,7 +870,7 @@ impl<M: BufferMode> SegmentWriter<M> {
         if !self.has_real_events {
             return Ok(false);
         }
-        self.rotate_strict()?;
+        self.rotate_strict().map_err(|failure| failure.error)?;
         Ok(true)
     }
 
@@ -850,14 +886,14 @@ impl<M: BufferMode> SegmentWriter<M> {
 
     /// Protect the current ring snapshot, then seal a non-empty active
     /// fragment. The caller must hold the checkpoint reservation. Protection
-    /// lasts until the triggered worker takes each memory segment or finishes
-    /// the disk segment's pipeline pass; this prevents the checkpoint's own
-    /// rotation from evicting data it is about to dispatch.
+    /// lasts until each segment reaches a terminal pipeline outcome; retries
+    /// remain protected. This prevents the checkpoint's own rotation and later
+    /// writes from evicting data the worker still needs.
     #[cfg(feature = "pipeline")]
     pub(crate) fn seal_checkpoint(
         &mut self,
         mut checkpoint: CheckpointGuard,
-    ) -> std::io::Result<CheckpointGuard> {
+    ) -> std::io::Result<(CheckpointGuard, Option<std::io::Error>)> {
         if matches!(self.state, WriterState::Finished) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::BrokenPipe,
@@ -883,9 +919,15 @@ impl<M: BufferMode> SegmentWriter<M> {
         checkpoint.track(protected);
 
         if self.has_real_events {
-            self.rotate_strict()?;
+            match self.rotate_strict() {
+                Ok(()) => {}
+                Err(failure) if failure.sealed => {
+                    return Ok((checkpoint, Some(failure.error)));
+                }
+                Err(failure) => return Err(failure.error),
+            }
         }
-        Ok(checkpoint)
+        Ok((checkpoint, None))
     }
 
     /// Re-apply the disk budget after the worker finishes checkpoint segments
@@ -1247,6 +1289,10 @@ mod tests {
             .rotate_segment()
             .expect_err("checkpoint rotation must propagate its final flush failure");
         assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert!(
+            !writer.is_closed(),
+            "a strict flush failure must leave the active writer available for retry"
+        );
     }
 
     #[test]

--- a/dial9-core/src/buffer.rs
+++ b/dial9-core/src/buffer.rs
@@ -183,6 +183,10 @@ pub struct SegmentWriter<Mode: BufferMode = Disk> {
     /// How often to rotate based on monotonic time. `Duration::MAX` disables
     /// time-based rotation (used by `single_file()`).
     rotation_period: Duration,
+    /// Whether a current-data checkpoint may seal the active segment and open
+    /// a replacement. Disabled for the `single_file()` compatibility mode.
+    #[cfg_attr(not(feature = "pipeline"), allow(dead_code))]
+    checkpoint_rotation: bool,
     /// The next monotonic instant at which time-based rotation should fire,
     /// or `None` if time-based rotation is disabled.
     next_rotation_time: Option<Instant>,
@@ -302,6 +306,7 @@ impl SegmentWriter<Disk> {
         }
         let stem = SEGMENT_STEM.to_string();
         let fs = Fs::new_disk(&dir, stem.as_str());
+        fs.set_disk_max_total_size(max_total_size);
         let discovered = fs.discover_existing()?;
         let first_index = discovered.next_active_index;
         let next_index = first_index
@@ -319,6 +324,7 @@ impl SegmentWriter<Disk> {
             max_file_size,
             max_total_size,
             rotation_period,
+            checkpoint_rotation: true,
             next_rotation_time: Self::next_rotation_from(now, rotation_period),
             closed_files: discovered.closed_files,
             active_path: first_path,
@@ -354,7 +360,9 @@ impl SegmentWriter<Disk> {
     /// and gzip it to `{stem}.0.bin.gz`.
     ///
     /// Note: This API does not allow the ability to provide custom segment metadata.
-    /// Time-based rotation is disabled.
+    /// Time-based rotation is disabled. A non-empty current-data dump returns
+    /// `DumpError::Checkpoint` with `ErrorKind::Unsupported`, because sealing
+    /// it would violate this method's single-file contract.
     pub fn single_file(path: impl Into<PathBuf>) -> std::io::Result<Self> {
         let path = path.into();
         // Unlike rotating writers, `single_file` takes both the directory and
@@ -381,6 +389,7 @@ impl SegmentWriter<Disk> {
             max_file_size: u64::MAX,
             max_total_size: u64::MAX,
             rotation_period: Duration::MAX,
+            checkpoint_rotation: false,
             next_rotation_time: None,
             closed_files: VecDeque::new(),
             active_path,
@@ -496,6 +505,7 @@ impl SegmentWriter<Memory> {
             max_file_size: max_segment_size,
             max_total_size,
             rotation_period,
+            checkpoint_rotation: true,
             next_rotation_time: Self::next_rotation_from(now, rotation_period),
             closed_files: VecDeque::new(),
             active_path,
@@ -749,11 +759,12 @@ impl<M: BufferMode> SegmentWriter<M> {
         closed + active
     }
 
-    fn evict_oldest(&mut self) -> std::io::Result<()> {
+    fn evict_closed_to_budget(&mut self) {
         if !M::IS_DISK {
-            return Ok(());
+            return;
         }
-        // Always keep at least the current file.
+        // Always keep at least the current file. Protected checkpoint segments
+        // may temporarily exceed the budget until their worker pass resolves.
         while self.total_size() > self.max_total_size {
             #[cfg(feature = "pipeline")]
             let evict_pos = self
@@ -768,6 +779,13 @@ impl<M: BufferMode> SegmentWriter<M> {
             if let Some((seg_ref, _size)) = self.closed_files.remove(evict_pos) {
                 self.fs.remove_sealed(&seg_ref, RemoveReason::Eviction);
             }
+        }
+    }
+
+    fn evict_oldest(&mut self) -> std::io::Result<()> {
+        self.evict_closed_to_budget();
+        if !M::IS_DISK {
+            return Ok(());
         }
         // If even the current file alone exceeds total budget, stop writing.
         // Protected checkpoint segments may temporarily occupy the pipeline's
@@ -902,6 +920,13 @@ impl<M: BufferMode> SegmentWriter<M> {
             ));
         }
 
+        if self.has_real_events && !self.checkpoint_rotation {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                "current-data checkpoints require a rotating trace buffer",
+            ));
+        }
+
         let current_index = self.has_real_events.then_some(self.next_index - 1);
         let protected = if M::IS_DISK {
             let mut indices: Vec<u32> = self
@@ -936,7 +961,11 @@ impl<M: BufferMode> SegmentWriter<M> {
     #[cfg(feature = "pipeline")]
     pub(crate) fn enforce_checkpoint_budget(&mut self) -> std::io::Result<()> {
         if self.fs.checkpoint_budget_dirty() {
-            self.evict_oldest()?;
+            // This check runs on arbitrary flush ticks, not only immediately
+            // after a write/rotation boundary. Reconcile closed segments but
+            // never finish a live writer merely because its active segment is
+            // temporarily larger than the total budget.
+            self.evict_closed_to_budget();
         }
         Ok(())
     }
@@ -1347,6 +1376,12 @@ mod tests {
         assert_eq!(writer.closed_files.len(), 1);
         assert!(writer.total_size() > max_total_size);
 
+        // Grow the replacement active segment beyond the total budget. The
+        // checkpoint-release reconciliation runs on an arbitrary flush tick;
+        // it must not finish this live writer mid-segment.
+        writer.write_encoded_batch(&test_batch()).unwrap();
+        writer.write_encoded_batch(&test_batch()).unwrap();
+
         let sealed = writer.closed_files.front().unwrap().0.clone();
         writer.fs.remove_sealed(&sealed, RemoveReason::Terminal);
         drop(checkpoint);
@@ -1356,8 +1391,28 @@ mod tests {
             writer.closed_files.is_empty(),
             "terminal removal must discard the writer's stale retention entry"
         );
-        assert!(writer.total_size() <= max_total_size);
+        assert!(writer.total_size() > max_total_size);
         assert!(!writer.is_closed());
+    }
+
+    #[cfg(feature = "pipeline")]
+    #[test]
+    fn single_file_rejects_nonempty_checkpoint_without_rotating() {
+        let dir = TempDir::new().unwrap();
+        let mut writer = DiskBuffer::single_file(dir.path().join("trace.bin")).unwrap();
+        let active = writer.current_active_path().to_owned();
+        writer.write_encoded_batch(&test_batch()).unwrap();
+
+        let checkpoint = writer.reserve_checkpoint().unwrap();
+        let error = writer
+            .seal_checkpoint(checkpoint)
+            .expect_err("single-file mode cannot create a stable current-data segment");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Unsupported);
+        assert!(!writer.is_closed());
+        assert_eq!(writer.current_active_path(), active);
+        assert!(active.exists());
+        assert!(!dir.path().join("trace.0.bin").exists());
     }
 
     #[test]

--- a/dial9-core/src/dump.rs
+++ b/dial9-core/src/dump.rs
@@ -16,30 +16,35 @@
 //! (`trigger.dump_current_data();`) the run drops at the end of the statement and
 //! dispatches right there; if you bind it to a variable, dispatch waits until that
 //! binding is awaited or goes out of scope. Awaiting is optional and only retrieves the
-//! [`DumpReceipt`](crate::dump::DumpReceipt).
-//! Dumps are strictly best-effort: a window wider than what the ring
-//! retained captures whatever survived, with no error and no effect on the
-//! live stream.
+//! [`DumpReceipt`](crate::dump::DumpReceipt). Window coverage is best-effort:
+//! a window wider than what the ring retained captures whatever survived.
+//! A current-data dump installed through the recorder also checkpoints the
+//! active fragment and may return
+//! [`DumpError::Checkpoint`](crate::dump::DumpError::Checkpoint) if it cannot
+//! be drained and sealed.
 //!
 //! # Concurrent dumps
 //!
-//! Dumps are independent: triggering two at once registers two dumps, each
-//! with its own [`DumpId`](crate::dump::DumpId) and (off S3) its own manifest. A segment whose
-//! span overlaps both windows is captured by both. There is no coordination
-//! by default - this is intentional, so unrelated subsystems can dump
-//! without stepping on each other.
+//! Dumps accepted by the worker are independent: each has its own
+//! [`DumpId`](crate::dump::DumpId), and a segment whose span overlaps two
+//! windows is captured by both. Recorder-installed current-data dumps first
+//! enter the flush thread's bounded, single-slot control queue to establish
+//! their boundary. If that queue is busy, the new request resolves with
+//! [`DumpError::Checkpoint`](crate::dump::DumpError::Checkpoint) wrapping
+//! [`std::io::ErrorKind::WouldBlock`] instead of accumulating an unbounded
+//! backlog.
 //!
 //! When a single source fires repeatedly (a watcher that re-trips every
 //! poll, a hot path that dumps on every slow request), configure
-//! [`DumpTriggerConfig::debounce`](crate::dump::DumpTriggerConfig::debounce) to coalesce a burst
-//! into one dump: triggers
-//! within the debounce window after a dump dispatched resolve
-//! [`DumpError::Coalesced`](crate::dump::DumpError::Coalesced), naming the dump they folded
-//! into instead of
-//! starting a new one. The gate lives on the trigger stored on the recorder,
-//! so every [`dump_trigger`](crate::handle::Dial9Handle::dump_trigger)
-//! clone shares it. (A *cooldown* that rejects extra triggers outright,
-//! rather than folding them, is a possible future addition.)
+//! [`DumpTriggerConfig::debounce`](crate::dump::DumpTriggerConfig::debounce) to
+//! coalesce a burst into one dump: triggers within the debounce window after a
+//! dump dispatched resolve
+//! [`DumpError::Coalesced`](crate::dump::DumpError::Coalesced), naming the dump
+//! they folded into instead of starting a new one. The gate lives on the
+//! trigger stored on the recorder, so every
+//! [`dump_trigger`](crate::handle::Dial9Handle::dump_trigger) clone shares it.
+//! (A *cooldown* that rejects extra triggers outright, rather than folding
+//! them, is a possible future addition.)
 
 use std::future::Future;
 use std::pin::Pin;
@@ -56,7 +61,14 @@ use crate::pipeline::ProcessErrorKind;
 /// [`Dial9Handle::dump_trigger`](crate::handle::Dial9Handle::dump_trigger).
 pub fn channel() -> (DumpTrigger, DumpRx) {
     let (tx, rx) = mpsc::unbounded_channel();
-    (DumpTrigger { tx, debounce: None }, DumpRx { rx })
+    (
+        DumpTrigger {
+            tx,
+            debounce: None,
+            checkpoint_tx: None,
+        },
+        DumpRx { rx },
+    )
 }
 
 /// On-demand dump configuration, passed to
@@ -182,9 +194,20 @@ pub struct DumpTrigger {
     /// [`DumpTriggerConfig::debounce`]; shared by reference so every clone honors one
     /// gate.
     debounce: Option<Arc<Debounce>>,
+    /// Flush-thread control sender installed by `RecorderBuilder`. Manually
+    /// constructed trigger/receiver pairs retain their historical behavior and
+    /// dispatch directly to the worker.
+    checkpoint_tx: Option<crate::primitives::sync::mpsc::SyncSender<crate::handle::ControlCommand>>,
 }
 
 impl DumpTrigger {
+    pub(crate) fn bind_checkpoint(
+        &mut self,
+        checkpoint_tx: crate::primitives::sync::mpsc::SyncSender<crate::handle::ControlCommand>,
+    ) {
+        self.checkpoint_tx = Some(checkpoint_tx);
+    }
+
     /// Coalesce duplicate triggers within `window` into a single dump.
     ///
     /// Applied once at build time from [`DumpTriggerConfig::debounce`]; every
@@ -204,9 +227,63 @@ impl DumpTrigger {
     }
 
     /// Capture everything the ring still holds, right now. No forward
-    /// window.
+    /// window. When this trigger was installed by
+    /// [`RecorderBuilder::with_dump_trigger`](crate::recorder::RecorderBuilder::with_dump_trigger),
+    /// the flush thread first drains pending events and seals the active
+    /// fragment, so callers do not need to coordinate trace segments.
+    ///
+    /// If recording was already disabled, registered
+    /// [`Source`](crate::source::Source)s are not flushed: a source flush may
+    /// sample new state, which would move post-boundary data into the capture.
+    /// Source-owned data buffered before [`Dial9Handle::disable`](crate::handle::Dial9Handle::disable)
+    /// may therefore remain buffered until recording is enabled again. To end
+    /// a bounded capture, prefer
+    /// [`stop_recording_and_dump_current_data`](Self::stop_recording_and_dump_current_data),
+    /// which takes the final source sample and closes the gate atomically on
+    /// the flush thread.
+    ///
+    /// The flush-thread control queue is bounded. If it is already handling
+    /// another control operation, this request resolves with
+    /// [`DumpError::Checkpoint`] wrapping [`std::io::ErrorKind::WouldBlock`].
     pub fn dump_current_data(&self) -> DumpRun<'_> {
-        self.request(Lookback::Unbounded, Duration::ZERO)
+        self.request(
+            Lookback::Unbounded,
+            Duration::ZERO,
+            Checkpoint::CurrentData {
+                stop_recording: false,
+            },
+            true,
+        )
+    }
+
+    /// Stop recording and capture everything accumulated through that boundary.
+    ///
+    /// This is the preferred operation for ending a bounded capture.
+    ///
+    /// The recording gate is closed on the flush thread after one final source
+    /// sample. In-flight event writers are synchronized with the subsequent
+    /// thread-local drain before the active fragment is sealed and dispatched
+    /// to the dump pipeline. The recorder remains alive and may be re-enabled
+    /// after this future completes.
+    ///
+    /// Unlike ordinary dump requests, capture-stop requests are never
+    /// debounced: closing the recording gate is a lifecycle operation, so it
+    /// is always attempted. The flush-thread control queue remains bounded; if
+    /// another control operation is already queued, this request resolves with
+    /// [`DumpError::Checkpoint`] wrapping [`std::io::ErrorKind::WouldBlock`].
+    ///
+    /// This operation requires a trigger installed through
+    /// `with_dump_trigger`; a standalone pair from [`channel`] has no recorder
+    /// to stop and resolves with [`DumpError::Checkpoint`].
+    pub fn stop_recording_and_dump_current_data(&self) -> DumpRun<'_> {
+        self.request(
+            Lookback::Unbounded,
+            Duration::ZERO,
+            Checkpoint::CurrentData {
+                stop_recording: true,
+            },
+            false,
+        )
     }
 
     /// Capture the window `[trigger - lookback, trigger + lookforward]`.
@@ -221,22 +298,37 @@ impl DumpTrigger {
     /// covered span is reported on [`DumpReceipt::time_range`]. This never
     /// errors and never resizes or pins the ring.
     pub fn dump_time_range(&self, lookback: Duration, lookforward: Duration) -> DumpRun<'_> {
-        self.request(Lookback::Window(lookback), lookforward)
+        self.request(
+            Lookback::Window(lookback),
+            lookforward,
+            Checkpoint::None,
+            true,
+        )
     }
 
-    fn request(&self, lookback: Lookback, lookforward: Duration) -> DumpRun<'_> {
+    fn request(
+        &self,
+        lookback: Lookback,
+        lookforward: Duration,
+        checkpoint: Checkpoint,
+        allow_debounce: bool,
+    ) -> DumpRun<'_> {
         let id = DumpId::new();
 
         // Leading-edge debounce: a trigger within `window` of the last
         // accepted request coalesces into it instead of starting a new one.
         // Armed here at request-build time so a folded trigger can return a
         // `Coalesced` run synchronously (see `Debounce`).
-        if let Some(debounce) = &self.debounce {
+        if allow_debounce && let Some(debounce) = &self.debounce {
             let now = Instant::now();
             let mut last = debounce.last.lock().expect("debounce mutex poisoned");
             match *last {
                 Some((at, into)) if now.duration_since(at) < debounce.window => {
-                    return DumpRun::preempted(&self.tx, DumpError::Coalesced { into });
+                    return DumpRun::preempted(
+                        &self.tx,
+                        self.checkpoint_tx.as_ref(),
+                        DumpError::Coalesced { into },
+                    );
                 }
                 _ => *last = Some((now, id)),
             }
@@ -253,6 +345,8 @@ impl DumpTrigger {
                 receipt_tx,
             }),
             tx: &self.tx,
+            checkpoint_tx: self.checkpoint_tx.as_ref(),
+            checkpoint,
             receipt_rx: Some(receipt_rx),
             preempt: None,
         }
@@ -263,6 +357,47 @@ impl DumpTrigger {
 #[derive(Debug)]
 pub struct DumpRx {
     pub(crate) rx: mpsc::UnboundedReceiver<DumpRequest>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Checkpoint {
+    None,
+    CurrentData { stop_recording: bool },
+}
+
+/// A current-data dump waiting for the flush thread to establish its boundary.
+#[derive(Debug)]
+pub(crate) struct CheckpointDump {
+    request: DumpRequest,
+    worker_tx: mpsc::UnboundedSender<DumpRequest>,
+    pub(crate) stop_recording: bool,
+}
+
+impl CheckpointDump {
+    fn new(
+        request: DumpRequest,
+        worker_tx: mpsc::UnboundedSender<DumpRequest>,
+        stop_recording: bool,
+    ) -> Self {
+        Self {
+            request,
+            worker_tx,
+            stop_recording,
+        }
+    }
+
+    pub(crate) fn dispatch(self) {
+        if let Err(error) = self.worker_tx.send(self.request) {
+            let _ = error.0.receipt_tx.send(Err(DumpError::WorkerStopped));
+        }
+    }
+
+    pub(crate) fn fail(self, error: std::io::Error) {
+        let _ = self
+            .request
+            .receipt_tx
+            .send(Err(DumpError::Checkpoint(error)));
+    }
 }
 
 /// In-flight dump request.
@@ -277,6 +412,9 @@ pub struct DumpRx {
 pub struct DumpRun<'a> {
     request: Option<DumpRequest>,
     tx: &'a mpsc::UnboundedSender<DumpRequest>,
+    checkpoint_tx:
+        Option<&'a crate::primitives::sync::mpsc::SyncSender<crate::handle::ControlCommand>>,
+    checkpoint: Checkpoint,
     receipt_rx: Option<oneshot::Receiver<Result<DumpReceipt, DumpError>>>,
     /// Set when the run never dispatches (debounced): awaiting resolves this
     /// error directly. `request` is `None` for a preempted run, so
@@ -286,10 +424,18 @@ pub struct DumpRun<'a> {
 
 impl<'a> DumpRun<'a> {
     /// A run that never dispatches; awaiting resolves `err`.
-    fn preempted(tx: &'a mpsc::UnboundedSender<DumpRequest>, err: DumpError) -> Self {
+    fn preempted(
+        tx: &'a mpsc::UnboundedSender<DumpRequest>,
+        checkpoint_tx: Option<
+            &'a crate::primitives::sync::mpsc::SyncSender<crate::handle::ControlCommand>,
+        >,
+        err: DumpError,
+    ) -> Self {
         DumpRun {
             request: None,
             tx,
+            checkpoint_tx,
+            checkpoint: Checkpoint::None,
             receipt_rx: None,
             preempt: Some(err),
         }
@@ -311,7 +457,51 @@ impl<'a> DumpRun<'a> {
     /// when the worker is gone (channel closed).
     fn dispatch(&mut self) -> bool {
         match self.request.take() {
-            Some(req) => self.tx.send(req).is_ok(),
+            Some(req) => {
+                let Checkpoint::CurrentData { stop_recording } = self.checkpoint else {
+                    return self.tx.send(req).is_ok();
+                };
+                let Some(checkpoint_tx) = self.checkpoint_tx else {
+                    if stop_recording {
+                        CheckpointDump::new(req, self.tx.clone(), true).fail(std::io::Error::new(
+                            std::io::ErrorKind::Unsupported,
+                            "capture-stop requires a recorder-installed dump trigger",
+                        ));
+                        return true;
+                    }
+                    return self.tx.send(req).is_ok();
+                };
+                let command = crate::handle::ControlCommand::CheckpointDump(CheckpointDump::new(
+                    req,
+                    self.tx.clone(),
+                    stop_recording,
+                ));
+                match checkpoint_tx.try_send(command) {
+                    Ok(()) => true,
+                    Err(crate::primitives::sync::mpsc::TrySendError::Full(command)) => {
+                        let crate::handle::ControlCommand::CheckpointDump(checkpoint) = command
+                        else {
+                            unreachable!("submitted a checkpoint command");
+                        };
+                        checkpoint.fail(std::io::Error::new(
+                            std::io::ErrorKind::WouldBlock,
+                            "dial9 flush thread is handling another control operation",
+                        ));
+                        true
+                    }
+                    Err(crate::primitives::sync::mpsc::TrySendError::Disconnected(command)) => {
+                        let crate::handle::ControlCommand::CheckpointDump(checkpoint) = command
+                        else {
+                            unreachable!("submitted a checkpoint command");
+                        };
+                        checkpoint.fail(std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            "dial9 flush thread has stopped",
+                        ));
+                        true
+                    }
+                }
+            }
             // Already dispatched.
             None => true,
         }
@@ -445,6 +635,9 @@ pub struct DumpReceipt {
 pub enum DumpError {
     /// The worker is shutting down or already stopped.
     WorkerStopped,
+    /// The flush thread could not accept, drain, or seal the active trace
+    /// fragment before dispatching the dump.
+    Checkpoint(std::io::Error),
     /// Every captured segment failed in a pipeline stage.
     Pipeline(ProcessErrorKind),
     /// The trigger was coalesced into an in-flight dump by the debounce gate
@@ -460,6 +653,9 @@ impl std::fmt::Display for DumpError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::WorkerStopped => write!(f, "worker is shutting down or already stopped"),
+            Self::Checkpoint(error) => {
+                write!(f, "could not checkpoint current trace data: {error}")
+            }
             Self::Pipeline(kind) => write!(f, "pipeline stage failed: {kind}"),
             Self::Coalesced { into } => write!(f, "coalesced into dump {into}"),
         }
@@ -470,6 +666,7 @@ impl std::error::Error for DumpError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::WorkerStopped => None,
+            Self::Checkpoint(error) => Some(error),
             Self::Pipeline(ProcessErrorKind::Io(e)) => Some(e),
             Self::Pipeline(ProcessErrorKind::Transfer { source, .. }) => Some(source.as_ref()),
             Self::Coalesced { .. } => None,
@@ -541,6 +738,20 @@ mod tests {
         drop(rx);
         let err = trigger.dump_current_data().await.unwrap_err();
         assert!(matches!(err, DumpError::WorkerStopped));
+    }
+
+    #[tokio::test]
+    async fn standalone_trigger_cannot_stop_a_recorder() {
+        let (trigger, _rx) = channel();
+        let error = trigger
+            .stop_recording_and_dump_current_data()
+            .await
+            .expect_err("standalone trigger has no recording gate");
+        assert!(matches!(
+            error,
+            DumpError::Checkpoint(ref error)
+                if error.kind() == std::io::ErrorKind::Unsupported
+        ));
     }
 
     #[tokio::test]

--- a/dial9-core/src/dump.rs
+++ b/dial9-core/src/dump.rs
@@ -169,16 +169,14 @@ pub(crate) struct DumpRequest {
 
 /// Leading-edge debounce gate shared across [`DumpTrigger`] clones.
 ///
-/// Records when the last accepted request was *built* and the [`DumpId`] it
-/// was given. The gate is armed in [`DumpTrigger::request`] (the coalescing
-/// decision has to be synchronous there so a folded trigger can return a
-/// [`DumpError::Coalesced`] run), not at the later drop/await that actually
-/// sends the request; the two coincide in the common temporary-statement
-/// usage. A request arriving within `window` of that instant coalesces into
-/// that id rather than starting a new dump. The window is measured from the
-/// last accepted request and is not extended by coalesced requests, so a
-/// burst all folds into the first dump and the effective rate is at most one
-/// dump per `window`.
+/// Records when the last request was accepted and the [`DumpId`] it was
+/// given. Recorder checkpoints arm the gate only after reserving their exact
+/// snapshot; other dumps arm it when the worker channel accepts them. A
+/// request arriving within `window` of that instant coalesces into that id
+/// rather than starting a new dump. The window is measured from the last
+/// accepted request and is not extended by coalesced requests, so a burst all
+/// folds into the first dump and the effective rate is at most one dump per
+/// `window`.
 #[derive(Debug)]
 struct Debounce {
     window: Duration,
@@ -324,25 +322,6 @@ impl DumpTrigger {
     ) -> DumpRun<'_> {
         let id = DumpId::new();
 
-        // Leading-edge debounce: a trigger within `window` of the last
-        // accepted request coalesces into it instead of starting a new one.
-        // Armed here at request-build time so a folded trigger can return a
-        // `Coalesced` run synchronously (see `Debounce`).
-        if allow_debounce && let Some(debounce) = &self.debounce {
-            let now = Instant::now();
-            let mut last = debounce.last.lock().expect("debounce mutex poisoned");
-            match *last {
-                Some((at, into)) if now.duration_since(at) < debounce.window => {
-                    return DumpRun::preempted(
-                        &self.tx,
-                        self.checkpoint_tx.as_ref(),
-                        DumpError::Coalesced { into },
-                    );
-                }
-                _ => *last = Some((now, id)),
-            }
-        }
-
         let (receipt_tx, receipt_rx) = oneshot::channel();
         DumpRun {
             request: Some(DumpRequest {
@@ -357,8 +336,10 @@ impl DumpTrigger {
             tx: &self.tx,
             checkpoint_tx: self.checkpoint_tx.as_ref(),
             checkpoint,
+            debounce: allow_debounce
+                .then(|| self.debounce.as_ref().map(Arc::clone))
+                .flatten(),
             receipt_rx: Some(receipt_rx),
-            preempt: None,
         }
     }
 }
@@ -381,6 +362,7 @@ pub(crate) struct CheckpointDump {
     request: DumpRequest,
     worker_tx: mpsc::UnboundedSender<DumpRequest>,
     pub(crate) stop_recording: bool,
+    debounce: Option<Arc<Debounce>>,
 }
 
 impl CheckpointDump {
@@ -388,11 +370,40 @@ impl CheckpointDump {
         request: DumpRequest,
         worker_tx: mpsc::UnboundedSender<DumpRequest>,
         stop_recording: bool,
+        debounce: Option<Arc<Debounce>>,
     ) -> Self {
         Self {
             request,
             worker_tx,
             stop_recording,
+            debounce,
+        }
+    }
+
+    /// Return the accepted dump this request would fold into, if any.
+    pub(crate) fn debounce_target(&self) -> Option<DumpId> {
+        let debounce = self.debounce.as_ref()?;
+        let now = Instant::now();
+        let last = debounce.last.lock().expect("debounce mutex poisoned");
+        match *last {
+            Some((at, into)) if now.duration_since(at) < debounce.window => Some(into),
+            _ => None,
+        }
+    }
+
+    /// Recheck and arm debounce after the checkpoint reservation succeeds.
+    pub(crate) fn accept_debounce(&self) -> Result<(), DumpId> {
+        let Some(debounce) = &self.debounce else {
+            return Ok(());
+        };
+        let now = Instant::now();
+        let mut last = debounce.last.lock().expect("debounce mutex poisoned");
+        match *last {
+            Some((at, into)) if now.duration_since(at) < debounce.window => Err(into),
+            _ => {
+                *last = Some((now, self.request.id));
+                Ok(())
+            }
         }
     }
 
@@ -408,6 +419,13 @@ impl CheckpointDump {
             .request
             .receipt_tx
             .send(Err(DumpError::Checkpoint(error)));
+    }
+
+    pub(crate) fn coalesce(self, into: DumpId) {
+        let _ = self
+            .request
+            .receipt_tx
+            .send(Err(DumpError::Coalesced { into }));
     }
 }
 
@@ -426,32 +444,11 @@ pub struct DumpRun<'a> {
     checkpoint_tx:
         Option<&'a crate::primitives::sync::mpsc::SyncSender<crate::handle::ControlCommand>>,
     checkpoint: Checkpoint,
+    debounce: Option<Arc<Debounce>>,
     receipt_rx: Option<oneshot::Receiver<Result<DumpReceipt, DumpError>>>,
-    /// Set when the run never dispatches (debounced): awaiting resolves this
-    /// error directly. `request` is `None` for a preempted run, so
-    /// [`dispatch`](Self::dispatch) and `Drop` are no-ops.
-    preempt: Option<DumpError>,
 }
 
 impl<'a> DumpRun<'a> {
-    /// A run that never dispatches; awaiting resolves `err`.
-    fn preempted(
-        tx: &'a mpsc::UnboundedSender<DumpRequest>,
-        checkpoint_tx: Option<
-            &'a crate::primitives::sync::mpsc::SyncSender<crate::handle::ControlCommand>,
-        >,
-        err: DumpError,
-    ) -> Self {
-        DumpRun {
-            request: None,
-            tx,
-            checkpoint_tx,
-            checkpoint: Checkpoint::None,
-            receipt_rx: None,
-            preempt: Some(err),
-        }
-    }
-
     /// Attach a caller-supplied correlation pair. Chainable. Each pair is
     /// stamped onto every captured segment's metadata (namespaced as
     /// `dump.{key}`) before the pipeline runs; pipeline stages decide what
@@ -470,22 +467,25 @@ impl<'a> DumpRun<'a> {
         match self.request.take() {
             Some(req) => {
                 let Checkpoint::CurrentData { stop_recording } = self.checkpoint else {
-                    return self.tx.send(req).is_ok();
+                    return self.dispatch_direct(req);
                 };
                 let Some(checkpoint_tx) = self.checkpoint_tx else {
                     if stop_recording {
-                        CheckpointDump::new(req, self.tx.clone(), true).fail(std::io::Error::new(
-                            std::io::ErrorKind::Unsupported,
-                            "capture-stop requires a recorder-installed dump trigger",
-                        ));
+                        CheckpointDump::new(req, self.tx.clone(), true, None).fail(
+                            std::io::Error::new(
+                                std::io::ErrorKind::Unsupported,
+                                "capture-stop requires a recorder-installed dump trigger",
+                            ),
+                        );
                         return true;
                     }
-                    return self.tx.send(req).is_ok();
+                    return self.dispatch_direct(req);
                 };
                 let command = crate::handle::ControlCommand::CheckpointDump(CheckpointDump::new(
                     req,
                     self.tx.clone(),
                     stop_recording,
+                    self.debounce.take(),
                 ));
                 match checkpoint_tx.try_send(command) {
                     Ok(()) => true,
@@ -517,6 +517,29 @@ impl<'a> DumpRun<'a> {
             None => true,
         }
     }
+
+    /// Dispatch a request that does not need a flush-thread reservation.
+    /// The debounce mutex stays held across the non-blocking send so only a
+    /// request actually accepted by the worker can arm the gate.
+    fn dispatch_direct(&self, req: DumpRequest) -> bool {
+        let Some(debounce) = &self.debounce else {
+            return self.tx.send(req).is_ok();
+        };
+        let now = Instant::now();
+        let mut last = debounce.last.lock().expect("debounce mutex poisoned");
+        if let Some((at, into)) = *last
+            && now.duration_since(at) < debounce.window
+        {
+            let _ = req.receipt_tx.send(Err(DumpError::Coalesced { into }));
+            return true;
+        }
+        let id = req.id;
+        if self.tx.send(req).is_err() {
+            return false;
+        }
+        *last = Some((now, id));
+        true
+    }
 }
 
 impl Drop for DumpRun<'_> {
@@ -532,11 +555,6 @@ impl<'a> IntoFuture for DumpRun<'a> {
     type IntoFuture = DumpFuture;
 
     fn into_future(mut self) -> Self::IntoFuture {
-        if let Some(err) = self.preempt.take() {
-            return DumpFuture {
-                inner: DumpFutureInner::Preempted(err),
-            };
-        }
         let sent = self.dispatch();
         let inner = match (sent, self.receipt_rx.take()) {
             (true, Some(rx)) => DumpFutureInner::Waiting(rx),
@@ -560,8 +578,6 @@ pub struct DumpFuture {
 enum DumpFutureInner {
     Waiting(oneshot::Receiver<Result<DumpReceipt, DumpError>>),
     Stopped,
-    /// Debounced: never dispatched, resolves this error.
-    Preempted(DumpError),
 }
 
 impl Future for DumpFuture {
@@ -577,13 +593,6 @@ impl Future for DumpFuture {
                 Poll::Pending => Poll::Pending,
             },
             DumpFutureInner::Stopped => Poll::Ready(Err(DumpError::WorkerStopped)),
-            // Move the error out; the future is not polled again after Ready.
-            DumpFutureInner::Preempted(_) => {
-                match std::mem::replace(inner, DumpFutureInner::Stopped) {
-                    DumpFutureInner::Preempted(err) => Poll::Ready(Err(err)),
-                    _ => unreachable!("matched Preempted above"),
-                }
-            }
         }
     }
 }

--- a/dial9-core/src/dump.rs
+++ b/dial9-core/src/dump.rs
@@ -32,7 +32,8 @@
 //! their boundary. If that queue is busy, the new request resolves with
 //! [`DumpError::Checkpoint`](crate::dump::DumpError::Checkpoint) wrapping
 //! [`std::io::ErrorKind::WouldBlock`] instead of accumulating an unbounded
-//! backlog.
+//! backlog. Only one eviction-protected current-data checkpoint may remain
+//! active in the worker; a second resolves with the same busy error.
 //!
 //! When a single source fires repeatedly (a watcher that re-trips every
 //! poll, a hot path that dumps on every slow request), configure
@@ -159,6 +160,11 @@ pub(crate) struct DumpRequest {
     pub(crate) lookback: Lookback,
     pub(crate) lookforward: Duration,
     pub(crate) metadata: Vec<(String, String)>,
+    /// Ring snapshot protected by the flush-thread checkpoint until the
+    /// worker takes it through the pipeline. `None` for ordinary time-range
+    /// requests; `Some` also owns the sole checkpoint reservation when the
+    /// snapshot contains no segments.
+    pub(crate) checkpoint_segments: Option<Vec<u32>>,
     pub(crate) receipt_tx: oneshot::Sender<Result<DumpReceipt, DumpError>>,
 }
 
@@ -242,8 +248,9 @@ impl DumpTrigger {
     /// which takes the final source sample and closes the gate atomically on
     /// the flush thread.
     ///
-    /// The flush-thread control queue is bounded. If it is already handling
-    /// another control operation, this request resolves with
+    /// The flush-thread control queue and active checkpoint are bounded. If
+    /// another control operation is queued or a protected checkpoint is still
+    /// running, this request resolves with
     /// [`DumpError::Checkpoint`] wrapping [`std::io::ErrorKind::WouldBlock`].
     pub fn dump_current_data(&self) -> DumpRun<'_> {
         self.request(
@@ -269,8 +276,9 @@ impl DumpTrigger {
     /// Unlike ordinary dump requests, capture-stop requests are never
     /// debounced: closing the recording gate is a lifecycle operation, so it
     /// is always attempted. The flush-thread control queue remains bounded; if
-    /// another control operation is already queued, this request resolves with
-    /// [`DumpError::Checkpoint`] wrapping [`std::io::ErrorKind::WouldBlock`].
+    /// another control operation is already queued or a protected checkpoint
+    /// is still running, this request resolves with [`DumpError::Checkpoint`]
+    /// wrapping [`std::io::ErrorKind::WouldBlock`].
     ///
     /// This operation requires a trigger installed through
     /// `with_dump_trigger`; a standalone pair from [`channel`] has no recorder
@@ -296,7 +304,9 @@ impl DumpTrigger {
     /// attaching segments as they seal; it is bounded only by the process
     /// lifetime and is best-effort under upload pressure. The actual
     /// covered span is reported on [`DumpReceipt::time_range`]. This never
-    /// errors and never resizes or pins the ring.
+    /// errors and never resizes or pins the ring, so matching data may also be
+    /// evicted after the request is made while the worker claims or processes
+    /// it.
     pub fn dump_time_range(&self, lookback: Duration, lookforward: Duration) -> DumpRun<'_> {
         self.request(
             Lookback::Window(lookback),
@@ -342,6 +352,7 @@ impl DumpTrigger {
                 lookback,
                 lookforward,
                 metadata: Vec::new(),
+                checkpoint_segments: None,
                 receipt_tx,
             }),
             tx: &self.tx,
@@ -386,10 +397,18 @@ impl CheckpointDump {
         }
     }
 
-    pub(crate) fn dispatch(self) {
+    pub(crate) fn dispatch(mut self, checkpoint_segments: Vec<u32>) -> Result<(), Vec<u32>> {
+        self.request.checkpoint_segments = Some(checkpoint_segments);
         if let Err(error) = self.worker_tx.send(self.request) {
+            let checkpoint_segments = error
+                .0
+                .checkpoint_segments
+                .clone()
+                .expect("checkpoint dispatch marks its reservation");
             let _ = error.0.receipt_tx.send(Err(DumpError::WorkerStopped));
+            return Err(checkpoint_segments);
         }
+        Ok(())
     }
 
     pub(crate) fn fail(self, error: std::io::Error) {

--- a/dial9-core/src/dump.rs
+++ b/dial9-core/src/dump.rs
@@ -55,6 +55,7 @@ use std::time::{Duration, Instant, SystemTime};
 
 use tokio::sync::{mpsc, oneshot};
 
+use crate::fs::CheckpointGuard;
 use crate::pipeline::ProcessErrorKind;
 
 /// Mint a dump trigger + receiver pair. The builder wires the receiver into
@@ -160,11 +161,9 @@ pub(crate) struct DumpRequest {
     pub(crate) lookback: Lookback,
     pub(crate) lookforward: Duration,
     pub(crate) metadata: Vec<(String, String)>,
-    /// Ring snapshot protected by the flush-thread checkpoint until the
-    /// worker takes it through the pipeline. `None` for ordinary time-range
-    /// requests; `Some` also owns the sole checkpoint reservation when the
-    /// snapshot contains no segments.
-    pub(crate) checkpoint_segments: Option<Vec<u32>>,
+    /// Exact ring snapshot and its eviction-protection lease. `None` for
+    /// ordinary time-range requests.
+    pub(crate) checkpoint: Option<CheckpointGuard>,
     pub(crate) receipt_tx: oneshot::Sender<Result<DumpReceipt, DumpError>>,
 }
 
@@ -352,7 +351,7 @@ impl DumpTrigger {
                 lookback,
                 lookforward,
                 metadata: Vec::new(),
-                checkpoint_segments: None,
+                checkpoint: None,
                 receipt_tx,
             }),
             tx: &self.tx,
@@ -397,18 +396,11 @@ impl CheckpointDump {
         }
     }
 
-    pub(crate) fn dispatch(mut self, checkpoint_segments: Vec<u32>) -> Result<(), Vec<u32>> {
-        self.request.checkpoint_segments = Some(checkpoint_segments);
+    pub(crate) fn dispatch(mut self, checkpoint: CheckpointGuard) {
+        self.request.checkpoint = Some(checkpoint);
         if let Err(error) = self.worker_tx.send(self.request) {
-            let checkpoint_segments = error
-                .0
-                .checkpoint_segments
-                .clone()
-                .expect("checkpoint dispatch marks its reservation");
             let _ = error.0.receipt_tx.send(Err(DumpError::WorkerStopped));
-            return Err(checkpoint_segments);
         }
-        Ok(())
     }
 
     pub(crate) fn fail(self, error: std::io::Error) {

--- a/dial9-core/src/dump.rs
+++ b/dial9-core/src/dump.rs
@@ -183,6 +183,19 @@ struct Debounce {
     last: Mutex<Option<(Instant, DumpId)>>,
 }
 
+impl Debounce {
+    /// Undo an accepted request that failed before reaching the worker.
+    ///
+    /// A later accepted request may already have replaced this slot, so only
+    /// clear it when it still names the request being rolled back.
+    fn clear_if(&self, id: DumpId) {
+        let mut last = self.last.lock().expect("debounce mutex poisoned");
+        if last.is_some_and(|(_, accepted)| accepted == id) {
+            *last = None;
+        }
+    }
+}
+
 /// Sending half of the trigger channel.
 ///
 /// Cloneable; reach it from any thread owned by the runtime via
@@ -410,11 +423,17 @@ impl CheckpointDump {
     pub(crate) fn dispatch(mut self, checkpoint: CheckpointGuard) {
         self.request.checkpoint = Some(checkpoint);
         if let Err(error) = self.worker_tx.send(self.request) {
+            if let Some(debounce) = &self.debounce {
+                debounce.clear_if(error.0.id);
+            }
             let _ = error.0.receipt_tx.send(Err(DumpError::WorkerStopped));
         }
     }
 
     pub(crate) fn fail(self, error: std::io::Error) {
+        if let Some(debounce) = &self.debounce {
+            debounce.clear_if(self.request.id);
+        }
         let _ = self
             .request
             .receipt_tx

--- a/dial9-core/src/encoder.rs
+++ b/dial9-core/src/encoder.rs
@@ -154,10 +154,9 @@ impl ThreadLocalEncoder<'_> {
 pub trait Encodable {
     /// Encode this event into the thread-local trace buffer.
     ///
-    /// Implementations should call [`ThreadLocalEncoder::encode`] exactly once.
-    /// Each `encode` call is counted as one event for buffer flush decisions;
-    /// calling `encode` multiple times will produce multiple wire events but
-    /// only one event will be counted.
+    /// Each [`ThreadLocalEncoder::encode`] call is counted as one event for
+    /// buffer flush decisions. Implementations may decline to emit an event or
+    /// emit more than one when their input expands to multiple wire events.
     fn encode(&self, encoder: &mut ThreadLocalEncoder<'_>);
 }
 
@@ -170,8 +169,9 @@ impl<T: dial9_trace_format::TraceEvent> Encodable for T {
 // ── Thread-local buffer internals ───────────────────────────────────────────
 
 /// Tracks the last drain epoch at which a particular thread-local buffer
-/// was flushed. The flush thread reads this (relaxed) to skip buffers
-/// that have self-flushed recently, avoiding contention with busy workers.
+/// was flushed. Producers publish completed collector flushes with a Release
+/// store. The flush thread uses an Acquire load before skipping a buffer, so a
+/// skip also observes the collector enqueue that made the lock unnecessary.
 #[derive(Clone)]
 pub(crate) struct FlushEpoch(Arc<AtomicU64>);
 
@@ -181,11 +181,15 @@ impl FlushEpoch {
     }
 
     pub(crate) fn store(&self, epoch: u64) {
-        self.0.store(epoch, Ordering::Relaxed);
+        self.0.store(epoch, Ordering::Release);
     }
 
     pub(crate) fn load(&self) -> u64 {
         self.0.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn load_acquire(&self) -> u64 {
+        self.0.load(Ordering::Acquire)
     }
 }
 
@@ -353,12 +357,7 @@ pub(crate) fn with_encoder(
             }
         };
         let first_call = buf.set_collector(collector);
-        f(&mut buf.thread_local_encoder());
-        let current_epoch = drain_epoch.load(Ordering::Relaxed);
-        if buf.should_flush() || buf.flush_epoch.load() < current_epoch {
-            collector.accept_flush(buf.flush());
-            buf.flush_epoch.store(current_epoch);
-        }
+        encode_and_maybe_flush(&mut buf, f, collector, drain_epoch);
         if first_call {
             Some(TlBufferHandle {
                 buffer: Arc::downgrade(arc),
@@ -428,13 +427,25 @@ pub(crate) fn with_encoder_if_enabled(
         if !is_enabled() {
             return;
         }
-        f(&mut buf.thread_local_encoder());
-        let current_epoch = drain_epoch.load(Ordering::Relaxed);
-        if buf.should_flush() || buf.flush_epoch.load() < current_epoch {
-            collector.accept_flush(buf.flush());
-            buf.flush_epoch.store(current_epoch);
-        }
+        encode_and_maybe_flush(&mut buf, f, collector, drain_epoch);
     });
+}
+
+/// Shared encode/flush path for ordinary and capture-gated events. Registration
+/// intentionally remains in the wrappers because the gated path must publish a
+/// first-use handle before checking the recording boundary.
+fn encode_and_maybe_flush(
+    buf: &mut ThreadLocalBuffer,
+    f: impl FnOnce(&mut ThreadLocalEncoder<'_>),
+    collector: &Arc<CentralCollector>,
+    drain_epoch: &AtomicU64,
+) {
+    f(&mut buf.thread_local_encoder());
+    let current_epoch = drain_epoch.load(Ordering::Relaxed);
+    if buf.should_flush() || buf.flush_epoch.load() < current_epoch {
+        collector.accept_flush(buf.flush());
+        buf.flush_epoch.store(current_epoch);
+    }
 }
 
 #[cfg(test)]

--- a/dial9-core/src/encoder.rs
+++ b/dial9-core/src/encoder.rs
@@ -370,6 +370,74 @@ pub(crate) fn with_encoder(
     })
 }
 
+/// Record through an enabled gate that can be closed concurrently by the
+/// flush thread.
+///
+/// The second gate check uses Acquire ordering while holding the thread-local
+/// buffer lock. Before that check, a first-use buffer is registered while also
+/// holding the registry mutex. The flush thread closes the gate with a Release
+/// store, then snapshots the registry and drains every registered buffer. If a
+/// producer registers first, the snapshot includes its buffer and waits for
+/// its event; if the snapshot wins, the registry mutex orders the Release
+/// before the producer's Acquire and the event is dropped. The same ordering
+/// applies to an already-registered buffer's lock. These mutex boundaries let
+/// the speculative outer check remain Relaxed.
+pub(crate) fn record_encodable_event_if_enabled(
+    event: &dyn Encodable,
+    is_enabled: impl FnOnce() -> bool,
+    collector: &Arc<CentralCollector>,
+    drain_epoch: &AtomicU64,
+    register: impl FnOnce(TlBufferHandle),
+) {
+    with_encoder_if_enabled(
+        |enc| event.encode(enc),
+        is_enabled,
+        collector,
+        drain_epoch,
+        register,
+    );
+}
+
+pub(crate) fn with_encoder_if_enabled(
+    f: impl FnOnce(&mut ThreadLocalEncoder<'_>),
+    is_enabled: impl FnOnce() -> bool,
+    collector: &Arc<CentralCollector>,
+    drain_epoch: &AtomicU64,
+    register: impl FnOnce(TlBufferHandle),
+) {
+    BUFFER.with(|arc| {
+        let mut buf = match arc.lock() {
+            Ok(guard) => guard,
+            Err(_) => {
+                crate::rate_limit::rate_limited!(Duration::from_secs(60), {
+                    tracing::error!(
+                        "dial9: thread-local buffer mutex poisoned in with_encoder_if_enabled; \
+                         dropping events for this thread"
+                    );
+                });
+                return;
+            }
+        };
+        let first_call = buf.set_collector(collector);
+        if first_call {
+            register(TlBufferHandle {
+                buffer: Arc::downgrade(arc),
+                flush_epoch: buf.flush_epoch.clone(),
+            });
+        }
+        if !is_enabled() {
+            return;
+        }
+        f(&mut buf.thread_local_encoder());
+        buf.event_count += 1;
+        let current_epoch = drain_epoch.load(Ordering::Relaxed);
+        if buf.should_flush() || buf.flush_epoch.load() < current_epoch {
+            collector.accept_flush(buf.flush());
+            buf.flush_epoch.store(current_epoch);
+        }
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/dial9-core/src/encoder.rs
+++ b/dial9-core/src/encoder.rs
@@ -429,7 +429,6 @@ pub(crate) fn with_encoder_if_enabled(
             return;
         }
         f(&mut buf.thread_local_encoder());
-        buf.event_count += 1;
         let current_epoch = drain_epoch.load(Ordering::Relaxed);
         if buf.should_flush() || buf.flush_epoch.load() < current_epoch {
             collector.accept_flush(buf.flush());

--- a/dial9-core/src/flush_loop.rs
+++ b/dial9-core/src/flush_loop.rs
@@ -1,6 +1,6 @@
 use crate::buffer::{BufferMode, SegmentWriter};
 use crate::encoder;
-use crate::handle::{ControlCommand, SegmentRotation};
+use crate::handle::ControlCommand;
 use crate::metrics::{FlushMetrics, FlushStats, Operation, TlDrainMetrics};
 use crate::rate_limit::rate_limited;
 use crate::shared_state::SharedState;
@@ -41,17 +41,9 @@ fn flush_once<M: BufferMode>(
     events_written: &mut u64,
     shared: &SharedState,
     drain_self: bool,
-    force_sources: bool,
+    cpu_flush_duration: Duration,
 ) -> FlushOutcome {
     let events_before = *events_written;
-    let cpu_events_time = std::time::Instant::now();
-    // A checkpoint must drain data that sources captured before the recording
-    // gate closed. Otherwise that data remains buffered in the source and can
-    // leak into the next capture after recording is re-enabled.
-    if force_sources || shared.is_enabled() {
-        shared.flush_sources();
-    }
-    let cpu_flush_duration = cpu_events_time.elapsed();
 
     if drain_self {
         // Periodically flush the flush thread's own TL buffer (queue samples + CPU events).
@@ -129,12 +121,14 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
 
     loop {
         let mut ack_tx = None;
-        let mut rotate_tx = None;
+        #[cfg(feature = "pipeline")]
+        let mut checkpoint_dump = None;
         let mut exit = false;
         // Wait for control commands up to 5ms.
         match control_rx.recv_timeout(Duration::from_millis(5)) {
-            Ok(ControlCommand::RotateSegment(ack)) => {
-                rotate_tx = Some(ack);
+            #[cfg(feature = "pipeline")]
+            Ok(ControlCommand::CheckpointDump(checkpoint)) => {
+                checkpoint_dump = Some(checkpoint);
             }
             Ok(ControlCommand::FinalizeAndStop(ack)) => {
                 ack_tx = Some(ack);
@@ -150,9 +144,31 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
         // When disabled, skip all recording work (queue sampling, metadata
         // merging, drain coordination, flush). The loop still wakes every
         // 5ms to check for control commands and the exit signal.
-        if !exit && rotate_tx.is_none() && !shared.is_enabled() {
+        #[cfg(feature = "pipeline")]
+        let has_checkpoint = checkpoint_dump.is_some();
+        #[cfg(not(feature = "pipeline"))]
+        let has_checkpoint = false;
+        if !exit && !has_checkpoint && !shared.is_enabled() {
             continue;
         }
+
+        // A capture-stop checkpoint takes one final source sample while the
+        // recording gate is still open, then closes the gate before draining
+        // thread-local buffers. A checkpoint received after a caller already
+        // disabled recording does not invoke sources: `Source::flush` may
+        // sample new state rather than merely draining pending data.
+        let cpu_events_time = std::time::Instant::now();
+        if shared.is_enabled() {
+            shared.flush_sources();
+        }
+        #[cfg(feature = "pipeline")]
+        if checkpoint_dump
+            .as_ref()
+            .is_some_and(|checkpoint| checkpoint.stop_recording)
+        {
+            shared.disable();
+        }
+        let cpu_flush_duration = cpu_events_time.elapsed();
 
         // Collect per-source metadata (per-runtime worker mappings, memory
         // sample rate, etc.) only from sources that report a change since the
@@ -172,8 +188,7 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
         }
 
         cycle_count += 1;
-        let drain_self =
-            exit || rotate_tx.is_some() || cycle_count.is_multiple_of(SELF_DRAIN_INTERVAL);
+        let drain_self = exit || has_checkpoint || cycle_count.is_multiple_of(SELF_DRAIN_INTERVAL);
         // --- Drain coordination state machine ---
         //
         // When the writer reports a drain is due, we can't act immediately
@@ -201,12 +216,12 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
 
         // On exit, bump + drain in the same tick since there is no next
         // tick for the grace period.
-        if exit || rotate_tx.is_some() {
+        if exit || has_checkpoint {
             shared.bump_drain_epoch();
         }
 
         // --- Execute intrusive drain when needed ---
-        if exit || rotate_tx.is_some() || do_drain {
+        if exit || has_checkpoint || do_drain {
             let mut tl_drain_timer = Timer::start_now();
             let stats = shared.drain_all_tl_buffers();
             tl_drain_timer.stop();
@@ -227,8 +242,10 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
             &mut events_written,
             shared,
             drain_self,
-            rotate_tx.is_some(),
+            cpu_flush_duration,
         );
+        #[cfg(not(feature = "pipeline"))]
+        let _ = &flush_error;
         flush_timer.stop();
 
         // Notify the writer that TL buffers have been drained and flushed.
@@ -236,7 +253,7 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
         // Skip on exit — finalize() below will seal the final segment.
         if do_drain
             && !exit
-            && rotate_tx.is_none()
+            && !has_checkpoint
             && let Err(e) = writer.drained()
         {
             rate_limited!(Duration::from_secs(60), {
@@ -278,35 +295,29 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
                 }
             }
         }
-        if let Some(tx) = rotate_tx.take() {
+        #[cfg(feature = "pipeline")]
+        if let Some(checkpoint) = checkpoint_dump.take() {
             let result = match flush_error {
                 Some(error) => Err(error),
-                None => writer.write_current_segment_metadata().and_then(|()| {
-                    writer.rotate_segment().map(|rotated| {
-                        if rotated {
-                            SegmentRotation::Sealed
-                        } else {
-                            SegmentRotation::Empty
-                        }
-                    })
-                }),
+                None => writer
+                    .write_current_segment_metadata()
+                    .and_then(|()| writer.rotate_segment().map(|_| ())),
             };
-            if let Err(e) = &result {
-                rate_limited!(Duration::from_secs(60), {
-                    tracing::warn!("failed to rotate trace segment on demand: {e}");
-                });
-                // A strict rotation can consume the active writer before
-                // failing to seal or replace it. Stop accepting events only
-                // when there is no writer left; a pre-rotation flush or
-                // metadata error leaves the writer available for a retry.
-                if writer.is_closed() {
-                    shared.disable();
+            match result {
+                Ok(()) => checkpoint.dispatch(),
+                Err(error) => {
+                    rate_limited!(Duration::from_secs(60), {
+                        tracing::warn!("failed to checkpoint current trace data: {error}");
+                    });
+                    // A strict rotation can consume the active writer before
+                    // failing to seal or replace it. Stop accepting events only
+                    // when there is no writer left; a pre-rotation flush or
+                    // metadata error leaves the writer available for a retry.
+                    if writer.is_closed() {
+                        shared.disable();
+                    }
+                    checkpoint.fail(error);
                 }
-            }
-            if tx.send(result).is_err() {
-                tracing::debug!(
-                    "trace segment rotation completed after the caller stopped waiting"
-                );
             }
         }
         drop(flush_guard);

--- a/dial9-core/src/flush_loop.rs
+++ b/dial9-core/src/flush_loop.rs
@@ -1,6 +1,6 @@
 use crate::buffer::{BufferMode, SegmentWriter};
 use crate::encoder;
-use crate::handle::ControlCommand;
+use crate::handle::{ControlCommand, SegmentRotation};
 use crate::metrics::{FlushMetrics, FlushStats, Operation, TlDrainMetrics};
 use crate::rate_limit::rate_limited;
 use crate::shared_state::SharedState;
@@ -28,6 +28,11 @@ enum DrainState {
     EpochBumped,
 }
 
+struct FlushOutcome {
+    stats: FlushStats,
+    error: Option<std::io::Error>,
+}
+
 /// Perform one flush cycle: drain CPU profilers, drain the collector, write
 /// events to disk, and flush the writer. This is the only code path that
 /// touches the writer, and it runs exclusively on the flush thread.
@@ -36,10 +41,14 @@ fn flush_once<M: BufferMode>(
     events_written: &mut u64,
     shared: &SharedState,
     drain_self: bool,
-) -> FlushStats {
+    force_sources: bool,
+) -> FlushOutcome {
     let events_before = *events_written;
     let cpu_events_time = std::time::Instant::now();
-    if shared.is_enabled() {
+    // A checkpoint must drain data that sources captured before the recording
+    // gate closed. Otherwise that data remains buffered in the source and can
+    // leak into the next capture after recording is re-enabled.
+    if force_sources || shared.is_enabled() {
         shared.flush_sources();
     }
     let cpu_flush_duration = cpu_events_time.elapsed();
@@ -68,24 +77,31 @@ fn flush_once<M: BufferMode>(
                     tracing::warn!("failed to transcode batch: {e}");
                 });
                 shared.disable();
-                return FlushStats {
-                    event_count: *events_written - events_before,
-                    dropped_batches: dropped as u64,
-                    cpu_flush_duration,
+                return FlushOutcome {
+                    stats: FlushStats {
+                        event_count: *events_written - events_before,
+                        dropped_batches: dropped as u64,
+                        cpu_flush_duration,
+                    },
+                    error: Some(e),
                 };
             }
             *events_written += batch.event_count();
         }
     }
-    if let Err(e) = writer.flush() {
+    let error = writer.flush().err();
+    if let Some(e) = &error {
         rate_limited!(Duration::from_secs(60), {
             tracing::warn!("failed to flush trace data: {e}");
         });
     }
-    FlushStats {
-        event_count: *events_written - events_before,
-        dropped_batches: dropped as u64,
-        cpu_flush_duration,
+    FlushOutcome {
+        stats: FlushStats {
+            event_count: *events_written - events_before,
+            dropped_batches: dropped as u64,
+            cpu_flush_duration,
+        },
+        error,
     }
 }
 
@@ -113,9 +129,13 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
 
     loop {
         let mut ack_tx = None;
+        let mut rotate_tx = None;
         let mut exit = false;
         // Wait for control commands up to 5ms.
         match control_rx.recv_timeout(Duration::from_millis(5)) {
+            Ok(ControlCommand::RotateSegment(ack)) => {
+                rotate_tx = Some(ack);
+            }
             Ok(ControlCommand::FinalizeAndStop(ack)) => {
                 ack_tx = Some(ack);
                 exit = true;
@@ -130,7 +150,7 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
         // When disabled, skip all recording work (queue sampling, metadata
         // merging, drain coordination, flush). The loop still wakes every
         // 5ms to check for control commands and the exit signal.
-        if !exit && !shared.is_enabled() {
+        if !exit && rotate_tx.is_none() && !shared.is_enabled() {
             continue;
         }
 
@@ -152,7 +172,8 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
         }
 
         cycle_count += 1;
-        let drain_self = exit || cycle_count.is_multiple_of(SELF_DRAIN_INTERVAL);
+        let drain_self =
+            exit || rotate_tx.is_some() || cycle_count.is_multiple_of(SELF_DRAIN_INTERVAL);
         // --- Drain coordination state machine ---
         //
         // When the writer reports a drain is due, we can't act immediately
@@ -180,12 +201,12 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
 
         // On exit, bump + drain in the same tick since there is no next
         // tick for the grace period.
-        if exit {
+        if exit || rotate_tx.is_some() {
             shared.bump_drain_epoch();
         }
 
         // --- Execute intrusive drain when needed ---
-        if exit || do_drain {
+        if exit || rotate_tx.is_some() || do_drain {
             let mut tl_drain_timer = Timer::start_now();
             let stats = shared.drain_all_tl_buffers();
             tl_drain_timer.stop();
@@ -198,7 +219,16 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
             .append_on_drop(flush_metrics_sink.clone());
         }
         let mut flush_timer = Timer::start_now();
-        let stats = flush_once(&mut writer, &mut events_written, shared, drain_self);
+        let FlushOutcome {
+            stats,
+            error: flush_error,
+        } = flush_once(
+            &mut writer,
+            &mut events_written,
+            shared,
+            drain_self,
+            rotate_tx.is_some(),
+        );
         flush_timer.stop();
 
         // Notify the writer that TL buffers have been drained and flushed.
@@ -206,6 +236,7 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
         // Skip on exit — finalize() below will seal the final segment.
         if do_drain
             && !exit
+            && rotate_tx.is_none()
             && let Err(e) = writer.drained()
         {
             rate_limited!(Duration::from_secs(60), {
@@ -245,6 +276,37 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
                 if let Some(g) = flush_guard.as_mut() {
                     g.finalize_failed = true;
                 }
+            }
+        }
+        if let Some(tx) = rotate_tx.take() {
+            let result = match flush_error {
+                Some(error) => Err(error),
+                None => writer.write_current_segment_metadata().and_then(|()| {
+                    writer.rotate_segment().map(|rotated| {
+                        if rotated {
+                            SegmentRotation::Sealed
+                        } else {
+                            SegmentRotation::Empty
+                        }
+                    })
+                }),
+            };
+            if let Err(e) = &result {
+                rate_limited!(Duration::from_secs(60), {
+                    tracing::warn!("failed to rotate trace segment on demand: {e}");
+                });
+                // A strict rotation can consume the active writer before
+                // failing to seal or replace it. Stop accepting events only
+                // when there is no writer left; a pre-rotation flush or
+                // metadata error leaves the writer available for a retry.
+                if writer.is_closed() {
+                    shared.disable();
+                }
+            }
+            if tx.send(result).is_err() {
+                tracing::debug!(
+                    "trace segment rotation completed after the caller stopped waiting"
+                );
             }
         }
         drop(flush_guard);

--- a/dial9-core/src/flush_loop.rs
+++ b/dial9-core/src/flush_loop.rs
@@ -141,6 +141,26 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
             Err(crate::primitives::sync::mpsc::RecvTimeoutError::Timeout) => {}
         }
 
+        #[cfg(feature = "pipeline")]
+        if let Err(error) = writer.enforce_checkpoint_budget() {
+            rate_limited!(Duration::from_secs(60), {
+                tracing::warn!("failed to restore trace budget after checkpoint: {error}");
+            });
+        }
+
+        // Claim the sole protected snapshot before source sampling or closing
+        // the recording gate. A busy capture-stop request must not disable
+        // recording when it cannot establish its boundary.
+        #[cfg(feature = "pipeline")]
+        if checkpoint_dump.is_some()
+            && let Err(error) = writer.reserve_checkpoint()
+        {
+            checkpoint_dump
+                .take()
+                .expect("checkpoint presence checked")
+                .fail(error);
+        }
+
         // When disabled, skip all recording work (queue sampling, metadata
         // merging, drain coordination, flush). The loop still wakes every
         // 5ms to check for control commands and the exit signal.
@@ -301,10 +321,15 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
                 Some(error) => Err(error),
                 None => writer
                     .write_current_segment_metadata()
-                    .and_then(|()| writer.rotate_segment().map(|_| ())),
+                    .and_then(|()| writer.checkpoint_segments()),
             };
             match result {
-                Ok(()) => checkpoint.dispatch(),
+                Ok(protected) => {
+                    if let Err(protected) = checkpoint.dispatch(protected) {
+                        writer.release_checkpoint_segments(&protected);
+                        writer.finish_checkpoint();
+                    }
+                }
                 Err(error) => {
                     rate_limited!(Duration::from_secs(60), {
                         tracing::warn!("failed to checkpoint current trace data: {error}");
@@ -317,6 +342,7 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
                         shared.disable();
                     }
                     checkpoint.fail(error);
+                    writer.finish_checkpoint();
                 }
             }
         }

--- a/dial9-core/src/flush_loop.rs
+++ b/dial9-core/src/flush_loop.rs
@@ -123,6 +123,8 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
         let mut ack_tx = None;
         #[cfg(feature = "pipeline")]
         let mut checkpoint_dump = None;
+        #[cfg(feature = "pipeline")]
+        let mut checkpoint_guard = None;
         let mut exit = false;
         // Wait for control commands up to 5ms.
         match control_rx.recv_timeout(Duration::from_millis(5)) {
@@ -152,13 +154,14 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
         // the recording gate. A busy capture-stop request must not disable
         // recording when it cannot establish its boundary.
         #[cfg(feature = "pipeline")]
-        if checkpoint_dump.is_some()
-            && let Err(error) = writer.reserve_checkpoint()
-        {
-            checkpoint_dump
-                .take()
-                .expect("checkpoint presence checked")
-                .fail(error);
+        if checkpoint_dump.is_some() {
+            match writer.reserve_checkpoint() {
+                Ok(guard) => checkpoint_guard = Some(guard),
+                Err(error) => checkpoint_dump
+                    .take()
+                    .expect("checkpoint presence checked")
+                    .fail(error),
+            }
         }
 
         // When disabled, skip all recording work (queue sampling, metadata
@@ -319,17 +322,16 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
         if let Some(checkpoint) = checkpoint_dump.take() {
             let result = match flush_error {
                 Some(error) => Err(error),
-                None => writer
-                    .write_current_segment_metadata()
-                    .and_then(|()| writer.checkpoint_segments()),
+                None => writer.write_current_segment_metadata().and_then(|()| {
+                    writer.seal_checkpoint(
+                        checkpoint_guard
+                            .take()
+                            .expect("active checkpoint owns its reservation"),
+                    )
+                }),
             };
             match result {
-                Ok(protected) => {
-                    if let Err(protected) = checkpoint.dispatch(protected) {
-                        writer.release_checkpoint_segments(&protected);
-                        writer.finish_checkpoint();
-                    }
-                }
+                Ok(guard) => checkpoint.dispatch(guard),
                 Err(error) => {
                     rate_limited!(Duration::from_secs(60), {
                         tracing::warn!("failed to checkpoint current trace data: {error}");
@@ -342,7 +344,6 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
                         shared.disable();
                     }
                     checkpoint.fail(error);
-                    writer.finish_checkpoint();
                 }
             }
         }

--- a/dial9-core/src/flush_loop.rs
+++ b/dial9-core/src/flush_loop.rs
@@ -154,9 +154,27 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
         // the recording gate. A busy capture-stop request must not disable
         // recording when it cannot establish its boundary.
         #[cfg(feature = "pipeline")]
-        if checkpoint_dump.is_some() {
+        if let Some(into) = checkpoint_dump
+            .as_ref()
+            .and_then(crate::dump::CheckpointDump::debounce_target)
+        {
+            checkpoint_dump
+                .take()
+                .expect("checkpoint presence checked")
+                .coalesce(into);
+        } else if checkpoint_dump.is_some() {
             match writer.reserve_checkpoint() {
-                Ok(guard) => checkpoint_guard = Some(guard),
+                Ok(guard) => match checkpoint_dump
+                    .as_ref()
+                    .expect("checkpoint presence checked")
+                    .accept_debounce()
+                {
+                    Ok(()) => checkpoint_guard = Some(guard),
+                    Err(into) => checkpoint_dump
+                        .take()
+                        .expect("checkpoint presence checked")
+                        .coalesce(into),
+                },
                 Err(error) => checkpoint_dump
                     .take()
                     .expect("checkpoint presence checked")
@@ -331,7 +349,19 @@ pub(crate) fn run_flush_loop<M: BufferMode>(
                 }),
             };
             match result {
-                Ok(guard) => checkpoint.dispatch(guard),
+                Ok((guard, post_seal_error)) => {
+                    if let Some(error) = post_seal_error {
+                        rate_limited!(Duration::from_secs(60), {
+                            tracing::warn!(
+                                "checkpoint sealed, but segment rotation reported a follow-up error: {error}"
+                            );
+                        });
+                        if writer.is_closed() {
+                            shared.disable();
+                        }
+                    }
+                    checkpoint.dispatch(guard);
+                }
                 Err(error) => {
                     rate_limited!(Duration::from_secs(60), {
                         tracing::warn!("failed to checkpoint current trace data: {error}");

--- a/dial9-core/src/fs/disk.rs
+++ b/dial9-core/src/fs/disk.rs
@@ -46,6 +46,9 @@ pub(crate) struct DiskFs {
     /// active and makes overlapping protection sets unambiguous.
     #[cfg(feature = "pipeline")]
     checkpoint_active: AtomicBool,
+    /// Writer retention budget, copied here so the final checkpoint lease can
+    /// enforce it even after the flush thread and `SegmentWriter` are gone.
+    max_total_size: AtomicU64,
     dropped: AtomicU64,
     writer_done: AtomicBool,
 }
@@ -62,9 +65,14 @@ impl DiskFs {
             checkpoint_budget_dirty: AtomicBool::new(false),
             #[cfg(feature = "pipeline")]
             checkpoint_active: AtomicBool::new(false),
+            max_total_size: AtomicU64::new(u64::MAX),
             dropped: AtomicU64::new(0),
             writer_done: AtomicBool::new(false),
         }
+    }
+
+    pub(super) fn set_max_total_size(&self, max_total_size: u64) {
+        self.max_total_size.store(max_total_size, Ordering::Release);
     }
 
     pub(super) fn create_segment(&self, path: &Path) -> io::Result<ActiveHandle> {
@@ -170,6 +178,7 @@ impl DiskFs {
     pub(super) fn release_checkpoint_segment(&self, index: u32) {
         if self.checkpoint_protected.lock().unwrap().remove(&index) {
             self.checkpoint_budget_dirty.store(true, Ordering::Release);
+            self.enforce_final_checkpoint_budget();
         }
     }
 
@@ -189,6 +198,52 @@ impl DiskFs {
     /// next `take_files` scan.
     pub(super) fn mark_writer_done(&self) {
         self.writer_done.store(true, Ordering::Release);
+        #[cfg(feature = "pipeline")]
+        self.enforce_final_checkpoint_budget();
+    }
+
+    /// Reconcile checkpoint-delayed eviction once no writer remains to consume
+    /// `checkpoint_budget_dirty`. Every protection release retries the scan,
+    /// so entries that are still protected stay until their own lease ends.
+    #[cfg(feature = "pipeline")]
+    fn enforce_final_checkpoint_budget(&self) {
+        if !self.writer_done.load(Ordering::Acquire)
+            || !self.checkpoint_budget_dirty.swap(false, Ordering::AcqRel)
+        {
+            return;
+        }
+
+        if let Err(error) = self.try_enforce_final_checkpoint_budget() {
+            // Keep the work pending in case another lease release gives us a
+            // retry opportunity. There is no background thread after shutdown.
+            self.checkpoint_budget_dirty.store(true, Ordering::Release);
+            rate_limited!(Duration::from_secs(60), {
+                tracing::warn!(
+                    target: "dial9_worker",
+                    %error,
+                    "failed to enforce disk budget after checkpoint shutdown"
+                );
+            });
+        }
+    }
+
+    #[cfg(feature = "pipeline")]
+    fn try_enforce_final_checkpoint_budget(&self) -> io::Result<()> {
+        let discovered = self.discover_existing()?;
+        let mut total_size: u64 = discovered.closed_files.iter().map(|(_, size)| size).sum();
+        let max_total_size = self.max_total_size.load(Ordering::Acquire);
+
+        for (segment, size) in discovered.closed_files {
+            if total_size <= max_total_size {
+                break;
+            }
+            if self.checkpoint_segment_is_protected(segment.index()) {
+                continue;
+            }
+            self.remove_sealed(&segment, RemoveReason::Eviction);
+            total_size = total_size.saturating_sub(size);
+        }
+        Ok(())
     }
 
     #[cfg(feature = "pipeline")]
@@ -582,6 +637,31 @@ mod tests {
     fn strip_active_suffix_no_suffix() {
         let p = Path::new("/tmp/trace.0.bin");
         check!(strip_active_suffix(p) == PathBuf::from("/tmp/trace.0.bin"));
+    }
+
+    #[test]
+    fn final_checkpoint_release_reconciles_disk_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("trace.0.bin");
+        let second = dir.path().join("trace.1.bin");
+        std::fs::write(&first, b"four").unwrap();
+        std::fs::write(&second, b"more").unwrap();
+        let disk = DiskFs::new(dir.path(), "trace");
+        disk.set_max_total_size(4);
+        disk.protect_checkpoint_segments(&[0, 1]);
+
+        disk.mark_writer_done();
+        check!(
+            first.exists() && second.exists(),
+            "protected files survive finalize"
+        );
+
+        disk.release_checkpoint_segment(0);
+        check!(!first.exists(), "released oldest segment is evicted");
+        check!(second.exists(), "remaining protected segment is retained");
+
+        disk.release_checkpoint_segment(1);
+        check!(second.exists(), "retention is already within budget");
     }
 }
 

--- a/dial9-core/src/fs/disk.rs
+++ b/dial9-core/src/fs/disk.rs
@@ -30,6 +30,22 @@ pub(crate) struct DiskFs {
     /// Claimed segment index -> uncompressed size in bytes. Dedup so each
     /// sealed file is dispensed at most once per `DiskFs` instance.
     claimed: Mutex<HashMap<u32, u64>>,
+    /// Segments belonging to a flush-thread checkpoint whose worker pipeline
+    /// pass has not finished yet. Writer-side eviction skips these entries so
+    /// sealing the checkpoint cannot invalidate its own dump or a stage that
+    /// still needs the original path.
+    #[cfg(feature = "pipeline")]
+    checkpoint_protected: Mutex<HashSet<u32>>,
+    /// Set when the worker releases checkpoint protection. The flush thread
+    /// consumes this flag and re-applies the disk budget from its writer-owned
+    /// `closed_files` queue.
+    #[cfg(feature = "pipeline")]
+    checkpoint_budget_dirty: AtomicBool,
+    /// At most one current-data checkpoint may own an eviction-protected
+    /// snapshot. This bounds the retention overshoot while its worker pass is
+    /// active and makes overlapping protection sets unambiguous.
+    #[cfg(feature = "pipeline")]
+    checkpoint_active: AtomicBool,
     dropped: AtomicU64,
     writer_done: AtomicBool,
 }
@@ -40,6 +56,12 @@ impl DiskFs {
             dir: dir.into(),
             stem: stem.into(),
             claimed: Mutex::new(HashMap::new()),
+            #[cfg(feature = "pipeline")]
+            checkpoint_protected: Mutex::new(HashSet::new()),
+            #[cfg(feature = "pipeline")]
+            checkpoint_budget_dirty: AtomicBool::new(false),
+            #[cfg(feature = "pipeline")]
+            checkpoint_active: AtomicBool::new(false),
             dropped: AtomicU64::new(0),
             writer_done: AtomicBool::new(false),
         }
@@ -85,6 +107,11 @@ impl DiskFs {
             remove_segment_family(path);
         }
         self.claimed.lock().unwrap().remove(&seg.index());
+        #[cfg(feature = "pipeline")]
+        self.checkpoint_protected
+            .lock()
+            .unwrap()
+            .remove(&seg.index());
         if matches!(reason, RemoveReason::Eviction) {
             self.dropped.fetch_add(1, Ordering::Relaxed);
         }
@@ -115,6 +142,43 @@ impl DiskFs {
     #[cfg(feature = "pipeline")]
     pub(super) fn release_claim(&self, index: u32) {
         self.claimed.lock().unwrap().remove(&index);
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn protect_checkpoint_segments(&self, indices: &[u32]) {
+        self.checkpoint_protected
+            .lock()
+            .unwrap()
+            .extend(indices.iter().copied());
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn try_reserve_checkpoint(&self) -> bool {
+        self.checkpoint_active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn finish_checkpoint(&self) {
+        self.checkpoint_active.store(false, Ordering::Release);
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn checkpoint_segment_is_protected(&self, index: u32) -> bool {
+        self.checkpoint_protected.lock().unwrap().contains(&index)
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn release_checkpoint_segment(&self, index: u32) {
+        if self.checkpoint_protected.lock().unwrap().remove(&index) {
+            self.checkpoint_budget_dirty.store(true, Ordering::Release);
+        }
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn checkpoint_budget_dirty(&self) -> bool {
+        self.checkpoint_budget_dirty.swap(false, Ordering::AcqRel)
     }
 
     #[cfg(feature = "pipeline")]

--- a/dial9-core/src/fs/disk.rs
+++ b/dial9-core/src/fs/disk.rs
@@ -108,10 +108,7 @@ impl DiskFs {
         }
         self.claimed.lock().unwrap().remove(&seg.index());
         #[cfg(feature = "pipeline")]
-        self.checkpoint_protected
-            .lock()
-            .unwrap()
-            .remove(&seg.index());
+        self.release_checkpoint_segment(seg.index());
         if matches!(reason, RemoveReason::Eviction) {
             self.dropped.fetch_add(1, Ordering::Relaxed);
         }

--- a/dial9-core/src/fs/mem.rs
+++ b/dial9-core/src/fs/mem.rs
@@ -79,9 +79,9 @@ struct Queue {
     bytes: u64,
     /// Segments evicted since the last `take_files` swap.
     dropped: u64,
-    /// Segments belonging to a checkpoint that the worker has not taken yet.
-    /// The sole active checkpoint may temporarily keep its active segment
-    /// beyond the ring budget until the worker takes the protected snapshot.
+    /// Segments belonging to a checkpoint that has not reached a terminal
+    /// pipeline outcome. The sole active checkpoint may temporarily keep its
+    /// snapshot beyond the ring budget while the worker processes or retries it.
     /// Later, unprotected production segments evict themselves while every
     /// retained entry is protected, so the overshoot is bounded to that one
     /// checkpoint segment (though a batch may overshoot its size threshold).
@@ -365,7 +365,6 @@ impl MemFs {
             };
             if let Some(s) = &popped {
                 q.bytes -= s.bytes.len() as u64;
-                q.checkpoint_protected.remove(&s.index);
             }
             let segments_dropped = std::mem::take(&mut q.dropped);
             (popped, q.segments.len() as u64, q.bytes, segments_dropped)

--- a/dial9-core/src/fs/mem.rs
+++ b/dial9-core/src/fs/mem.rs
@@ -89,6 +89,36 @@ struct Queue {
     checkpoint_protected: HashSet<u32>,
 }
 
+impl Queue {
+    fn evict_to_budget(&mut self, max_total_size: u64) -> (u64, Option<u32>, Option<u32>) {
+        let mut evicted = 0;
+        let mut first = None;
+        let mut last = None;
+        while self.bytes > max_total_size && self.segments.len() > 1 {
+            #[cfg(feature = "pipeline")]
+            let evict_pos = self
+                .segments
+                .iter()
+                .position(|segment| !self.checkpoint_protected.contains(&segment.index));
+            #[cfg(not(feature = "pipeline"))]
+            let evict_pos = Some(0);
+            let Some(evict_pos) = evict_pos else {
+                break;
+            };
+            let old = self
+                .segments
+                .remove(evict_pos)
+                .expect("eviction position came from the queue");
+            self.bytes -= old.bytes.len() as u64;
+            evicted += 1;
+            first.get_or_insert(old.index);
+            last = Some(old.index);
+        }
+        self.dropped += evicted;
+        (evicted, first, last)
+    }
+}
+
 struct MemChannel {
     max_total_size: u64,
     queue: Mutex<Queue>,
@@ -185,31 +215,7 @@ impl MemFs {
             // unprotected entries; later production segments evict themselves
             // if the retained snapshot alone fills the budget. Without a
             // checkpoint this is the same oldest-first policy as before.
-            let mut evicted = 0u64;
-            let mut first: Option<u32> = None;
-            let mut last: Option<u32> = None;
-            while q.bytes > ch.max_total_size {
-                #[cfg(feature = "pipeline")]
-                let evict_pos = q
-                    .segments
-                    .iter()
-                    .position(|segment| !q.checkpoint_protected.contains(&segment.index));
-                #[cfg(not(feature = "pipeline"))]
-                let evict_pos = (!q.segments.is_empty()).then_some(0);
-                let Some(evict_pos) = evict_pos else {
-                    break;
-                };
-                let old = q
-                    .segments
-                    .remove(evict_pos)
-                    .expect("eviction position came from the queue");
-                q.bytes -= old.bytes.len() as u64;
-                evicted += 1;
-                first.get_or_insert(old.index);
-                last = Some(old.index);
-            }
-            q.dropped += evicted;
-            (evicted, first, last)
+            q.evict_to_budget(ch.max_total_size)
         };
 
         if let (Some(first), Some(last)) = (first_idx, last_idx) {
@@ -273,21 +279,7 @@ impl MemFs {
 
         // If the worker never took a protected entry (for example it stopped
         // before registering the request), restore the ring budget now.
-        while q.bytes > ch.max_total_size {
-            let Some(pos) = q
-                .segments
-                .iter()
-                .position(|segment| !q.checkpoint_protected.contains(&segment.index))
-            else {
-                break;
-            };
-            let old = q
-                .segments
-                .remove(pos)
-                .expect("eviction position came from the queue");
-            q.bytes -= old.bytes.len() as u64;
-            q.dropped += 1;
-        }
+        q.evict_to_budget(ch.max_total_size);
     }
 
     /// Re-enqueue `bytes` for re-dispense on the next `take_files` cycle.
@@ -474,6 +466,15 @@ mod tests {
     use super::*;
     use assert2::check;
 
+    fn seal_bytes(mem: &MemFs, index: u32, len: usize) {
+        let ActiveHandle::Mem(mut handle) = mem.create_segment(Path::new("dummy")).unwrap() else {
+            unreachable!("memory backend yields a memory handle")
+        };
+        handle.buf.resize(len, index as u8);
+        mem.seal(ActiveHandle::Mem(handle), Path::new("dummy"), index)
+            .unwrap();
+    }
+
     #[test]
     fn mem_fs_seal_take_roundtrip() {
         let mem = MemFs::with_capacity(64 * 1024, 1024).unwrap();
@@ -508,13 +509,7 @@ mod tests {
         let mem = MemFs::with_capacity(60, 60).unwrap();
 
         for index in 0..2u32 {
-            let handle = mem.create_segment(Path::new("dummy")).unwrap();
-            let ActiveHandle::Mem(mut w) = handle else {
-                panic!()
-            };
-            w.buf.resize(60, index as u8);
-            mem.seal(ActiveHandle::Mem(w), Path::new("dummy"), index)
-                .unwrap();
+            seal_bytes(&mem, index, 60);
         }
 
         // Only the most recent segment remains.
@@ -530,18 +525,22 @@ mod tests {
         // evicts everything that overflows. Final state: just segment 2.
         let mem = MemFs::with_capacity(100, 60).unwrap();
         for index in 0..3u32 {
-            let handle = mem.create_segment(Path::new("dummy")).unwrap();
-            let ActiveHandle::Mem(mut w) = handle else {
-                panic!()
-            };
-            w.buf.resize(60, index as u8);
-            mem.seal(ActiveHandle::Mem(w), Path::new("dummy"), index)
-                .unwrap();
+            seal_bytes(&mem, index, 60);
         }
         let t = mem.take_files();
         check!(t.segments_dropped == 2);
         check!(t.segments.len() == 1);
         check!(t.segments[0].seg_ref.index() == 2);
+    }
+
+    #[test]
+    fn mem_fs_keeps_lone_oversized_segment() {
+        let mem = MemFs::with_capacity(4, 8).unwrap();
+        seal_bytes(&mem, 0, 8);
+
+        let taken = mem.take_files();
+        check!(taken.segments_dropped == 0);
+        check!(taken.segments[0].seg_ref.index() == 0);
     }
 
     #[test]
@@ -556,12 +555,7 @@ mod tests {
     fn mem_fs_queued_segments_after_pop() {
         let mem = MemFs::with_capacity(64 * 1024, 1024).unwrap();
         for i in 0..3u32 {
-            let handle = mem.create_segment(Path::new("x")).unwrap();
-            let ActiveHandle::Mem(mut w) = handle else {
-                panic!()
-            };
-            w.buf.push(i as u8);
-            mem.seal(ActiveHandle::Mem(w), Path::new("x"), i).unwrap();
+            seal_bytes(&mem, i, 1);
         }
         let t = mem.take_files();
         check!(t.segments.len() == 1);
@@ -586,13 +580,7 @@ mod tests {
     fn mem_fs_take_pops_one_at_a_time() {
         let mem = MemFs::with_capacity(64 * 1024, 1024).unwrap();
         for i in 0..3u32 {
-            let handle = mem.create_segment(Path::new("dummy")).unwrap();
-            let ActiveHandle::Mem(mut w) = handle else {
-                panic!()
-            };
-            w.buf.push(i as u8);
-            mem.seal(ActiveHandle::Mem(w), Path::new("dummy"), i)
-                .unwrap();
+            seal_bytes(&mem, i, 1);
         }
 
         for _ in 0..3 {
@@ -607,24 +595,12 @@ mod tests {
     fn checkpoint_snapshot_uses_in_flight_reserve_instead_of_evicting() {
         let mem = MemFs::with_capacity(4, 4).unwrap();
         check!(mem.try_reserve_checkpoint());
-        let first = mem.create_segment(Path::new("first")).unwrap();
-        let ActiveHandle::Mem(mut first) = first else {
-            unreachable!("memory backend yields a memory handle")
-        };
-        first.buf.resize(4, 1);
-        mem.seal(ActiveHandle::Mem(first), Path::new("first"), 0)
-            .unwrap();
+        seal_bytes(&mem, 0, 4);
 
         let protected = mem.protect_checkpoint_segments(Some(1));
         check!(protected == vec![0, 1]);
 
-        let checkpoint = mem.create_segment(Path::new("checkpoint")).unwrap();
-        let ActiveHandle::Mem(mut checkpoint) = checkpoint else {
-            unreachable!("memory backend yields a memory handle")
-        };
-        checkpoint.buf.resize(4, 2);
-        mem.seal(ActiveHandle::Mem(checkpoint), Path::new("checkpoint"), 1)
-            .unwrap();
+        seal_bytes(&mem, 1, 4);
 
         let first_taken = mem.take_files();
         check!(first_taken.segments.len() == 1);
@@ -644,23 +620,11 @@ mod tests {
         check!(mem.try_reserve_checkpoint());
         check!(!mem.try_reserve_checkpoint());
 
-        let first = mem.create_segment(Path::new("first")).unwrap();
-        let ActiveHandle::Mem(mut first) = first else {
-            unreachable!("memory backend yields a memory handle")
-        };
-        first.buf.resize(4, 1);
-        mem.seal(ActiveHandle::Mem(first), Path::new("first"), 0)
-            .unwrap();
+        seal_bytes(&mem, 0, 4);
         let protected = mem.protect_checkpoint_segments(Some(1));
 
         for index in 1..=32 {
-            let segment = mem.create_segment(Path::new("later")).unwrap();
-            let ActiveHandle::Mem(mut segment) = segment else {
-                unreachable!("memory backend yields a memory handle")
-            };
-            segment.buf.resize(4, 2);
-            mem.seal(ActiveHandle::Mem(segment), Path::new("later"), index)
-                .unwrap();
+            seal_bytes(&mem, index, 4);
         }
 
         {

--- a/dial9-core/src/fs/mem.rs
+++ b/dial9-core/src/fs/mem.rs
@@ -1,12 +1,17 @@
 //! In-memory `Fs` variant.
 //!
 //! `MemFs` keeps sealed segments in a byte-bounded ring. On each `seal`,
-//! the oldest segments are dropped until `queued_bytes <=
-//! max_total_size`. The worker pops one segment per `take_files` cycle.
+//! the oldest segments are dropped until `queued_bytes <= max_total_size`.
+//! While the sole current-data checkpoint is active, its snapshot plus the
+//! newly sealed checkpoint segment are retained; that one segment may
+//! temporarily exceed the ring budget until the worker takes it. The worker
+//! pops one segment per `take_files` cycle.
 //!
 //! The shutdown handoff rides `writer_done` (Acquire/Release) plus a
 //! `tokio::sync::Notify` for wakeups.
 
+#[cfg(feature = "pipeline")]
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::io::{self, Write};
 use std::path::Path;
@@ -74,6 +79,14 @@ struct Queue {
     bytes: u64,
     /// Segments evicted since the last `take_files` swap.
     dropped: u64,
+    /// Segments belonging to a checkpoint that the worker has not taken yet.
+    /// The sole active checkpoint may temporarily keep its active segment
+    /// beyond the ring budget until the worker takes the protected snapshot.
+    /// Later, unprotected production segments evict themselves while every
+    /// retained entry is protected, so the overshoot is bounded to that one
+    /// checkpoint segment (though a batch may overshoot its size threshold).
+    #[cfg(feature = "pipeline")]
+    checkpoint_protected: HashSet<u32>,
 }
 
 struct MemChannel {
@@ -85,6 +98,10 @@ struct MemChannel {
     in_flight_segments: Arc<AtomicU64>,
     #[cfg_attr(not(feature = "pipeline"), allow(dead_code))]
     in_flight_bytes_peak: Arc<AtomicU64>,
+    /// Serializes current-data checkpoint snapshots so protected memory can
+    /// exceed the ring budget by at most one checkpoint segment.
+    #[cfg(feature = "pipeline")]
+    checkpoint_active: AtomicBool,
     writer_done: AtomicBool,
     notify: Notify,
 }
@@ -117,10 +134,14 @@ impl MemFs {
                     segments: VecDeque::with_capacity(slots),
                     bytes: 0,
                     dropped: 0,
+                    #[cfg(feature = "pipeline")]
+                    checkpoint_protected: HashSet::new(),
                 }),
                 in_flight_bytes: Arc::new(AtomicU64::new(0)),
                 in_flight_segments: Arc::new(AtomicU64::new(0)),
                 in_flight_bytes_peak: Arc::new(AtomicU64::new(0)),
+                #[cfg(feature = "pipeline")]
+                checkpoint_active: AtomicBool::new(false),
                 writer_done: AtomicBool::new(false),
                 notify: Notify::new(),
             }),
@@ -150,20 +171,6 @@ impl MemFs {
 
         let (evicted, first_idx, last_idx) = {
             let mut q = ch.queue.lock().unwrap();
-            // Evict-first under the lock: keeps `q.bytes <= max_total_size`
-            // at every observable moment, no transient overshoot.
-            let mut evicted = 0u64;
-            let mut first: Option<u32> = None;
-            let mut last: Option<u32> = None;
-            while q.bytes + size > ch.max_total_size
-                && let Some(old) = q.segments.pop_front()
-            {
-                q.bytes -= old.bytes.len() as u64;
-                evicted += 1;
-                first.get_or_insert(old.index);
-                last = Some(old.index);
-            }
-            q.dropped += evicted;
             q.segments.push_back(MemSealedSegment {
                 index,
                 bytes,
@@ -172,6 +179,36 @@ impl MemFs {
                 seal_secs,
             });
             q.bytes += size;
+
+            // The sole active checkpoint may add its active segment beyond
+            // the ring budget until the worker takes it. Evict only
+            // unprotected entries; later production segments evict themselves
+            // if the retained snapshot alone fills the budget. Without a
+            // checkpoint this is the same oldest-first policy as before.
+            let mut evicted = 0u64;
+            let mut first: Option<u32> = None;
+            let mut last: Option<u32> = None;
+            while q.bytes > ch.max_total_size {
+                #[cfg(feature = "pipeline")]
+                let evict_pos = q
+                    .segments
+                    .iter()
+                    .position(|segment| !q.checkpoint_protected.contains(&segment.index));
+                #[cfg(not(feature = "pipeline"))]
+                let evict_pos = (!q.segments.is_empty()).then_some(0);
+                let Some(evict_pos) = evict_pos else {
+                    break;
+                };
+                let old = q
+                    .segments
+                    .remove(evict_pos)
+                    .expect("eviction position came from the queue");
+                q.bytes -= old.bytes.len() as u64;
+                evicted += 1;
+                first.get_or_insert(old.index);
+                last = Some(old.index);
+            }
+            q.dropped += evicted;
             (evicted, first, last)
         };
 
@@ -189,6 +226,69 @@ impl MemFs {
     }
 
     pub(super) fn remove_sealed(&self, _seg: &SegmentRef, _reason: RemoveReason) {}
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn protect_checkpoint_segments(&self, current_index: Option<u32>) -> Vec<u32> {
+        let mut q = self.channel.queue.lock().unwrap();
+        let mut indices: Vec<u32> = q.segments.iter().map(|segment| segment.index).collect();
+        if let Some(index) = current_index {
+            indices.push(index);
+        }
+        q.checkpoint_protected.extend(indices.iter().copied());
+        indices
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn try_reserve_checkpoint(&self) -> bool {
+        self.channel
+            .checkpoint_active
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn finish_checkpoint(&self) {
+        self.channel
+            .checkpoint_active
+            .store(false, Ordering::Release);
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn checkpoint_segment_is_protected(&self, index: u32) -> bool {
+        self.channel
+            .queue
+            .lock()
+            .unwrap()
+            .checkpoint_protected
+            .contains(&index)
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(super) fn release_checkpoint_segment(&self, index: u32) {
+        let ch = &self.channel;
+        let mut q = ch.queue.lock().unwrap();
+        if !q.checkpoint_protected.remove(&index) {
+            return;
+        }
+
+        // If the worker never took a protected entry (for example it stopped
+        // before registering the request), restore the ring budget now.
+        while q.bytes > ch.max_total_size {
+            let Some(pos) = q
+                .segments
+                .iter()
+                .position(|segment| !q.checkpoint_protected.contains(&segment.index))
+            else {
+                break;
+            };
+            let old = q
+                .segments
+                .remove(pos)
+                .expect("eviction position came from the queue");
+            q.bytes -= old.bytes.len() as u64;
+            q.dropped += 1;
+        }
+    }
 
     /// Re-enqueue `bytes` for re-dispense on the next `take_files` cycle.
     ///
@@ -262,6 +362,7 @@ impl MemFs {
             };
             if let Some(s) = &popped {
                 q.bytes -= s.bytes.len() as u64;
+                q.checkpoint_protected.remove(&s.index);
             }
             let segments_dropped = std::mem::take(&mut q.dropped);
             (popped, q.segments.len() as u64, q.bytes, segments_dropped)
@@ -489,6 +590,85 @@ mod tests {
         }
         let t = mem.take_files();
         check!(t.segments.is_empty());
+    }
+
+    #[test]
+    fn checkpoint_snapshot_uses_in_flight_reserve_instead_of_evicting() {
+        let mem = MemFs::with_capacity(4, 4).unwrap();
+        check!(mem.try_reserve_checkpoint());
+        let first = mem.create_segment(Path::new("first")).unwrap();
+        let ActiveHandle::Mem(mut first) = first else {
+            unreachable!("memory backend yields a memory handle")
+        };
+        first.buf.resize(4, 1);
+        mem.seal(ActiveHandle::Mem(first), Path::new("first"), 0)
+            .unwrap();
+
+        let protected = mem.protect_checkpoint_segments(Some(1));
+        check!(protected == vec![0, 1]);
+
+        let checkpoint = mem.create_segment(Path::new("checkpoint")).unwrap();
+        let ActiveHandle::Mem(mut checkpoint) = checkpoint else {
+            unreachable!("memory backend yields a memory handle")
+        };
+        checkpoint.buf.resize(4, 2);
+        mem.seal(ActiveHandle::Mem(checkpoint), Path::new("checkpoint"), 1)
+            .unwrap();
+
+        let first_taken = mem.take_files();
+        check!(first_taken.segments.len() == 1);
+        check!(first_taken.segments[0].seg_ref.index() == 0);
+        check!(first_taken.segments_dropped == 0);
+
+        let checkpoint_taken = mem.take_files();
+        check!(checkpoint_taken.segments.len() == 1);
+        check!(checkpoint_taken.segments[0].seg_ref.index() == 1);
+        check!(checkpoint_taken.segments_dropped == 0);
+        mem.finish_checkpoint();
+    }
+
+    #[test]
+    fn active_checkpoint_bounds_memory_overshoot_and_rejects_another() {
+        let mem = MemFs::with_capacity(4, 4).unwrap();
+        check!(mem.try_reserve_checkpoint());
+        check!(!mem.try_reserve_checkpoint());
+
+        let first = mem.create_segment(Path::new("first")).unwrap();
+        let ActiveHandle::Mem(mut first) = first else {
+            unreachable!("memory backend yields a memory handle")
+        };
+        first.buf.resize(4, 1);
+        mem.seal(ActiveHandle::Mem(first), Path::new("first"), 0)
+            .unwrap();
+        let protected = mem.protect_checkpoint_segments(Some(1));
+
+        for index in 1..=32 {
+            let segment = mem.create_segment(Path::new("later")).unwrap();
+            let ActiveHandle::Mem(mut segment) = segment else {
+                unreachable!("memory backend yields a memory handle")
+            };
+            segment.buf.resize(4, 2);
+            mem.seal(ActiveHandle::Mem(segment), Path::new("later"), index)
+                .unwrap();
+        }
+
+        {
+            let q = mem.channel.queue.lock().unwrap();
+            check!(q.bytes == 8);
+            check!(q.segments.len() == 2);
+            check!(q.segments[0].index == 0);
+            check!(q.segments[1].index == 1);
+        }
+
+        for index in protected {
+            mem.release_checkpoint_segment(index);
+        }
+        mem.finish_checkpoint();
+        check!(mem.try_reserve_checkpoint());
+        mem.finish_checkpoint();
+
+        let q = mem.channel.queue.lock().unwrap();
+        check!(q.bytes <= mem.channel.max_total_size);
     }
 
     #[test]

--- a/dial9-core/src/fs/mem.rs
+++ b/dial9-core/src/fs/mem.rs
@@ -325,21 +325,29 @@ impl MemFs {
 
     #[cfg(feature = "pipeline")]
     pub(super) fn take_files(&self) -> TakenFiles {
-        self.take_files_inner(None)
+        self.take_files_inner(None, None)
     }
 
-    /// Windowed pop for the triggered worker: the oldest slot whose
-    /// `[creation, seal]` span overlaps one of `windows`. Non-matching
-    /// slots stay in the ring (history is preserved for later dumps); still
-    /// at most one segment per call so the in-flight memory bound is
-    /// unchanged.
+    /// Selective pop for the triggered worker: the oldest exact checkpoint
+    /// member or slot whose `[creation, seal]` span overlaps one of `windows`.
+    /// Non-matching slots stay in the ring (history is preserved for later
+    /// dumps); still at most one segment per call so the in-flight memory bound
+    /// is unchanged.
     #[cfg(feature = "pipeline")]
-    pub(super) fn take_files_matching(&self, windows: &[EpochWindow]) -> TakenFiles {
-        self.take_files_inner(Some(windows))
+    pub(super) fn take_files_matching(
+        &self,
+        windows: &[EpochWindow],
+        checkpoint_segments: &HashSet<u32>,
+    ) -> TakenFiles {
+        self.take_files_inner(Some(windows), Some(checkpoint_segments))
     }
 
     #[cfg(feature = "pipeline")]
-    fn take_files_inner(&self, windows: Option<&[EpochWindow]>) -> TakenFiles {
+    fn take_files_inner(
+        &self,
+        windows: Option<&[EpochWindow]>,
+        checkpoint_segments: Option<&HashSet<u32>>,
+    ) -> TakenFiles {
         let ch = &self.channel;
 
         // Floor peak at current in-flight, this cycle's pop seeds the next.
@@ -357,7 +365,10 @@ impl MemFs {
                 Some(ws) => q
                     .segments
                     .iter()
-                    .position(|s| ws.iter().any(|w| w.overlaps(s.epoch_secs, s.seal_secs)))
+                    .position(|s| {
+                        checkpoint_segments.is_some_and(|indices| indices.contains(&s.index))
+                            || ws.iter().any(|w| w.overlaps(s.epoch_secs, s.seal_secs))
+                    })
                     .and_then(|i| q.segments.remove(i)),
             };
             if let Some(s) = &popped {

--- a/dial9-core/src/fs/mod.rs
+++ b/dial9-core/src/fs/mod.rs
@@ -108,6 +108,11 @@ impl Drop for SegmentAccounting {
 pub(crate) enum ActiveHandle {
     Disk(fs::File),
     Mem(MemActiveWriter),
+    #[cfg(test)]
+    FailAfterFlushes {
+        bytes: Vec<u8>,
+        successful_flushes: usize,
+    },
 }
 
 impl Write for ActiveHandle {
@@ -115,12 +120,28 @@ impl Write for ActiveHandle {
         match self {
             ActiveHandle::Disk(f) => f.write(data),
             ActiveHandle::Mem(m) => m.write(data),
+            #[cfg(test)]
+            ActiveHandle::FailAfterFlushes { bytes, .. } => {
+                bytes.extend_from_slice(data);
+                Ok(data.len())
+            }
         }
     }
     fn flush(&mut self) -> io::Result<()> {
         match self {
             ActiveHandle::Disk(f) => f.flush(),
             ActiveHandle::Mem(m) => m.flush(),
+            #[cfg(test)]
+            ActiveHandle::FailAfterFlushes {
+                successful_flushes, ..
+            } => {
+                if *successful_flushes == 0 {
+                    Err(io::Error::other("injected flush failure"))
+                } else {
+                    *successful_flushes -= 1;
+                    Ok(())
+                }
+            }
         }
     }
 }

--- a/dial9-core/src/fs/mod.rs
+++ b/dial9-core/src/fs/mod.rs
@@ -345,6 +345,15 @@ impl Fs {
         Arc::new(Fs::Disk(DiskFs::new(dir, stem)))
     }
 
+    /// Record the writer's disk budget so checkpoint leases released after
+    /// shutdown can reconcile retention without access to `SegmentWriter`.
+    pub(crate) fn set_disk_max_total_size(&self, max_total_size: u64) {
+        match self {
+            Fs::Disk(d) => d.set_max_total_size(max_total_size),
+            Fs::Mem(_) => unreachable!("disk budget configured for memory backend"),
+        }
+    }
+
     /// Ring budget = `max_total_size - PIPELINE_RESERVE_SEGMENTS * max_segment_size`.
     pub(crate) fn new_in_memory(
         max_total_size: u64,

--- a/dial9-core/src/fs/mod.rs
+++ b/dial9-core/src/fs/mod.rs
@@ -6,6 +6,8 @@
 //! - `Fs::Disk(DiskFs)`: real filesystem. See [`disk`].
 //! - `Fs::Mem(MemFs)`: in-process ring channel. See [`mem`].
 
+#[cfg(feature = "pipeline")]
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
@@ -375,20 +377,24 @@ impl Fs {
         matches!(self, Fs::Disk(_))
     }
 
-    /// Like [`Self::take_files`], but only dispense segments whose
-    /// `[creation, seal]` span overlaps one of `windows`. Used by the
-    /// triggered worker so out-of-window history stays in the ring for
-    /// later dumps.
+    /// Like [`Self::take_files`], but only dispense exact checkpoint members
+    /// or segments whose `[creation, seal]` span overlaps one of `windows`.
+    /// Used by the triggered worker so out-of-window history stays in the ring
+    /// for later dumps without losing a checkpoint to clock-boundary races.
     ///
     /// Memory: pops the oldest matching slot, leaving non-matching slots in
     /// place (still at most one segment per call). Disk: returns all new
     /// claims; the worker filters after reading the header and releases
     /// unmatched claims.
     #[cfg(feature = "pipeline")]
-    pub(crate) fn take_files_matching(&self, windows: &[EpochWindow]) -> TakenFiles {
+    pub(crate) fn take_files_matching(
+        &self,
+        windows: &[EpochWindow],
+        checkpoint_segments: &HashSet<u32>,
+    ) -> TakenFiles {
         match self {
             Fs::Disk(d) => d.take_files(),
-            Fs::Mem(m) => m.take_files_matching(windows),
+            Fs::Mem(m) => m.take_files_matching(windows, checkpoint_segments),
         }
     }
 

--- a/dial9-core/src/fs/mod.rs
+++ b/dial9-core/src/fs/mod.rs
@@ -277,6 +277,61 @@ pub(crate) enum Fs {
     Mem(MemFs),
 }
 
+/// Owns the sole active checkpoint reservation and its protected snapshot.
+///
+/// Cleanup is deliberately drop-based: construction failures, a closed worker
+/// channel, shutdown before registration, and normal dump resolution all
+/// release protection and reopen the checkpoint gate through the same path.
+#[cfg(feature = "pipeline")]
+pub(crate) struct CheckpointGuard {
+    fs: Arc<Fs>,
+    segments: HashSet<u32>,
+}
+
+#[cfg(feature = "pipeline")]
+impl CheckpointGuard {
+    pub(crate) fn reserve(fs: &Arc<Fs>) -> io::Result<Self> {
+        if !fs.try_reserve_checkpoint() {
+            return Err(io::Error::new(
+                io::ErrorKind::WouldBlock,
+                "another current-data checkpoint is still active",
+            ));
+        }
+        Ok(Self {
+            fs: Arc::clone(fs),
+            segments: HashSet::new(),
+        })
+    }
+
+    pub(crate) fn track(&mut self, segments: Vec<u32>) {
+        debug_assert!(self.segments.is_empty());
+        self.segments.extend(segments);
+    }
+
+    pub(crate) fn segments(&self) -> &HashSet<u32> {
+        &self.segments
+    }
+}
+
+#[cfg(feature = "pipeline")]
+impl std::fmt::Debug for CheckpointGuard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CheckpointGuard")
+            .field("segments", &self.segments)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(feature = "pipeline")]
+impl Drop for CheckpointGuard {
+    fn drop(&mut self) {
+        for &index in &self.segments {
+            self.fs.release_checkpoint_segment(index);
+        }
+        self.fs.finish_checkpoint();
+    }
+}
+
 impl Fs {
     /// Create a new active-segment write handle.
     pub(crate) fn create_segment(&self, path: &Path) -> io::Result<ActiveHandle> {
@@ -497,13 +552,6 @@ impl Fs {
         match self {
             Fs::Disk(d) => d.release_checkpoint_segment(index),
             Fs::Mem(m) => m.release_checkpoint_segment(index),
-        }
-    }
-
-    #[cfg(feature = "pipeline")]
-    pub(crate) fn release_checkpoint_segments(&self, indices: &[u32]) {
-        for &index in indices {
-            self.release_checkpoint_segment(index);
         }
     }
 

--- a/dial9-core/src/fs/mod.rs
+++ b/dial9-core/src/fs/mod.rs
@@ -438,6 +438,77 @@ impl Fs {
         }
     }
 
+    /// Reserve the sole current-data checkpoint snapshot.
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn try_reserve_checkpoint(&self) -> bool {
+        match self {
+            Fs::Disk(d) => d.try_reserve_checkpoint(),
+            Fs::Mem(m) => m.try_reserve_checkpoint(),
+        }
+    }
+
+    /// Release the current-data checkpoint reservation after its worker pass
+    /// resolves or checkpoint construction fails.
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn finish_checkpoint(&self) {
+        match self {
+            Fs::Disk(d) => d.finish_checkpoint(),
+            Fs::Mem(m) => m.finish_checkpoint(),
+        }
+    }
+
+    /// Protect disk indices from the writer's ordered retention queue.
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn protect_disk_checkpoint_segments(&self, indices: &[u32]) {
+        match self {
+            Fs::Disk(d) => d.protect_checkpoint_segments(indices),
+            Fs::Mem(_) => unreachable!("disk checkpoint protection used with memory backend"),
+        }
+    }
+
+    /// Snapshot and protect the memory queue under its seal/eviction lock.
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn protect_memory_checkpoint_segments(
+        &self,
+        current_index: Option<u32>,
+    ) -> Vec<u32> {
+        match self {
+            Fs::Disk(_) => unreachable!("memory checkpoint protection used with disk backend"),
+            Fs::Mem(m) => m.protect_checkpoint_segments(current_index),
+        }
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn checkpoint_segment_is_protected(&self, index: u32) -> bool {
+        match self {
+            Fs::Disk(d) => d.checkpoint_segment_is_protected(index),
+            Fs::Mem(m) => m.checkpoint_segment_is_protected(index),
+        }
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn release_checkpoint_segment(&self, index: u32) {
+        match self {
+            Fs::Disk(d) => d.release_checkpoint_segment(index),
+            Fs::Mem(m) => m.release_checkpoint_segment(index),
+        }
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn release_checkpoint_segments(&self, indices: &[u32]) {
+        for &index in indices {
+            self.release_checkpoint_segment(index);
+        }
+    }
+
+    #[cfg(feature = "pipeline")]
+    pub(crate) fn checkpoint_budget_dirty(&self) -> bool {
+        match self {
+            Fs::Disk(d) => d.checkpoint_budget_dirty(),
+            Fs::Mem(_) => false,
+        }
+    }
+
     /// Re-enqueue a memory segment after a retryable failure.
     ///
     /// Caller owns the [`MEMORY_RETRY_BUDGET`] check, this method always

--- a/dial9-core/src/handle.rs
+++ b/dial9-core/src/handle.rs
@@ -6,7 +6,6 @@ use crate::thread::ThreadTrackingGuard;
 use arc_swap::ArcSwapOption;
 use std::any::Any;
 use std::cell::RefCell;
-use std::time::Duration;
 
 /// First registered source of type `T`, if any.
 fn find_source<T: Source>(sources: &mut [Box<dyn Source>]) -> Option<&mut T> {
@@ -35,30 +34,14 @@ fn global_handle() -> Option<Dial9Handle> {
 }
 
 /// Commands sent to the flush thread by [`Recorder`](crate::recording::Recorder).
+#[derive(Debug)]
 pub(crate) enum ControlCommand {
-    /// Drain all thread-local buffers, flush, and seal the current segment,
-    /// then continue recording into a fresh segment.
-    RotateSegment(crate::primitives::sync::mpsc::SyncSender<std::io::Result<SegmentRotation>>),
+    /// Establish a dump boundary on the flush thread, then dispatch the dump
+    /// request to the pipeline worker.
+    #[cfg(feature = "pipeline")]
+    CheckpointDump(crate::dump::CheckpointDump),
     /// Flush, finalize (seal segment), then exit the thread.
     FinalizeAndStop(crate::primitives::sync::mpsc::SyncSender<()>),
-}
-
-/// Result of an on-demand trace-segment rotation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum SegmentRotation {
-    /// The current segment contained events and was sealed. A fresh active
-    /// segment is ready for subsequent events.
-    Sealed,
-    /// No events had reached the current segment, so there was nothing to
-    /// seal. The existing empty active segment remains open.
-    Empty,
-    /// This handle is not connected to a recorder.
-    ///
-    /// Returned by an inert [`Dial9Handle::disabled`] handle. This does not
-    /// describe a live recorder whose event-recording gate was closed with
-    /// [`Dial9Handle::disable`].
-    NoRecorder,
 }
 
 /// Cheap, cloneable handle for recording events and controlling telemetry.
@@ -92,7 +75,6 @@ impl std::fmt::Debug for Dial9Handle {
     }
 }
 
-#[bon::bon]
 impl Dial9Handle {
     /// Build an enabled handle wired to a flush thread's control sender.
     /// [`Recorder::start`](crate::recording::Recorder::start) mints the channel
@@ -196,93 +178,6 @@ impl Dial9Handle {
     pub fn disable(&self) {
         if let Some(inner) = &self.inner {
             inner.shared.disable();
-        }
-    }
-
-    /// Seal the current trace segment and continue with a fresh one.
-    ///
-    /// The flush thread first drains all registered thread-local buffers, then
-    /// flushes and atomically seals the current segment. This is a checkpoint,
-    /// not a lifecycle operation: it does not change whether recording is
-    /// enabled, and it does not stop the recorder or its processing pipeline.
-    /// Call [`disable`](Self::disable) first when the sealed segment must
-    /// contain everything recorded before a capture gate was closed.
-    ///
-    /// `timeout` bounds waiting for an accepted filesystem operation. If it
-    /// expires, this returns
-    /// [`std::io::ErrorKind::TimedOut`], but a command already accepted by the
-    /// flush thread is not cancellable and may finish sealing in the
-    /// background. Calling this method from an async task blocks that task's
-    /// worker thread; use the runtime's blocking-task facility when necessary.
-    ///
-    /// A busy control queue returns [`std::io::ErrorKind::WouldBlock`] instead
-    /// of waiting without a bound. A stopped recorder returns
-    /// [`std::io::ErrorKind::BrokenPipe`].
-    ///
-    /// A write failure is returned to the caller. If that failure leaves the
-    /// writer permanently closed, recording is also disabled so producers do
-    /// not continue submitting events that cannot be persisted. Calling
-    /// [`enable`](Self::enable) cannot repair a closed writer.
-    ///
-    /// # Example
-    ///
-    /// ```no_run
-    /// use dial9_core::buffer::MemoryBuffer;
-    /// use dial9_core::recorder::recorder;
-    /// use std::time::Duration;
-    ///
-    /// # fn main() -> std::io::Result<()> {
-    /// let recorder = recorder(MemoryBuffer::new(1 << 20)?).build();
-    /// let handle = recorder.handle().clone();
-    ///
-    /// handle.disable();
-    /// let _outcome = handle
-    ///     .rotate_segment()
-    ///     .timeout(Duration::from_secs(5))
-    ///     .call()?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[builder]
-    pub fn rotate_segment(&self, timeout: Duration) -> std::io::Result<SegmentRotation> {
-        let Some(inner) = &self.inner else {
-            return Ok(SegmentRotation::NoRecorder);
-        };
-
-        let (ack_tx, ack_rx) = crate::primitives::sync::mpsc::sync_channel(1);
-        match inner
-            .control_tx
-            .try_send(ControlCommand::RotateSegment(ack_tx))
-        {
-            Ok(()) => {}
-            Err(crate::primitives::sync::mpsc::TrySendError::Full(_)) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::WouldBlock,
-                    "dial9 flush thread is handling another control operation",
-                ));
-            }
-            Err(crate::primitives::sync::mpsc::TrySendError::Disconnected(_)) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "dial9 flush thread has stopped",
-                ));
-            }
-        }
-
-        match ack_rx.recv_timeout(timeout) {
-            Ok(result) => result,
-            Err(crate::primitives::sync::mpsc::RecvTimeoutError::Timeout) => {
-                Err(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "timed out waiting for dial9 trace segment rotation; the accepted rotation may still finish",
-                ))
-            }
-            Err(crate::primitives::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                Err(std::io::Error::new(
-                    std::io::ErrorKind::BrokenPipe,
-                    "dial9 flush thread stopped before acknowledging trace segment rotation",
-                ))
-            }
         }
     }
 
@@ -499,59 +394,4 @@ pub(crate) fn clear_global_handle_for(shared: &Arc<SharedState>) {
 /// process-global one. Equivalent to [`Dial9Handle::current`].
 pub fn current_handle() -> Dial9Handle {
     Dial9Handle::current()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::primitives::sync::{Arc, mpsc};
-
-    fn handle_with_idle_control(capacity: usize) -> (Dial9Handle, mpsc::Receiver<ControlCommand>) {
-        let (control_tx, control_rx) = mpsc::sync_channel(capacity);
-        let shared = Arc::new(SharedState::new(0));
-        (Dial9Handle::enabled(shared, control_tx), control_rx)
-    }
-
-    #[test]
-    fn rotate_segment_times_out_when_an_accepted_command_is_not_processed() {
-        let (handle, _control_rx) = handle_with_idle_control(1);
-
-        let error = handle
-            .rotate_segment()
-            .timeout(Duration::ZERO)
-            .call()
-            .expect_err("an unprocessed command must time out");
-        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
-    }
-
-    #[test]
-    fn rotate_segment_returns_would_block_when_control_queue_is_full() {
-        let (handle, _control_rx) = handle_with_idle_control(1);
-        let first = handle
-            .rotate_segment()
-            .timeout(Duration::ZERO)
-            .call()
-            .expect_err("the queued command is not processed");
-        assert_eq!(first.kind(), std::io::ErrorKind::TimedOut);
-
-        let error = handle
-            .rotate_segment()
-            .timeout(Duration::ZERO)
-            .call()
-            .expect_err("the second command must see the full queue");
-        assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
-    }
-
-    #[test]
-    fn rotate_segment_returns_broken_pipe_when_control_thread_is_gone() {
-        let (handle, control_rx) = handle_with_idle_control(1);
-        drop(control_rx);
-
-        let error = handle
-            .rotate_segment()
-            .timeout(Duration::ZERO)
-            .call()
-            .expect_err("a disconnected control queue must fail");
-        assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
-    }
 }

--- a/dial9-core/src/handle.rs
+++ b/dial9-core/src/handle.rs
@@ -6,6 +6,7 @@ use crate::thread::ThreadTrackingGuard;
 use arc_swap::ArcSwapOption;
 use std::any::Any;
 use std::cell::RefCell;
+use std::time::Duration;
 
 /// First registered source of type `T`, if any.
 fn find_source<T: Source>(sources: &mut [Box<dyn Source>]) -> Option<&mut T> {
@@ -35,8 +36,29 @@ fn global_handle() -> Option<Dial9Handle> {
 
 /// Commands sent to the flush thread by [`Recorder`](crate::recording::Recorder).
 pub(crate) enum ControlCommand {
+    /// Drain all thread-local buffers, flush, and seal the current segment,
+    /// then continue recording into a fresh segment.
+    RotateSegment(crate::primitives::sync::mpsc::SyncSender<std::io::Result<SegmentRotation>>),
     /// Flush, finalize (seal segment), then exit the thread.
     FinalizeAndStop(crate::primitives::sync::mpsc::SyncSender<()>),
+}
+
+/// Result of an on-demand trace-segment rotation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SegmentRotation {
+    /// The current segment contained events and was sealed. A fresh active
+    /// segment is ready for subsequent events.
+    Sealed,
+    /// No events had reached the current segment, so there was nothing to
+    /// seal. The existing empty active segment remains open.
+    Empty,
+    /// This handle is not connected to a recorder.
+    ///
+    /// Returned by an inert [`Dial9Handle::disabled`] handle. This does not
+    /// describe a live recorder whose event-recording gate was closed with
+    /// [`Dial9Handle::disable`].
+    NoRecorder,
 }
 
 /// Cheap, cloneable handle for recording events and controlling telemetry.
@@ -70,6 +92,7 @@ impl std::fmt::Debug for Dial9Handle {
     }
 }
 
+#[bon::bon]
 impl Dial9Handle {
     /// Build an enabled handle wired to a flush thread's control sender.
     /// [`Recorder::start`](crate::recording::Recorder::start) mints the channel
@@ -173,6 +196,93 @@ impl Dial9Handle {
     pub fn disable(&self) {
         if let Some(inner) = &self.inner {
             inner.shared.disable();
+        }
+    }
+
+    /// Seal the current trace segment and continue with a fresh one.
+    ///
+    /// The flush thread first drains all registered thread-local buffers, then
+    /// flushes and atomically seals the current segment. This is a checkpoint,
+    /// not a lifecycle operation: it does not change whether recording is
+    /// enabled, and it does not stop the recorder or its processing pipeline.
+    /// Call [`disable`](Self::disable) first when the sealed segment must
+    /// contain everything recorded before a capture gate was closed.
+    ///
+    /// `timeout` bounds waiting for an accepted filesystem operation. If it
+    /// expires, this returns
+    /// [`std::io::ErrorKind::TimedOut`], but a command already accepted by the
+    /// flush thread is not cancellable and may finish sealing in the
+    /// background. Calling this method from an async task blocks that task's
+    /// worker thread; use the runtime's blocking-task facility when necessary.
+    ///
+    /// A busy control queue returns [`std::io::ErrorKind::WouldBlock`] instead
+    /// of waiting without a bound. A stopped recorder returns
+    /// [`std::io::ErrorKind::BrokenPipe`].
+    ///
+    /// A write failure is returned to the caller. If that failure leaves the
+    /// writer permanently closed, recording is also disabled so producers do
+    /// not continue submitting events that cannot be persisted. Calling
+    /// [`enable`](Self::enable) cannot repair a closed writer.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use dial9_core::buffer::MemoryBuffer;
+    /// use dial9_core::recorder::recorder;
+    /// use std::time::Duration;
+    ///
+    /// # fn main() -> std::io::Result<()> {
+    /// let recorder = recorder(MemoryBuffer::new(1 << 20)?).build();
+    /// let handle = recorder.handle().clone();
+    ///
+    /// handle.disable();
+    /// let _outcome = handle
+    ///     .rotate_segment()
+    ///     .timeout(Duration::from_secs(5))
+    ///     .call()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[builder]
+    pub fn rotate_segment(&self, timeout: Duration) -> std::io::Result<SegmentRotation> {
+        let Some(inner) = &self.inner else {
+            return Ok(SegmentRotation::NoRecorder);
+        };
+
+        let (ack_tx, ack_rx) = crate::primitives::sync::mpsc::sync_channel(1);
+        match inner
+            .control_tx
+            .try_send(ControlCommand::RotateSegment(ack_tx))
+        {
+            Ok(()) => {}
+            Err(crate::primitives::sync::mpsc::TrySendError::Full(_)) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::WouldBlock,
+                    "dial9 flush thread is handling another control operation",
+                ));
+            }
+            Err(crate::primitives::sync::mpsc::TrySendError::Disconnected(_)) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "dial9 flush thread has stopped",
+                ));
+            }
+        }
+
+        match ack_rx.recv_timeout(timeout) {
+            Ok(result) => result,
+            Err(crate::primitives::sync::mpsc::RecvTimeoutError::Timeout) => {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    "timed out waiting for dial9 trace segment rotation; the accepted rotation may still finish",
+                ))
+            }
+            Err(crate::primitives::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::BrokenPipe,
+                    "dial9 flush thread stopped before acknowledging trace segment rotation",
+                ))
+            }
         }
     }
 
@@ -389,4 +499,59 @@ pub(crate) fn clear_global_handle_for(shared: &Arc<SharedState>) {
 /// process-global one. Equivalent to [`Dial9Handle::current`].
 pub fn current_handle() -> Dial9Handle {
     Dial9Handle::current()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::primitives::sync::{Arc, mpsc};
+
+    fn handle_with_idle_control(capacity: usize) -> (Dial9Handle, mpsc::Receiver<ControlCommand>) {
+        let (control_tx, control_rx) = mpsc::sync_channel(capacity);
+        let shared = Arc::new(SharedState::new(0));
+        (Dial9Handle::enabled(shared, control_tx), control_rx)
+    }
+
+    #[test]
+    fn rotate_segment_times_out_when_an_accepted_command_is_not_processed() {
+        let (handle, _control_rx) = handle_with_idle_control(1);
+
+        let error = handle
+            .rotate_segment()
+            .timeout(Duration::ZERO)
+            .call()
+            .expect_err("an unprocessed command must time out");
+        assert_eq!(error.kind(), std::io::ErrorKind::TimedOut);
+    }
+
+    #[test]
+    fn rotate_segment_returns_would_block_when_control_queue_is_full() {
+        let (handle, _control_rx) = handle_with_idle_control(1);
+        let first = handle
+            .rotate_segment()
+            .timeout(Duration::ZERO)
+            .call()
+            .expect_err("the queued command is not processed");
+        assert_eq!(first.kind(), std::io::ErrorKind::TimedOut);
+
+        let error = handle
+            .rotate_segment()
+            .timeout(Duration::ZERO)
+            .call()
+            .expect_err("the second command must see the full queue");
+        assert_eq!(error.kind(), std::io::ErrorKind::WouldBlock);
+    }
+
+    #[test]
+    fn rotate_segment_returns_broken_pipe_when_control_thread_is_gone() {
+        let (handle, control_rx) = handle_with_idle_control(1);
+        drop(control_rx);
+
+        let error = handle
+            .rotate_segment()
+            .timeout(Duration::ZERO)
+            .call()
+            .expect_err("a disconnected control queue must fail");
+        assert_eq!(error.kind(), std::io::ErrorKind::BrokenPipe);
+    }
 }

--- a/dial9-core/src/pipeline_shuttle_tests.rs
+++ b/dial9-core/src/pipeline_shuttle_tests.rs
@@ -359,9 +359,15 @@ crate::shuttle_test! {
 /// under-lock gate check wins, the checkpoint drain must include its event; if
 /// the stop wins, encoding must not begin. An event attempted after the
 /// completed stop must always be rejected.
-fn checkpoint_stop_boundary() {
+fn run_checkpoint_stop_boundary() {
     let dir = tempfile::tempdir().unwrap();
-    let writer = DiskBuffer::single_file(dir.path().join("trace.bin")).unwrap();
+    let writer = DiskBuffer::builder()
+        .base_path(dir.path())
+        .max_file_size(1024 * 1024)
+        .max_total_size(8 * 1024 * 1024)
+        .rotation_period(std::time::Duration::MAX)
+        .build()
+        .unwrap();
     let shared = Arc::new(SharedState::new(clock_monotonic_ns()));
     let recorder = Recorder::start(shared.clone(), writer, None, || || {});
     recorder.enable();
@@ -440,9 +446,11 @@ fn checkpoint_stop_boundary() {
     recorder.graceful_shutdown(std::time::Duration::ZERO);
 }
 
-#[test]
-fn shuttle_checkpoint_stop_boundary() {
-    shuttle::check_pct(checkpoint_stop_boundary, 1_000, 2);
+crate::shuttle_test! {
+    num_iters = 1_000, depth = 2;
+    fn checkpoint_stop_boundary() {
+        run_checkpoint_stop_boundary();
+    }
 }
 
 // ── Error injection ─────────────────────────────────────────────────

--- a/dial9-core/src/pipeline_shuttle_tests.rs
+++ b/dial9-core/src/pipeline_shuttle_tests.rs
@@ -4,9 +4,10 @@
 
 use crate::buffer::{DiskBuffer, MemoryBuffer};
 use crate::clock::clock_monotonic_ns;
+use crate::encoder::{Encodable, ThreadLocalEncoder};
 use crate::primitives::fs;
-use crate::primitives::sync::atomic::{AtomicU64, Ordering};
-use crate::primitives::sync::{Arc, Mutex};
+use crate::primitives::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use crate::primitives::sync::{Arc, Mutex, mpsc};
 use crate::recording::Recorder;
 use crate::shared_state::SharedState;
 use crate::source::{FlushContext, Source};
@@ -87,6 +88,22 @@ fn check_timestamps_roundtrip(expected: &[ValidationEvent], decoded: &[Validatio
             "timestamp mismatch for event id {}: expected {exp_ts}, got {}",
             ev.id, ev.timestamp_ns
         );
+    }
+}
+
+struct BoundaryEvent {
+    encoded: Arc<AtomicBool>,
+}
+
+impl Encodable for BoundaryEvent {
+    fn encode(&self, encoder: &mut ThreadLocalEncoder<'_>) {
+        self.encoded.store(true, Ordering::Relaxed);
+        encoder.encode(&ValidationEvent {
+            timestamp_ns: clock_monotonic_ns(),
+            thread_id: 0,
+            seq: 0,
+            id: 1,
+        });
     }
 }
 
@@ -336,6 +353,96 @@ crate::shuttle_test! {
             "TL-buffer event must survive a sibling source's panic"
         );
     }
+}
+
+/// Race a producer against the exact capture-stop boundary. If the producer's
+/// under-lock gate check wins, the checkpoint drain must include its event; if
+/// the stop wins, encoding must not begin. An event attempted after the
+/// completed stop must always be rejected.
+fn checkpoint_stop_boundary() {
+    let dir = tempfile::tempdir().unwrap();
+    let writer = DiskBuffer::single_file(dir.path().join("trace.bin")).unwrap();
+    let shared = Arc::new(SharedState::new(clock_monotonic_ns()));
+    let recorder = Recorder::start(shared.clone(), writer, None, || || {});
+    recorder.enable();
+    let (mut trigger, mut dump_rx) = crate::dump::channel();
+    trigger.bind_checkpoint(
+        recorder
+            .handle()
+            .control_tx()
+            .expect("live recorder has a control channel")
+            .clone(),
+    );
+    let handle = recorder.handle().clone();
+    let encoded = Arc::new(AtomicBool::new(false));
+    let producer_encoded = encoded.clone();
+    let (release_tx, release_rx) = mpsc::sync_channel(1);
+
+    let producer = crate::primitives::thread::spawn(move || {
+        handle.record_event(BoundaryEvent {
+            encoded: producer_encoded,
+        });
+        // Keep this thread's TLS buffer alive until the checkpoint has drained
+        // it or rejected the event.
+        release_rx.recv().expect("release producer");
+    });
+
+    drop(trigger.stop_recording_and_dump_current_data());
+    let request = loop {
+        match dump_rx.rx.try_recv() {
+            Ok(request) => break request,
+            Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
+                shuttle::thread::yield_now();
+            }
+            Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                panic!("checkpoint did not dispatch to the dump worker")
+            }
+        }
+    };
+    assert!(
+        !shared.is_enabled(),
+        "checkpoint dispatch happens only after the recording gate closes"
+    );
+    release_tx.send(()).expect("producer remains live");
+    producer.join().expect("producer exits");
+
+    let post_boundary_encoded = Arc::new(AtomicBool::new(false));
+    recorder.handle().record_event(BoundaryEvent {
+        encoded: post_boundary_encoded.clone(),
+    });
+    assert!(
+        !post_boundary_encoded.load(Ordering::Relaxed),
+        "events after the completed stop boundary are rejected"
+    );
+
+    let mut decoded = Vec::new();
+    for entry in std::fs::read_dir(dir.path()).unwrap() {
+        let path = entry.unwrap().path();
+        if path.to_string_lossy().ends_with(".bin") {
+            decoded.extend(decode_validation_events(&std::fs::read(path).unwrap()));
+        }
+    }
+    let ids: Vec<_> = decoded.iter().map(|event| event.id).collect();
+    if encoded.load(Ordering::Relaxed) {
+        assert_eq!(
+            ids,
+            vec![1],
+            "an event that crossed the under-lock gate is drained exactly once"
+        );
+    } else {
+        assert!(
+            ids.is_empty(),
+            "an event rejected at the stop boundary is absent"
+        );
+    }
+
+    drop(request);
+    recorder.graceful_shutdown(std::time::Duration::ZERO);
+}
+
+#[test]
+fn shuttle_checkpoint_stop_boundary() {
+    shuttle::check_pct(checkpoint_stop_boundary, 1_000, 2);
 }
 
 // ── Error injection ─────────────────────────────────────────────────

--- a/dial9-core/src/primitives.rs
+++ b/dial9-core/src/primitives.rs
@@ -55,7 +55,7 @@ pub mod sync {
     /// randomly return `Timeout` instead, so shuttle can explore multiple
     /// flush-loop cycles.
     pub mod mpsc {
-        pub use shuttle::sync::mpsc::{RecvTimeoutError, SyncSender};
+        pub use shuttle::sync::mpsc::{RecvTimeoutError, SyncSender, TrySendError};
 
         pub struct Receiver<T> {
             inner: shuttle::sync::mpsc::Receiver<T>,

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -277,13 +277,6 @@ impl<M: BufferMode> RecorderBuilder<M> {
 
         let shared = Arc::new(SharedState::new(clock::clock_monotonic_ns()));
 
-        // Install the on-demand dump trigger so `Dial9Handle::dump_trigger` can
-        // reach it (paired with the `trigger` receiver handed to the worker).
-        #[cfg(feature = "pipeline")]
-        if let Some(trigger) = self.pending_dump_trigger {
-            shared.set_dump_trigger(trigger);
-        }
-
         // Sync any `boot_id` metadata to the writer's per-process namespace, so a
         // trace's identity matches its on-disk `{boot_id}/` directory (and its
         // S3 keys).
@@ -305,7 +298,7 @@ impl<M: BufferMode> RecorderBuilder<M> {
         // Collect the stages the sources ask for before they move into the
         // shared state; only the default pipeline uses them.
         #[cfg(feature = "pipeline")]
-        let processors = match self.pipeline {
+        let mut processors = match self.pipeline {
             Some(processors) => processors,
             None => {
                 let source_stages = sources
@@ -315,6 +308,14 @@ impl<M: BufferMode> RecorderBuilder<M> {
                 default_pipeline(source_stages, self.terminal_processor, M::IS_DISK)
             }
         };
+        // A current-data dump is also useful without processing stages: the
+        // flush-thread checkpoint makes the active fragment stable and the
+        // retain stage lets the worker acknowledge it without rewriting or
+        // removing it.
+        #[cfg(feature = "pipeline")]
+        if self.trigger.is_some() && processors.is_empty() {
+            processors.push(Box::new(crate::worker::processors::RetainProcessor));
+        }
 
         for source in sources {
             shared.push_source(source);
@@ -351,6 +352,19 @@ impl<M: BufferMode> RecorderBuilder<M> {
         #[allow(unused_mut)]
         let mut recorder = Recorder::start(shared, writer, self.metrics_sink, move || hook());
         recorder.hold_process(sole_recorder);
+
+        // Bind builder-created dump triggers to the recorder's flush-thread
+        // control channel. Manually paired trigger receivers continue to
+        // dispatch directly to the worker for backwards compatibility.
+        #[cfg(feature = "pipeline")]
+        if let Some(mut trigger) = self.pending_dump_trigger
+            && let Some(control_tx) = recorder.handle().control_tx().cloned()
+        {
+            trigger.bind_checkpoint(control_tx);
+            if let Some(shared) = recorder.shared() {
+                shared.set_dump_trigger(trigger);
+            }
+        }
 
         #[cfg(feature = "pipeline")]
         if let Some(worker) = worker {
@@ -493,7 +507,9 @@ impl<M: BufferMode> RecorderBuilder<M> {
     /// [`DumpTrigger`](crate::dump::DumpTrigger), reachable from any recording
     /// thread via [`Dial9Handle::dump_trigger`](crate::handle::Dial9Handle::dump_trigger).
     /// Pass `|_| {}` for the default, or `|t| { t.debounce(window); }` to
-    /// coalesce bursts.
+    /// coalesce bursts. [`DumpTrigger::dump_current_data`](crate::dump::DumpTrigger::dump_current_data)
+    /// drains and seals the active fragment before the worker runs; when no
+    /// processing stages are configured, the raw sealed segment is retained.
     pub fn with_dump_trigger<F>(mut self, configure: F) -> Self
     where
         F: FnOnce(&mut crate::dump::DumpTriggerConfig),
@@ -570,6 +586,14 @@ mod tests {
             .collect();
         paths.sort();
         paths
+    }
+
+    fn active_segment(dir: &Path) -> PathBuf {
+        std::fs::read_dir(dir)
+            .expect("trace dir readable")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .find(|p| p.to_string_lossy().ends_with(".bin.active"))
+            .expect("an active .bin segment")
     }
 
     fn decoded_test_values(bytes: &[u8]) -> Vec<u64> {
@@ -649,10 +673,10 @@ mod tests {
         );
     }
 
-    /// An on-demand rotation seals everything recorded before a disabled
-    /// capture gate, then leaves the recorder ready for a later capture.
-    #[test]
-    fn rotate_segment_seals_and_continues_after_reenable() {
+    /// A current-data dump seals the pending fragment before dispatching it,
+    /// without closing the recording gate.
+    #[tokio::test]
+    async fn dump_current_data_seals_and_continues_recording() {
         let dir = tempfile::tempdir().expect("tempdir");
         let writer = DiskBuffer::builder()
             .base_path(dir.path())
@@ -661,25 +685,26 @@ mod tests {
             .rotation_period(Duration::MAX)
             .build()
             .expect("writer");
-        let recorder = recorder(writer).build();
+        let recorder = recorder(writer).with_dump_trigger(|_| {}).build();
         let handle = recorder.handle().clone();
+        let trigger = handle.dump_trigger().expect("configured dump trigger");
 
         handle.record_event(TestEvent {
             timestamp_ns: clock::clock_monotonic_ns(),
             value: 41,
         });
-        handle.disable();
-        assert_eq!(
-            handle
-                .rotate_segment()
-                .timeout(Duration::from_secs(2))
-                .call()
-                .expect("first rotation"),
-            crate::handle::SegmentRotation::Sealed
+        let receipt = tokio::time::timeout(Duration::from_secs(2), trigger.dump_current_data())
+            .await
+            .expect("dump should complete")
+            .expect("checkpoint and pipeline should succeed");
+        assert_eq!(receipt.segments_processed, 1);
+        assert!(
+            handle.shared().is_some_and(|shared| shared.is_enabled()),
+            "an ordinary current-data dump must leave recording enabled"
         );
 
         let first = sealed_segments(dir.path());
-        assert_eq!(first.len(), 1, "rotation should seal one segment");
+        assert_eq!(first.len(), 1, "checkpoint should seal one segment");
         assert_eq!(
             decoded_test_values(&std::fs::read(&first[0]).expect("read first segment")),
             vec![41]
@@ -689,10 +714,9 @@ mod tests {
                 .expect("trace dir readable")
                 .filter_map(Result::ok)
                 .any(|e| e.path().to_string_lossy().ends_with(".bin.active")),
-            "rotation should leave a fresh active segment"
+            "checkpoint should leave a fresh active segment"
         );
 
-        handle.enable();
         handle.record_event(TestEvent {
             timestamp_ns: clock::clock_monotonic_ns(),
             value: 42,
@@ -707,20 +731,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn rotate_segment_on_handle_without_recorder_is_a_noop() {
-        assert_eq!(
-            Dial9Handle::disabled()
-                .rotate_segment()
-                .timeout(Duration::ZERO)
-                .call()
-                .expect("disabled handle"),
-            crate::handle::SegmentRotation::NoRecorder
-        );
-    }
-
-    #[test]
-    fn rotate_segment_flushes_pending_source_after_disable() {
+    #[tokio::test]
+    async fn stop_recording_takes_final_source_sample_before_checkpoint() {
         let dir = tempfile::tempdir().expect("tempdir");
         let writer = DiskBuffer::builder()
             .base_path(dir.path())
@@ -729,60 +741,54 @@ mod tests {
             .rotation_period(Duration::MAX)
             .build()
             .expect("writer");
-        // A paused recorder makes the boundary deterministic: the source owns
-        // data captured before the gate closed, but no ordinary enabled flush
-        // can consume it before the explicit checkpoint.
         let recorder = recorder(writer)
             .source(OnceSource {
                 emitted: false,
                 value: 72,
             })
             .paused()
+            .with_dump_trigger(|_| {})
             .build();
         let handle = recorder.handle().clone();
+        let trigger = handle.dump_trigger().expect("configured dump trigger");
 
-        handle.disable();
-        assert_eq!(
-            handle
-                .rotate_segment()
-                .timeout(Duration::from_secs(2))
-                .call()
-                .expect("rotation"),
-            crate::handle::SegmentRotation::Sealed
+        handle.enable();
+        let receipt = tokio::time::timeout(
+            Duration::from_secs(2),
+            trigger.stop_recording_and_dump_current_data(),
+        )
+        .await
+        .expect("dump should complete")
+        .expect("checkpoint and pipeline should succeed");
+        assert_eq!(receipt.segments_processed, 1);
+        assert!(
+            handle.shared().is_some_and(|shared| !shared.is_enabled()),
+            "capture-stop must close the recording gate"
         );
         let segments = sealed_segments(dir.path());
         assert_eq!(segments.len(), 1);
         assert_eq!(
             decoded_test_values(&std::fs::read(&segments[0]).expect("read segment")),
             vec![72],
-            "source data captured before disable must stay in the checkpointed segment"
+            "the final source sample must stay in the checkpointed segment"
         );
     }
 
-    #[test]
-    fn rotate_segment_drains_flush_thread_events_after_disable() {
-        struct BlockingSource {
+    #[tokio::test]
+    async fn stop_recording_waits_for_in_flight_event_and_rejects_later_event() {
+        struct BlockingEvent {
             ready: std::sync::mpsc::SyncSender<()>,
             release: std::sync::mpsc::Receiver<()>,
-            emitted: bool,
         }
 
-        impl Source for BlockingSource {
-            fn flush(&mut self, ctx: &FlushContext<'_>) {
-                if self.emitted {
-                    return;
-                }
-                ctx.record_event(&TestEvent {
+        impl crate::encoder::Encodable for BlockingEvent {
+            fn encode(&self, encoder: &mut crate::encoder::ThreadLocalEncoder<'_>) {
+                self.ready.send(()).expect("test receiver remains live");
+                self.release.recv().expect("test sender remains live");
+                encoder.encode(&TestEvent {
                     timestamp_ns: clock::clock_monotonic_ns(),
                     value: 73,
                 });
-                self.emitted = true;
-                self.ready.send(()).expect("test receiver remains live");
-                self.release.recv().expect("test sender remains live");
-            }
-
-            fn name(&self) -> &'static str {
-                "blocking-once"
             }
         }
 
@@ -794,43 +800,169 @@ mod tests {
             .rotation_period(Duration::MAX)
             .build()
             .expect("writer");
+        let recorder = recorder(writer).with_dump_trigger(|_| {}).build();
+        let handle = recorder.handle().clone();
+        let trigger = handle.dump_trigger().expect("configured dump trigger");
         let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
-        let recorder = recorder(writer)
-            .source(BlockingSource {
+        let producer_handle = handle.clone();
+        let producer = std::thread::spawn(move || {
+            producer_handle.record_event(BlockingEvent {
                 ready: ready_tx,
                 release: release_rx,
-                emitted: false,
-            })
-            .build();
-        let handle = recorder.handle().clone();
-
+            });
+        });
         ready_rx
             .recv_timeout(Duration::from_secs(2))
-            .expect("source should record on the flush thread");
-        handle.disable();
-        release_tx
-            .send(())
-            .expect("flush thread should still be waiting");
+            .expect("producer reached the encoder");
 
-        assert_eq!(
-            handle
-                .rotate_segment()
-                .timeout(Duration::from_secs(2))
-                .call()
-                .expect("rotation"),
-            crate::handle::SegmentRotation::Sealed
+        let dump =
+            tokio::spawn(async move { trigger.stop_recording_and_dump_current_data().await });
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while handle.shared().is_some_and(|shared| shared.is_enabled()) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("checkpoint should close the gate");
+        assert!(
+            !dump.is_finished(),
+            "the checkpoint must wait for the in-flight encoder"
         );
-        let segments = sealed_segments(dir.path());
-        assert_eq!(segments.len(), 1);
+
+        handle.record_event(TestEvent {
+            timestamp_ns: clock::clock_monotonic_ns(),
+            value: 74,
+        });
+        release_tx.send(()).expect("producer remains live");
+        producer.join().expect("producer exits");
+
+        let receipt = tokio::time::timeout(Duration::from_secs(2), dump)
+            .await
+            .expect("dump should complete")
+            .expect("dump task should not panic")
+            .expect("checkpoint and pipeline should succeed");
+        assert_eq!(receipt.segments_processed, 1);
         assert_eq!(
-            decoded_test_values(&std::fs::read(&segments[0]).expect("read segment")),
-            vec![73]
+            decoded_test_values(&std::fs::read(sealed_segment(dir.path())).expect("read segment")),
+            vec![73],
+            "the in-flight event belongs before the boundary and the later event after it"
         );
     }
 
-    #[test]
-    fn rotate_segment_returns_flush_failure() {
+    #[tokio::test]
+    async fn stop_recording_does_not_sample_sources_when_already_disabled() {
+        use std::sync::Arc as StdArc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct CountingSource(StdArc<AtomicUsize>);
+        impl Source for CountingSource {
+            fn flush(&mut self, _ctx: &FlushContext<'_>) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+
+            fn name(&self) -> &'static str {
+                "counting"
+            }
+        }
+
+        let flushes = StdArc::new(AtomicUsize::new(0));
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = DiskBuffer::builder()
+            .base_path(dir.path())
+            .max_file_size(1024 * 1024)
+            .max_total_size(8 * 1024 * 1024)
+            .rotation_period(Duration::MAX)
+            .build()
+            .expect("writer");
+        let recorder = recorder(writer)
+            .source(CountingSource(StdArc::clone(&flushes)))
+            .paused()
+            .with_dump_trigger(|_| {})
+            .build();
+        let handle = recorder.handle().clone();
+        let trigger = handle.dump_trigger().expect("configured dump trigger");
+
+        let receipt = tokio::time::timeout(
+            Duration::from_secs(2),
+            trigger.stop_recording_and_dump_current_data(),
+        )
+        .await
+        .expect("dump should complete")
+        .expect("empty checkpoint should succeed");
+        assert_eq!(receipt.segments_processed, 0);
+        assert_eq!(
+            flushes.load(Ordering::SeqCst),
+            0,
+            "a source may sample new state, so an already-closed capture must not flush it"
+        );
+        assert!(sealed_segments(dir.path()).is_empty());
+    }
+
+    #[tokio::test]
+    async fn current_data_checkpoint_returns_would_block_when_control_queue_is_full() {
+        use std::future::IntoFuture;
+
+        struct BlockingSource {
+            ready: Option<std::sync::mpsc::SyncSender<()>>,
+            release: std::sync::mpsc::Receiver<()>,
+        }
+
+        impl Source for BlockingSource {
+            fn flush(&mut self, _ctx: &FlushContext<'_>) {
+                let Some(ready) = self.ready.take() else {
+                    return;
+                };
+                ready.send(()).expect("test receiver remains live");
+                self.release.recv().expect("test sender remains live");
+            }
+
+            fn name(&self) -> &'static str {
+                "blocking"
+            }
+        }
+
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let writer = MemoryBuffer::new(1 << 20).expect("writer");
+        let recorder = recorder(writer)
+            .source(BlockingSource {
+                ready: Some(ready_tx),
+                release: release_rx,
+            })
+            .with_dump_trigger(|_| {})
+            .build();
+        let trigger = recorder
+            .handle()
+            .dump_trigger()
+            .expect("configured dump trigger");
+
+        ready_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("flush thread is blocked in the source");
+        let first = trigger.dump_current_data().into_future();
+        let error = trigger
+            .stop_recording_and_dump_current_data()
+            .await
+            .expect_err("the occupied control slot must apply backpressure");
+        assert!(
+            matches!(
+                error,
+                crate::dump::DumpError::Checkpoint(ref error)
+                    if error.kind() == std::io::ErrorKind::WouldBlock
+            ),
+            "unexpected busy error: {error}"
+        );
+
+        release_tx.send(()).expect("flush thread remains live");
+        tokio::time::timeout(Duration::from_secs(2), first)
+            .await
+            .expect("accepted checkpoint should complete")
+            .expect("accepted checkpoint should succeed");
+    }
+
+    #[tokio::test]
+    async fn dump_current_data_returns_checkpoint_flush_failure() {
         let dir = tempfile::tempdir().expect("tempdir");
         let mut writer = DiskBuffer::builder()
             .base_path(dir.path())
@@ -842,18 +974,100 @@ mod tests {
         writer
             .fail_after_flushes_for_test(0)
             .expect("install failing writer");
-        let recorder = recorder(writer).build();
+        let recorder = recorder(writer).with_dump_trigger(|_| {}).build();
         let handle = recorder.handle().clone();
+        let trigger = handle.dump_trigger().expect("configured dump trigger");
 
-        let error = handle
-            .rotate_segment()
-            .timeout(Duration::from_secs(2))
-            .call()
+        let error = tokio::time::timeout(Duration::from_secs(2), trigger.dump_current_data())
+            .await
+            .expect("dump should complete")
             .expect_err("flush failure must reach the checkpoint caller");
-        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert!(
+            matches!(
+                error,
+                crate::dump::DumpError::Checkpoint(ref error)
+                    if error.kind() == std::io::ErrorKind::Other
+            ),
+            "unexpected dump error: {error}"
+        );
         assert!(
             handle.shared().is_some_and(|shared| shared.is_enabled()),
             "a pre-rotation flush failure leaves the active writer available and must not close the recording gate"
+        );
+    }
+
+    #[tokio::test]
+    async fn dump_current_data_reports_missing_active_and_recovers_writer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = DiskBuffer::builder()
+            .base_path(dir.path())
+            .max_file_size(1024 * 1024)
+            .max_total_size(8 * 1024 * 1024)
+            .rotation_period(Duration::MAX)
+            .build()
+            .expect("writer");
+        let recorder = recorder(writer).with_dump_trigger(|_| {}).build();
+        let handle = recorder.handle().clone();
+        let trigger = handle.dump_trigger().expect("configured dump trigger");
+
+        handle.record_event(TestEvent {
+            timestamp_ns: clock::clock_monotonic_ns(),
+            value: 81,
+        });
+        std::fs::remove_file(active_segment(dir.path())).expect("remove active segment");
+        let error = tokio::time::timeout(Duration::from_secs(2), trigger.dump_current_data())
+            .await
+            .expect("dump should complete")
+            .expect_err("a missing active segment must not be acknowledged");
+        assert!(
+            matches!(
+                error,
+                crate::dump::DumpError::Checkpoint(ref error)
+                    if error.kind() == std::io::ErrorKind::NotFound
+            ),
+            "unexpected dump error: {error}"
+        );
+        assert!(
+            handle.shared().is_some_and(|shared| shared.is_enabled()),
+            "recovering a fresh writer keeps recording available"
+        );
+        assert!(active_segment(dir.path()).exists());
+
+        handle.record_event(TestEvent {
+            timestamp_ns: clock::clock_monotonic_ns(),
+            value: 82,
+        });
+        let receipt = tokio::time::timeout(Duration::from_secs(2), trigger.dump_current_data())
+            .await
+            .expect("retry should complete")
+            .expect("recovered writer should checkpoint");
+        assert_eq!(receipt.segments_processed, 1);
+        assert_eq!(
+            decoded_test_values(&std::fs::read(sealed_segment(dir.path())).expect("read segment")),
+            vec![82]
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_recording_bypasses_dump_debounce() {
+        let writer = MemoryBuffer::new(1 << 20).expect("writer");
+        let recorder = recorder(writer)
+            .with_dump_trigger(|trigger| trigger.debounce(Duration::from_secs(60)))
+            .build();
+        let handle = recorder.handle().clone();
+        let trigger = handle.dump_trigger().expect("configured dump trigger");
+
+        trigger
+            .dump_current_data()
+            .await
+            .expect("first dump arms debounce");
+        trigger
+            .stop_recording_and_dump_current_data()
+            .await
+            .expect("capture-stop must not coalesce");
+        assert!(
+            handle.shared().is_some_and(|shared| !shared.is_enabled()),
+            "non-debounced lifecycle request reaches the flush thread"
         );
     }
 

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -564,6 +564,27 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "pipeline")]
+    struct BlockingSource {
+        ready: Option<std::sync::mpsc::SyncSender<()>>,
+        release: std::sync::mpsc::Receiver<()>,
+    }
+
+    #[cfg(feature = "pipeline")]
+    impl Source for BlockingSource {
+        fn flush(&mut self, _ctx: &FlushContext<'_>) {
+            let Some(ready) = self.ready.take() else {
+                return;
+            };
+            ready.send(()).expect("test receiver remains live");
+            self.release.recv().expect("test sender remains live");
+        }
+
+        fn name(&self) -> &'static str {
+            "blocking"
+        }
+    }
+
     fn sealed_segment(dir: &Path) -> PathBuf {
         sealed_segments(dir)
             .into_iter()
@@ -1019,25 +1040,6 @@ mod tests {
     async fn current_data_checkpoint_returns_would_block_when_control_queue_is_full() {
         use std::future::IntoFuture;
 
-        struct BlockingSource {
-            ready: Option<std::sync::mpsc::SyncSender<()>>,
-            release: std::sync::mpsc::Receiver<()>,
-        }
-
-        impl Source for BlockingSource {
-            fn flush(&mut self, _ctx: &FlushContext<'_>) {
-                let Some(ready) = self.ready.take() else {
-                    return;
-                };
-                ready.send(()).expect("test receiver remains live");
-                self.release.recv().expect("test sender remains live");
-            }
-
-            fn name(&self) -> &'static str {
-                "blocking"
-            }
-        }
-
         let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
         let writer = MemoryBuffer::new(1 << 20).expect("writer");
@@ -1075,6 +1077,54 @@ mod tests {
             .await
             .expect("accepted checkpoint should complete")
             .expect("accepted checkpoint should succeed");
+    }
+
+    #[cfg(feature = "pipeline")]
+    #[tokio::test]
+    async fn rejected_current_data_checkpoint_does_not_arm_debounce() {
+        use std::future::IntoFuture;
+
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let writer = MemoryBuffer::new(1 << 20).expect("writer");
+        let recorder = recorder(writer)
+            .source(BlockingSource {
+                ready: Some(ready_tx),
+                release: release_rx,
+            })
+            .with_dump_trigger(|trigger| trigger.debounce(Duration::from_secs(60)))
+            .build();
+        let trigger = recorder
+            .handle()
+            .dump_trigger()
+            .expect("configured dump trigger");
+
+        ready_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("flush thread is blocked in the source");
+        let capture_stop = trigger.stop_recording_and_dump_current_data().into_future();
+        let error = trigger
+            .dump_current_data()
+            .await
+            .expect_err("the occupied control slot must reject the dump");
+        assert!(
+            matches!(
+                error,
+                crate::dump::DumpError::Checkpoint(ref error)
+                    if error.kind() == std::io::ErrorKind::WouldBlock
+            ),
+            "unexpected busy error: {error}"
+        );
+
+        release_tx.send(()).expect("flush thread remains live");
+        tokio::time::timeout(Duration::from_secs(2), capture_stop)
+            .await
+            .expect("accepted capture-stop should complete")
+            .expect("accepted capture-stop should succeed");
+        tokio::time::timeout(Duration::from_secs(2), trigger.dump_current_data())
+            .await
+            .expect("retry should complete")
+            .expect("rejected dump must not poison debounce");
     }
 
     #[cfg(feature = "pipeline")]
@@ -1151,6 +1201,42 @@ mod tests {
         assert_eq!(
             decoded_test_values(&std::fs::read(sealed_segment(dir.path())).expect("read segment")),
             vec![82]
+        );
+    }
+
+    #[cfg(feature = "pipeline")]
+    #[tokio::test]
+    async fn dump_dispatches_sealed_checkpoint_when_replacement_open_fails() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = checkpoint_disk_writer(dir.path());
+        let recorder = recorder(writer).with_dump_trigger(|_| {}).build();
+        let handle = recorder.handle().clone();
+        let trigger = handle.dump_trigger().expect("configured dump trigger");
+
+        let current = active_segment(dir.path());
+        let current_name = current.file_name().unwrap().to_string_lossy();
+        let next_name = current_name.replace(".0.bin.active", ".1.bin.active");
+        assert_ne!(next_name, current_name, "test expects the first segment");
+        std::fs::create_dir(current.with_file_name(next_name))
+            .expect("directory collision makes replacement creation fail");
+
+        handle.record_event(TestEvent {
+            timestamp_ns: clock::clock_monotonic_ns(),
+            value: 91,
+        });
+        let receipt = tokio::time::timeout(Duration::from_secs(2), trigger.dump_current_data())
+            .await
+            .expect("dump should complete")
+            .expect("the already-sealed checkpoint should still dispatch");
+
+        assert_eq!(receipt.segments_processed, 1);
+        assert!(
+            handle.shared().is_some_and(|shared| !shared.is_enabled()),
+            "failure to open the replacement closes recording"
+        );
+        assert_eq!(
+            decoded_test_values(&std::fs::read(sealed_segment(dir.path())).expect("read segment")),
+            vec![91]
         );
     }
 

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -559,6 +559,19 @@ mod tests {
             .expect("a sealed .bin segment")
     }
 
+    fn sealed_segments(dir: &Path) -> Vec<PathBuf> {
+        let mut paths: Vec<_> = std::fs::read_dir(dir)
+            .expect("trace dir readable")
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| {
+                let name = p.file_name().unwrap().to_string_lossy();
+                name.ends_with(".bin") && !name.ends_with(".active")
+            })
+            .collect();
+        paths.sort();
+        paths
+    }
+
     fn decoded_test_values(bytes: &[u8]) -> Vec<u64> {
         let mut decoder = Decoder::new(bytes).expect("valid trace header");
         let mut values = Vec::new();
@@ -633,6 +646,214 @@ mod tests {
         assert!(
             recorder.handle().is_enabled(),
             "handle enabled after enable()"
+        );
+    }
+
+    /// An on-demand rotation seals everything recorded before a disabled
+    /// capture gate, then leaves the recorder ready for a later capture.
+    #[test]
+    fn rotate_segment_seals_and_continues_after_reenable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = DiskBuffer::builder()
+            .base_path(dir.path())
+            .max_file_size(1024 * 1024)
+            .max_total_size(8 * 1024 * 1024)
+            .rotation_period(Duration::MAX)
+            .build()
+            .expect("writer");
+        let recorder = recorder(writer).build();
+        let handle = recorder.handle().clone();
+
+        handle.record_event(TestEvent {
+            timestamp_ns: clock::clock_monotonic_ns(),
+            value: 41,
+        });
+        handle.disable();
+        assert_eq!(
+            handle
+                .rotate_segment()
+                .timeout(Duration::from_secs(2))
+                .call()
+                .expect("first rotation"),
+            crate::handle::SegmentRotation::Sealed
+        );
+
+        let first = sealed_segments(dir.path());
+        assert_eq!(first.len(), 1, "rotation should seal one segment");
+        assert_eq!(
+            decoded_test_values(&std::fs::read(&first[0]).expect("read first segment")),
+            vec![41]
+        );
+        assert!(
+            std::fs::read_dir(dir.path())
+                .expect("trace dir readable")
+                .filter_map(Result::ok)
+                .any(|e| e.path().to_string_lossy().ends_with(".bin.active")),
+            "rotation should leave a fresh active segment"
+        );
+
+        handle.enable();
+        handle.record_event(TestEvent {
+            timestamp_ns: clock::clock_monotonic_ns(),
+            value: 42,
+        });
+        recorder.graceful_shutdown(Duration::ZERO);
+
+        let segments = sealed_segments(dir.path());
+        assert_eq!(segments.len(), 2);
+        assert_eq!(
+            decoded_test_values(&std::fs::read(&segments[1]).expect("read second segment")),
+            vec![42]
+        );
+    }
+
+    #[test]
+    fn rotate_segment_on_handle_without_recorder_is_a_noop() {
+        assert_eq!(
+            Dial9Handle::disabled()
+                .rotate_segment()
+                .timeout(Duration::ZERO)
+                .call()
+                .expect("disabled handle"),
+            crate::handle::SegmentRotation::NoRecorder
+        );
+    }
+
+    #[test]
+    fn rotate_segment_flushes_pending_source_after_disable() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = DiskBuffer::builder()
+            .base_path(dir.path())
+            .max_file_size(1024 * 1024)
+            .max_total_size(8 * 1024 * 1024)
+            .rotation_period(Duration::MAX)
+            .build()
+            .expect("writer");
+        // A paused recorder makes the boundary deterministic: the source owns
+        // data captured before the gate closed, but no ordinary enabled flush
+        // can consume it before the explicit checkpoint.
+        let recorder = recorder(writer)
+            .source(OnceSource {
+                emitted: false,
+                value: 72,
+            })
+            .paused()
+            .build();
+        let handle = recorder.handle().clone();
+
+        handle.disable();
+        assert_eq!(
+            handle
+                .rotate_segment()
+                .timeout(Duration::from_secs(2))
+                .call()
+                .expect("rotation"),
+            crate::handle::SegmentRotation::Sealed
+        );
+        let segments = sealed_segments(dir.path());
+        assert_eq!(segments.len(), 1);
+        assert_eq!(
+            decoded_test_values(&std::fs::read(&segments[0]).expect("read segment")),
+            vec![72],
+            "source data captured before disable must stay in the checkpointed segment"
+        );
+    }
+
+    #[test]
+    fn rotate_segment_drains_flush_thread_events_after_disable() {
+        struct BlockingSource {
+            ready: std::sync::mpsc::SyncSender<()>,
+            release: std::sync::mpsc::Receiver<()>,
+            emitted: bool,
+        }
+
+        impl Source for BlockingSource {
+            fn flush(&mut self, ctx: &FlushContext<'_>) {
+                if self.emitted {
+                    return;
+                }
+                ctx.record_event(&TestEvent {
+                    timestamp_ns: clock::clock_monotonic_ns(),
+                    value: 73,
+                });
+                self.emitted = true;
+                self.ready.send(()).expect("test receiver remains live");
+                self.release.recv().expect("test sender remains live");
+            }
+
+            fn name(&self) -> &'static str {
+                "blocking-once"
+            }
+        }
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = DiskBuffer::builder()
+            .base_path(dir.path())
+            .max_file_size(1024 * 1024)
+            .max_total_size(8 * 1024 * 1024)
+            .rotation_period(Duration::MAX)
+            .build()
+            .expect("writer");
+        let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
+        let recorder = recorder(writer)
+            .source(BlockingSource {
+                ready: ready_tx,
+                release: release_rx,
+                emitted: false,
+            })
+            .build();
+        let handle = recorder.handle().clone();
+
+        ready_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("source should record on the flush thread");
+        handle.disable();
+        release_tx
+            .send(())
+            .expect("flush thread should still be waiting");
+
+        assert_eq!(
+            handle
+                .rotate_segment()
+                .timeout(Duration::from_secs(2))
+                .call()
+                .expect("rotation"),
+            crate::handle::SegmentRotation::Sealed
+        );
+        let segments = sealed_segments(dir.path());
+        assert_eq!(segments.len(), 1);
+        assert_eq!(
+            decoded_test_values(&std::fs::read(&segments[0]).expect("read segment")),
+            vec![73]
+        );
+    }
+
+    #[test]
+    fn rotate_segment_returns_flush_failure() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut writer = DiskBuffer::builder()
+            .base_path(dir.path())
+            .max_file_size(1024 * 1024)
+            .max_total_size(8 * 1024 * 1024)
+            .rotation_period(Duration::MAX)
+            .build()
+            .expect("writer");
+        writer
+            .fail_after_flushes_for_test(0)
+            .expect("install failing writer");
+        let recorder = recorder(writer).build();
+        let handle = recorder.handle().clone();
+
+        let error = handle
+            .rotate_segment()
+            .timeout(Duration::from_secs(2))
+            .call()
+            .expect_err("flush failure must reach the checkpoint caller");
+        assert_eq!(error.kind(), std::io::ErrorKind::Other);
+        assert!(
+            handle.shared().is_some_and(|shared| shared.is_enabled()),
+            "a pre-rotation flush failure leaves the active writer available and must not close the recording gate"
         );
     }
 

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -308,12 +308,13 @@ impl<M: BufferMode> RecorderBuilder<M> {
                 default_pipeline(source_stages, self.terminal_processor, M::IS_DISK)
             }
         };
-        // A current-data dump is also useful without processing stages: the
-        // flush-thread checkpoint makes the active fragment stable and the
+        // A disk current-data dump is also useful without processing stages:
+        // the flush-thread checkpoint makes the active fragment stable and the
         // retain stage lets the worker acknowledge it without rewriting or
-        // removing it.
+        // removing it. Memory has no retain-in-place worker path because
+        // taking a segment consumes its ring slot.
         #[cfg(feature = "pipeline")]
-        if self.trigger.is_some() && processors.is_empty() {
+        if self.trigger.is_some() && processors.is_empty() && M::IS_DISK {
             processors.push(Box::new(crate::worker::processors::RetainProcessor));
         }
 
@@ -1042,7 +1043,8 @@ mod tests {
 
         let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
-        let writer = MemoryBuffer::new(1 << 20).expect("writer");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = checkpoint_disk_writer(dir.path());
         let recorder = recorder(writer)
             .source(BlockingSource {
                 ready: Some(ready_tx),
@@ -1086,7 +1088,8 @@ mod tests {
 
         let (ready_tx, ready_rx) = std::sync::mpsc::sync_channel(0);
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(0);
-        let writer = MemoryBuffer::new(1 << 20).expect("writer");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = checkpoint_disk_writer(dir.path());
         let recorder = recorder(writer)
             .source(BlockingSource {
                 ready: Some(ready_tx),
@@ -1162,7 +1165,9 @@ mod tests {
     async fn dump_current_data_reports_missing_active_and_recovers_writer() {
         let dir = tempfile::tempdir().expect("tempdir");
         let writer = checkpoint_disk_writer(dir.path());
-        let recorder = recorder(writer).with_dump_trigger(|_| {}).build();
+        let recorder = recorder(writer)
+            .with_dump_trigger(|trigger| trigger.debounce(Duration::from_secs(60)))
+            .build();
         let handle = recorder.handle().clone();
         let trigger = handle.dump_trigger().expect("configured dump trigger");
 
@@ -1206,6 +1211,38 @@ mod tests {
 
     #[cfg(feature = "pipeline")]
     #[tokio::test]
+    async fn memory_trigger_without_pipeline_retains_ring_and_rolls_back_debounce() {
+        let writer = MemoryBuffer::new(1 << 20).expect("writer");
+        let fs = writer.fs_handle().expect("memory writer exposes its fs");
+        let recorder = recorder(writer)
+            .with_dump_trigger(|trigger| trigger.debounce(Duration::from_secs(60)))
+            .build();
+        let handle = recorder.handle().clone();
+        let trigger = handle.dump_trigger().expect("configured dump trigger");
+
+        handle.record_event(TestEvent {
+            timestamp_ns: clock::clock_monotonic_ns(),
+            value: 83,
+        });
+        for attempt in 1..=2 {
+            let error = tokio::time::timeout(Duration::from_secs(2), trigger.dump_current_data())
+                .await
+                .expect("dump should complete")
+                .expect_err("no pipeline worker is configured for a memory recorder");
+            assert!(
+                matches!(error, crate::dump::DumpError::WorkerStopped),
+                "attempt {attempt} should reach dispatch instead of coalescing: {error}"
+            );
+        }
+
+        let taken = fs.take_files();
+        assert_eq!(taken.segments.len(), 1, "the raw ring segment is retained");
+        let (_, payload, _) = taken.segments.into_iter().next().unwrap().load().unwrap();
+        assert_eq!(decoded_test_values(&payload.into_vec()), vec![83]);
+    }
+
+    #[cfg(feature = "pipeline")]
+    #[tokio::test]
     async fn dump_dispatches_sealed_checkpoint_when_replacement_open_fails() {
         let dir = tempfile::tempdir().expect("tempdir");
         let writer = checkpoint_disk_writer(dir.path());
@@ -1243,7 +1280,8 @@ mod tests {
     #[cfg(feature = "pipeline")]
     #[tokio::test]
     async fn stop_recording_bypasses_dump_debounce() {
-        let writer = MemoryBuffer::new(1 << 20).expect("writer");
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = checkpoint_disk_writer(dir.path());
         let recorder = recorder(writer)
             .with_dump_trigger(|trigger| trigger.debounce(Duration::from_secs(60)))
             .build();

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -575,6 +575,7 @@ mod tests {
             .expect("a sealed .bin segment")
     }
 
+    #[cfg(feature = "pipeline")]
     fn sealed_segments(dir: &Path) -> Vec<PathBuf> {
         let mut paths: Vec<_> = std::fs::read_dir(dir)
             .expect("trace dir readable")
@@ -588,6 +589,7 @@ mod tests {
         paths
     }
 
+    #[cfg(feature = "pipeline")]
     fn active_segment(dir: &Path) -> PathBuf {
         std::fs::read_dir(dir)
             .expect("trace dir readable")
@@ -675,6 +677,7 @@ mod tests {
 
     /// A current-data dump seals the pending fragment before dispatching it,
     /// without closing the recording gate.
+    #[cfg(feature = "pipeline")]
     #[tokio::test]
     async fn dump_current_data_seals_and_continues_recording() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -731,6 +734,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "pipeline")]
     #[tokio::test]
     async fn stop_recording_takes_final_source_sample_before_checkpoint() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -774,6 +778,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "pipeline")]
     #[tokio::test]
     async fn stop_recording_waits_for_in_flight_event_and_rejects_later_event() {
         struct BlockingEvent {
@@ -850,6 +855,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "pipeline")]
     #[tokio::test]
     async fn stop_recording_does_not_sample_sources_when_already_disabled() {
         use std::sync::Arc as StdArc;
@@ -899,6 +905,7 @@ mod tests {
         assert!(sealed_segments(dir.path()).is_empty());
     }
 
+    #[cfg(feature = "pipeline")]
     #[tokio::test]
     async fn current_data_checkpoint_returns_would_block_when_control_queue_is_full() {
         use std::future::IntoFuture;
@@ -961,6 +968,7 @@ mod tests {
             .expect("accepted checkpoint should succeed");
     }
 
+    #[cfg(feature = "pipeline")]
     #[tokio::test]
     async fn dump_current_data_returns_checkpoint_flush_failure() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -996,6 +1004,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "pipeline")]
     #[tokio::test]
     async fn dump_current_data_reports_missing_active_and_recovers_writer() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -1048,6 +1057,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "pipeline")]
     #[tokio::test]
     async fn stop_recording_bypasses_dump_debounce() {
         let writer = MemoryBuffer::new(1 << 20).expect("writer");

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -735,6 +735,126 @@ mod tests {
     }
 
     #[cfg(feature = "pipeline")]
+    /// A checkpoint must survive the retention pass caused by opening its
+    /// replacement active segment. Before checkpoint protection, a budget
+    /// that fit exactly one sealed segment evicted that segment before the
+    /// dump request reached the worker and returned an empty receipt.
+    #[tokio::test]
+    async fn dump_current_data_survives_checkpoint_retention_pressure() {
+        struct DelayedPathCheck;
+
+        impl crate::pipeline::SegmentProcessor for DelayedPathCheck {
+            fn name(&self) -> &'static str {
+                "DelayedPathCheck"
+            }
+
+            fn process(
+                &mut self,
+                data: crate::pipeline::SegmentData,
+            ) -> std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = Result<
+                                crate::pipeline::SegmentData,
+                                crate::pipeline::ProcessError,
+                            >,
+                        > + Send
+                        + '_,
+                >,
+            > {
+                Box::pin(async move {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    if data
+                        .segment()
+                        .disk_path()
+                        .is_some_and(std::path::Path::exists)
+                    {
+                        Ok(data)
+                    } else {
+                        Err(crate::pipeline::ProcessError::io(
+                            data,
+                            std::io::Error::new(
+                                std::io::ErrorKind::NotFound,
+                                "checkpoint segment was evicted during its pipeline pass",
+                            ),
+                        ))
+                    }
+                })
+            }
+        }
+
+        // Keep the probe on another thread so its thread-local encoder cannot
+        // affect the recorder under test.
+        let one_segment_budget = std::thread::spawn(|| {
+            let probe_dir = tempfile::tempdir().expect("probe tempdir");
+            let probe_writer = DiskBuffer::builder()
+                .base_path(probe_dir.path())
+                .max_file_size(u64::MAX)
+                .max_total_size(1024 * 1024)
+                .rotation_period(Duration::MAX)
+                .build()
+                .expect("probe writer");
+            let probe = recorder(probe_writer).build();
+            probe.handle().record_event(TestEvent {
+                timestamp_ns: clock::clock_monotonic_ns(),
+                value: 51,
+            });
+            probe.graceful_shutdown(Duration::ZERO);
+            std::fs::metadata(sealed_segment(probe_dir.path()))
+                .expect("probe segment metadata")
+                .len()
+        })
+        .join()
+        .expect("probe thread");
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let writer = DiskBuffer::builder()
+            .base_path(dir.path())
+            .max_file_size(u64::MAX)
+            .max_total_size(one_segment_budget)
+            .rotation_period(Duration::MAX)
+            .build()
+            .expect("writer");
+        let recorder = recorder(writer)
+            .pipe(DelayedPathCheck)
+            .with_dump_trigger(|_| {})
+            .build();
+        let handle = recorder.handle().clone();
+        let trigger = handle.dump_trigger().expect("configured dump trigger");
+        handle.record_event(TestEvent {
+            timestamp_ns: clock::clock_monotonic_ns(),
+            value: 51,
+        });
+
+        let receipt = tokio::time::timeout(Duration::from_secs(2), trigger.dump_current_data())
+            .await
+            .expect("dump should complete")
+            .expect("checkpoint and pipeline should succeed");
+        assert_eq!(
+            receipt.segments_processed, 1,
+            "the checkpoint segment must remain available until the worker loads it"
+        );
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                let retained_bytes: u64 = std::fs::read_dir(dir.path())
+                    .expect("trace dir readable")
+                    .map(|entry| entry.expect("trace directory entry"))
+                    .map(|entry| entry.metadata().expect("trace metadata").len())
+                    .sum();
+                if retained_bytes <= one_segment_budget {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("checkpoint protection must not permanently weaken the disk budget");
+
+        recorder.graceful_shutdown(Duration::ZERO);
+    }
+
+    #[cfg(feature = "pipeline")]
     #[tokio::test]
     async fn stop_recording_takes_final_source_sample_before_checkpoint() {
         let dir = tempfile::tempdir().expect("tempdir");

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -840,7 +840,14 @@ mod tests {
                 let retained_bytes: u64 = std::fs::read_dir(dir.path())
                     .expect("trace dir readable")
                     .map(|entry| entry.expect("trace directory entry"))
-                    .map(|entry| entry.metadata().expect("trace metadata").len())
+                    .filter_map(|entry| match entry.metadata() {
+                        Ok(metadata) => Some(metadata.len()),
+                        // Budget restoration removes files concurrently with
+                        // this observation; disappearance is the condition
+                        // this loop is waiting for.
+                        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                        Err(error) => panic!("trace metadata: {error}"),
+                    })
                     .sum();
                 if retained_bytes <= one_segment_budget {
                     break;

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -565,17 +565,12 @@ mod tests {
     }
 
     fn sealed_segment(dir: &Path) -> PathBuf {
-        std::fs::read_dir(dir)
-            .expect("trace dir readable")
-            .filter_map(|e| e.ok().map(|e| e.path()))
-            .find(|p| {
-                let name = p.file_name().unwrap().to_string_lossy();
-                name.ends_with(".bin") && !name.ends_with(".active")
-            })
+        sealed_segments(dir)
+            .into_iter()
+            .next()
             .expect("a sealed .bin segment")
     }
 
-    #[cfg(feature = "pipeline")]
     fn sealed_segments(dir: &Path) -> Vec<PathBuf> {
         let mut paths: Vec<_> = std::fs::read_dir(dir)
             .expect("trace dir readable")
@@ -596,6 +591,17 @@ mod tests {
             .filter_map(|e| e.ok().map(|e| e.path()))
             .find(|p| p.to_string_lossy().ends_with(".bin.active"))
             .expect("an active .bin segment")
+    }
+
+    #[cfg(feature = "pipeline")]
+    fn checkpoint_disk_writer(dir: &Path) -> DiskBuffer {
+        DiskBuffer::builder()
+            .base_path(dir)
+            .max_file_size(1024 * 1024)
+            .max_total_size(8 * 1024 * 1024)
+            .rotation_period(Duration::MAX)
+            .build()
+            .expect("writer")
     }
 
     fn decoded_test_values(bytes: &[u8]) -> Vec<u64> {
@@ -681,13 +687,7 @@ mod tests {
     #[tokio::test]
     async fn dump_current_data_seals_and_continues_recording() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let writer = DiskBuffer::builder()
-            .base_path(dir.path())
-            .max_file_size(1024 * 1024)
-            .max_total_size(8 * 1024 * 1024)
-            .rotation_period(Duration::MAX)
-            .build()
-            .expect("writer");
+        let writer = checkpoint_disk_writer(dir.path());
         let recorder = recorder(writer).with_dump_trigger(|_| {}).build();
         let handle = recorder.handle().clone();
         let trigger = handle.dump_trigger().expect("configured dump trigger");
@@ -865,13 +865,7 @@ mod tests {
     #[tokio::test]
     async fn stop_recording_takes_final_source_sample_before_checkpoint() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let writer = DiskBuffer::builder()
-            .base_path(dir.path())
-            .max_file_size(1024 * 1024)
-            .max_total_size(8 * 1024 * 1024)
-            .rotation_period(Duration::MAX)
-            .build()
-            .expect("writer");
+        let writer = checkpoint_disk_writer(dir.path());
         let recorder = recorder(writer)
             .source(OnceSource {
                 emitted: false,
@@ -925,13 +919,7 @@ mod tests {
         }
 
         let dir = tempfile::tempdir().expect("tempdir");
-        let writer = DiskBuffer::builder()
-            .base_path(dir.path())
-            .max_file_size(1024 * 1024)
-            .max_total_size(8 * 1024 * 1024)
-            .rotation_period(Duration::MAX)
-            .build()
-            .expect("writer");
+        let writer = checkpoint_disk_writer(dir.path());
         let recorder = recorder(writer).with_dump_trigger(|_| {}).build();
         let handle = recorder.handle().clone();
         let trigger = handle.dump_trigger().expect("configured dump trigger");
@@ -1001,13 +989,7 @@ mod tests {
 
         let flushes = StdArc::new(AtomicUsize::new(0));
         let dir = tempfile::tempdir().expect("tempdir");
-        let writer = DiskBuffer::builder()
-            .base_path(dir.path())
-            .max_file_size(1024 * 1024)
-            .max_total_size(8 * 1024 * 1024)
-            .rotation_period(Duration::MAX)
-            .build()
-            .expect("writer");
+        let writer = checkpoint_disk_writer(dir.path());
         let recorder = recorder(writer)
             .source(CountingSource(StdArc::clone(&flushes)))
             .paused()
@@ -1099,13 +1081,7 @@ mod tests {
     #[tokio::test]
     async fn dump_current_data_returns_checkpoint_flush_failure() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let mut writer = DiskBuffer::builder()
-            .base_path(dir.path())
-            .max_file_size(1024 * 1024)
-            .max_total_size(8 * 1024 * 1024)
-            .rotation_period(Duration::MAX)
-            .build()
-            .expect("writer");
+        let mut writer = checkpoint_disk_writer(dir.path());
         writer
             .fail_after_flushes_for_test(0)
             .expect("install failing writer");
@@ -1135,13 +1111,7 @@ mod tests {
     #[tokio::test]
     async fn dump_current_data_reports_missing_active_and_recovers_writer() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let writer = DiskBuffer::builder()
-            .base_path(dir.path())
-            .max_file_size(1024 * 1024)
-            .max_total_size(8 * 1024 * 1024)
-            .rotation_period(Duration::MAX)
-            .build()
-            .expect("writer");
+        let writer = checkpoint_disk_writer(dir.path());
         let recorder = recorder(writer).with_dump_trigger(|_| {}).build();
         let handle = recorder.handle().clone();
         let trigger = handle.dump_trigger().expect("configured dump trigger");

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -364,6 +364,31 @@ mod tests {
     }
 
     #[test]
+    fn event_buffer_counts_only_events_written() {
+        let ss = Arc::new(enabled_shared_state());
+        let recording = Arc::clone(&ss);
+        std::thread::spawn(move || {
+            recording.if_enabled(|events| events.record_encodable_event(&sample_event()));
+        })
+        .join()
+        .unwrap();
+
+        let batch = ss.collector.next().expect("thread exit flushes its event");
+        assert_eq!(batch.event_count(), 1);
+
+        let declining = Arc::clone(&ss);
+        std::thread::spawn(move || {
+            declining.if_enabled(|events| events.with_encoder(|_| {}));
+        })
+        .join()
+        .unwrap();
+        assert!(
+            ss.collector.next().is_none(),
+            "a callback that writes no event must not flush a header-only batch"
+        );
+    }
+
+    #[test]
     fn record_event_registers_tl_buffer_handle() {
         let ss = enabled_shared_state();
         // First event on this thread should register a handle.

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -116,7 +116,7 @@ impl SharedState {
             let _ = self.state.compare_exchange(
                 State::Disabled as u8,
                 State::Enabled as u8,
-                Ordering::Relaxed,
+                Ordering::Release,
                 Ordering::Relaxed,
             );
         }
@@ -127,7 +127,7 @@ impl SharedState {
         let _ = self.state.compare_exchange(
             State::Enabled as u8,
             State::Disabled as u8,
-            Ordering::Relaxed,
+            Ordering::Release,
             Ordering::Relaxed,
         );
     }
@@ -135,7 +135,7 @@ impl SharedState {
     /// Stop for good: recording off, [`enable`](Self::enable) and new attaches
     /// refused. Called at shutdown once the flush thread is gone.
     pub(crate) fn mark_stopped(&self) {
-        self.state.store(State::Stopped as u8, Ordering::Relaxed);
+        self.state.store(State::Stopped as u8, Ordering::Release);
     }
 
     /// Whether the recorder has shut down for good.
@@ -173,6 +173,9 @@ impl SharedState {
     /// that provides `record_event` / `record_encodable_event`. Returns
     /// `None` when disabled (no work is done).
     pub(crate) fn if_enabled<R>(&self, f: impl FnOnce(&EventBuffer<'_>) -> R) -> Option<R> {
+        // Speculative hot-path check only. EventBuffer repeats the check with
+        // Acquire ordering while holding the TL-buffer lock; that second check
+        // establishes the precise capture-stop boundary.
         if !self.is_enabled() {
             return None;
         }
@@ -298,17 +301,23 @@ pub(crate) struct EventBuffer<'a>(&'a SharedState);
 
 impl EventBuffer<'_> {
     pub(crate) fn record_encodable_event(&self, event: &dyn encoder::Encodable) {
-        if let Some(handle) =
-            encoder::record_encodable_event(event, &self.0.collector, &self.0.drain_epoch)
-        {
-            self.0.tl_buffers.lock().unwrap().push(handle);
-        }
+        encoder::record_encodable_event_if_enabled(
+            event,
+            || self.0.state.load(Ordering::Acquire) == State::Enabled as u8,
+            &self.0.collector,
+            &self.0.drain_epoch,
+            |handle| self.0.tl_buffers.lock().unwrap().push(handle),
+        );
     }
 
     pub(crate) fn with_encoder(&self, f: impl FnOnce(&mut encoder::ThreadLocalEncoder<'_>)) {
-        if let Some(handle) = encoder::with_encoder(f, &self.0.collector, &self.0.drain_epoch) {
-            self.0.tl_buffers.lock().unwrap().push(handle);
-        }
+        encoder::with_encoder_if_enabled(
+            f,
+            || self.0.state.load(Ordering::Acquire) == State::Enabled as u8,
+            &self.0.collector,
+            &self.0.drain_epoch,
+            |handle| self.0.tl_buffers.lock().unwrap().push(handle),
+        );
     }
 }
 
@@ -329,6 +338,29 @@ mod tests {
         let ss = SharedState::new(0);
         ss.enable();
         ss
+    }
+
+    #[test]
+    fn event_buffer_rechecks_gate_before_encoding() {
+        let ss = enabled_shared_state();
+        let mut encoded = false;
+
+        ss.if_enabled(|events| {
+            // Model capture-stop closing the gate after the caller's fast-path
+            // check but before it acquires its thread-local buffer lock.
+            ss.disable();
+            events.with_encoder(|_| encoded = true);
+        });
+
+        assert!(
+            !encoded,
+            "an event crossing the stop boundary must be dropped"
+        );
+        assert_eq!(
+            ss.tl_buffers.lock().unwrap().len(),
+            1,
+            "a first-use buffer must register before the under-lock gate check"
+        );
     }
 
     #[test]

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -222,7 +222,10 @@ impl SharedState {
 
         for handle in &handles {
             // Skip buffers that self-flushed during the current epoch.
-            if handle.flush_epoch.load() >= epoch {
+            // The Acquire pairs with the producer's Release stamp. Skipping
+            // the buffer therefore observes the collector enqueue that
+            // completed before the producer advertised this epoch.
+            if handle.flush_epoch.load_acquire() >= epoch {
                 stats.buffers_skipped_busy += 1;
                 continue;
             }

--- a/dial9-core/src/worker/mod.rs
+++ b/dial9-core/src/worker/mod.rs
@@ -234,16 +234,26 @@ struct ActiveDump {
     first_error: Option<ProcessErrorKind>,
 }
 
-/// Releases checkpoint eviction protection on every segment exit path:
-/// success, terminal failure, retry, panic, or load failure.
+/// Releases checkpoint eviction protection on terminal segment exit paths.
+/// Retryable failures disarm this attempt guard so the active checkpoint
+/// continues to own the lease until a later attempt settles.
 struct CheckpointProtection {
     fs: Arc<Fs>,
     index: u32,
+    release_on_drop: bool,
+}
+
+impl CheckpointProtection {
+    fn retain_for_retry(&mut self) {
+        self.release_on_drop = false;
+    }
 }
 
 impl Drop for CheckpointProtection {
     fn drop(&mut self) {
-        self.fs.release_checkpoint_segment(self.index);
+        if self.release_on_drop {
+            self.fs.release_checkpoint_segment(self.index);
+        }
     }
 }
 
@@ -678,9 +688,10 @@ impl WorkerLoop {
         }
 
         'next_segment: for (seg_idx, taken) in segments.into_iter().enumerate() {
-            let _checkpoint_protection = CheckpointProtection {
+            let mut checkpoint_protection = CheckpointProtection {
                 fs: Arc::clone(&self.fs),
                 index: taken.seg_ref.index(),
+                release_on_drop: true,
             };
             // Cached-epoch fast path (triggered mode, disk): a segment
             // already inspected and found out-of-window is released without
@@ -881,6 +892,7 @@ impl WorkerLoop {
                                                     attempt,
                                                     (epoch_secs, seal_secs),
                                                 );
+                                                checkpoint_protection.retain_for_retry();
                                                 stats
                                                     .retry_dump_ids
                                                     .extend(matched.iter().map(|&i| dumps[i].id));
@@ -900,6 +912,7 @@ impl WorkerLoop {
                                 SegmentRef::Disk(_) => {
                                     tracing::debug!(target: "dial9_worker", id = %data.segment(), err = %kind_msg, "retryable error");
                                     self.fs.release_claim(data.segment());
+                                    checkpoint_protection.retain_for_retry();
                                     stats
                                         .retry_dump_ids
                                         .extend(matched.iter().map(|&i| dumps[i].id));

--- a/dial9-core/src/worker/mod.rs
+++ b/dial9-core/src/worker/mod.rs
@@ -24,7 +24,7 @@ use crate::worker::pipeline_metrics::{MetriqueResult, PipelineMetrics, StageMetr
 use futures_util::FutureExt;
 use metrique::timers::Timer;
 use metrique::writer::BoxEntrySink;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -290,6 +290,16 @@ impl ActiveDump {
         self.deadline.is_none_or(|d| now >= d)
     }
 
+    /// Recorder checkpoints carry an exact ring snapshot. Its membership is
+    /// authoritative even when coarse wall-clock timestamps straddle the
+    /// boundary; ordinary and standalone dumps continue to match by window.
+    fn matches(&self, index: u32, start_secs: u64, seal_secs: u64) -> bool {
+        match &self.checkpoint_segments {
+            Some(indices) => indices.contains(&index),
+            None => self.window.overlaps(start_secs, seal_secs),
+        }
+    }
+
     /// Actual covered span: the captured segments' epoch extent, or the
     /// trigger instant for an empty dump.
     fn time_range(&self) -> (SystemTime, SystemTime) {
@@ -532,8 +542,18 @@ impl WorkerLoop {
             if dumps.is_empty() {
                 return Vec::new();
             }
-            let windows: Vec<EpochWindow> = dumps.iter().map(|d| d.window).collect();
-            let mut taken = self.fs.take_files_matching(&windows);
+            let windows: Vec<EpochWindow> = dumps
+                .iter()
+                .filter(|dump| dump.checkpoint_segments.is_none())
+                .map(|dump| dump.window)
+                .collect();
+            let checkpoint_segments: HashSet<u32> = dumps
+                .iter()
+                .filter_map(|dump| dump.checkpoint_segments.as_ref())
+                .flatten()
+                .copied()
+                .collect();
+            let mut taken = self.fs.take_files_matching(&windows, &checkpoint_segments);
             // Prune cache entries for files no longer dispensed (disk
             // dispenses every unclaimed file per pass, so absence means the
             // writer evicted it).
@@ -713,7 +733,7 @@ impl WorkerLoop {
             let matched: Vec<usize> = dumps
                 .iter()
                 .enumerate()
-                .filter(|(_, d)| d.window.overlaps(epoch_secs, seal_secs))
+                .filter(|(_, d)| d.matches(seg_ref.index(), epoch_secs, seal_secs))
                 .map(|(i, _)| i)
                 .collect();
             if !dumps.is_empty() && matched.is_empty() {

--- a/dial9-core/src/worker/mod.rs
+++ b/dial9-core/src/worker/mod.rs
@@ -223,11 +223,29 @@ struct ActiveDump {
     /// registered until this elapses.
     deadline: Option<tokio::time::Instant>,
     metadata: Vec<(String, String)>,
+    /// Snapshot protected by a flush-thread checkpoint. Entries are released
+    /// as the worker finishes them; leftovers are released when the dump
+    /// resolves. `Some`, including an empty snapshot, owns the sole active
+    /// checkpoint reservation.
+    checkpoint_segments: Option<Vec<u32>>,
     receipt_tx: Option<tokio::sync::oneshot::Sender<Result<DumpReceipt, DumpError>>>,
     segments_processed: usize,
     first_epoch: Option<u64>,
     last_epoch: Option<u64>,
     first_error: Option<ProcessErrorKind>,
+}
+
+/// Releases checkpoint eviction protection on every segment exit path:
+/// success, terminal failure, retry, panic, or load failure.
+struct CheckpointProtection {
+    fs: Arc<Fs>,
+    index: u32,
+}
+
+impl Drop for CheckpointProtection {
+    fn drop(&mut self) {
+        self.fs.release_checkpoint_segment(self.index);
+    }
 }
 
 impl ActiveDump {
@@ -257,6 +275,7 @@ impl ActiveDump {
             window,
             deadline,
             metadata: req.metadata,
+            checkpoint_segments: req.checkpoint_segments,
             receipt_tx: Some(req.receipt_tx),
             segments_processed: 0,
             first_epoch: None,
@@ -474,6 +493,10 @@ impl WorkerLoop {
                 // Requests that never registered fail explicitly.
                 rx.rx.close();
                 while let Ok(req) = rx.rx.try_recv() {
+                    if let Some(indices) = &req.checkpoint_segments {
+                        self.fs.release_checkpoint_segments(indices);
+                        self.fs.finish_checkpoint();
+                    }
                     let _ = req.receipt_tx.send(Err(DumpError::WorkerStopped));
                 }
                 tracing::debug!(target: "dial9_worker", "Exiting triggered run loop");
@@ -577,6 +600,10 @@ impl WorkerLoop {
                 }
             }
         }
+        if let Some(indices) = &dump.checkpoint_segments {
+            self.fs.release_checkpoint_segments(indices);
+            self.fs.finish_checkpoint();
+        }
         let (tx, result) = dump.into_result(manifest_key);
         // The caller may have dropped the handle; that does not cancel.
         let _ = tx.send(result);
@@ -629,6 +656,10 @@ impl WorkerLoop {
         }
 
         'next_segment: for (seg_idx, taken) in segments.into_iter().enumerate() {
+            let _checkpoint_protection = CheckpointProtection {
+                fs: Arc::clone(&self.fs),
+                index: taken.seg_ref.index(),
+            };
             // Cached-epoch fast path (triggered mode, disk): a segment
             // already inspected and found out-of-window is released without
             // re-reading its file.

--- a/dial9-core/src/worker/mod.rs
+++ b/dial9-core/src/worker/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod pipeline_metrics;
 pub mod processors;
 
 use crate::dump::{DumpError, DumpReceipt, DumpRequest, Lookback};
-use crate::fs::{EpochWindow, Fs, RemoveReason, TakenFiles, TakenSegment};
+use crate::fs::{CheckpointGuard, EpochWindow, Fs, RemoveReason, TakenFiles, TakenSegment};
 use crate::pipeline::{ProcessErrorKind, SegmentData, SegmentProcessor};
 use crate::rate_limit::rate_limited;
 use crate::sealed::{self, SegmentRef};
@@ -223,11 +223,10 @@ struct ActiveDump {
     /// registered until this elapses.
     deadline: Option<tokio::time::Instant>,
     metadata: Vec<(String, String)>,
-    /// Snapshot protected by a flush-thread checkpoint. Entries are released
-    /// as the worker finishes them; leftovers are released when the dump
-    /// resolves. `Some`, including an empty snapshot, owns the sole active
-    /// checkpoint reservation.
-    checkpoint_segments: Option<Vec<u32>>,
+    /// Exact flush-thread snapshot. Per-segment guards release protection as
+    /// processing finishes; dropping this guard releases any leftovers and
+    /// reopens the checkpoint gate.
+    checkpoint: Option<CheckpointGuard>,
     receipt_tx: Option<tokio::sync::oneshot::Sender<Result<DumpReceipt, DumpError>>>,
     segments_processed: usize,
     first_epoch: Option<u64>,
@@ -275,7 +274,7 @@ impl ActiveDump {
             window,
             deadline,
             metadata: req.metadata,
-            checkpoint_segments: req.checkpoint_segments,
+            checkpoint: req.checkpoint,
             receipt_tx: Some(req.receipt_tx),
             segments_processed: 0,
             first_epoch: None,
@@ -294,10 +293,14 @@ impl ActiveDump {
     /// authoritative even when coarse wall-clock timestamps straddle the
     /// boundary; ordinary and standalone dumps continue to match by window.
     fn matches(&self, index: u32, start_secs: u64, seal_secs: u64) -> bool {
-        match &self.checkpoint_segments {
+        match self.checkpoint_segments() {
             Some(indices) => indices.contains(&index),
             None => self.window.overlaps(start_secs, seal_secs),
         }
+    }
+
+    fn checkpoint_segments(&self) -> Option<&HashSet<u32>> {
+        self.checkpoint.as_ref().map(CheckpointGuard::segments)
     }
 
     /// Actual covered span: the captured segments' epoch extent, or the
@@ -503,10 +506,6 @@ impl WorkerLoop {
                 // Requests that never registered fail explicitly.
                 rx.rx.close();
                 while let Ok(req) = rx.rx.try_recv() {
-                    if let Some(indices) = &req.checkpoint_segments {
-                        self.fs.release_checkpoint_segments(indices);
-                        self.fs.finish_checkpoint();
-                    }
                     let _ = req.receipt_tx.send(Err(DumpError::WorkerStopped));
                 }
                 tracing::debug!(target: "dial9_worker", "Exiting triggered run loop");
@@ -544,16 +543,23 @@ impl WorkerLoop {
             }
             let windows: Vec<EpochWindow> = dumps
                 .iter()
-                .filter(|dump| dump.checkpoint_segments.is_none())
+                .filter(|dump| dump.checkpoint.is_none())
                 .map(|dump| dump.window)
                 .collect();
-            let checkpoint_segments: HashSet<u32> = dumps
+            let no_checkpoint_segments = HashSet::new();
+            let checkpoint_segments = dumps
                 .iter()
-                .filter_map(|dump| dump.checkpoint_segments.as_ref())
-                .flatten()
-                .copied()
-                .collect();
-            let mut taken = self.fs.take_files_matching(&windows, &checkpoint_segments);
+                .find_map(ActiveDump::checkpoint_segments)
+                .unwrap_or(&no_checkpoint_segments);
+            debug_assert!(
+                dumps
+                    .iter()
+                    .filter(|dump| dump.checkpoint.is_some())
+                    .count()
+                    <= 1,
+                "the checkpoint gate permits at most one active snapshot"
+            );
+            let mut taken = self.fs.take_files_matching(&windows, checkpoint_segments);
             // Prune cache entries for files no longer dispensed (disk
             // dispenses every unclaimed file per pass, so absence means the
             // writer evicted it).
@@ -620,10 +626,6 @@ impl WorkerLoop {
                 }
             }
         }
-        if let Some(indices) = &dump.checkpoint_segments {
-            self.fs.release_checkpoint_segments(indices);
-            self.fs.finish_checkpoint();
-        }
         let (tx, result) = dump.into_result(manifest_key);
         // The caller may have dropped the handle; that does not cancel.
         let _ = tx.send(result);
@@ -685,7 +687,9 @@ impl WorkerLoop {
             // re-reading its file.
             if !dumps.is_empty()
                 && let Some(&(start, seal)) = self.epoch_cache.get(&taken.seg_ref.index())
-                && !dumps.iter().any(|d| d.window.overlaps(start, seal))
+                && !dumps
+                    .iter()
+                    .any(|d| d.matches(taken.seg_ref.index(), start, seal))
             {
                 self.fs.release_claim(&taken.seg_ref);
                 continue;

--- a/dial9-core/src/worker/processors.rs
+++ b/dial9-core/src/worker/processors.rs
@@ -8,6 +8,25 @@ use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
 
+/// Terminal no-op used by triggered disk recorders that have no processing
+/// stages. Successfully claiming the segment keeps the raw file in place while
+/// preventing later dumps from processing the same artifact again.
+#[derive(Debug, Default)]
+pub(crate) struct RetainProcessor;
+
+impl SegmentProcessor for RetainProcessor {
+    fn name(&self) -> &'static str {
+        "Retain"
+    }
+
+    fn process(
+        &mut self,
+        data: SegmentData,
+    ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
+        Box::pin(std::future::ready(Ok(data)))
+    }
+}
+
 /// Gzips the segment payload in-memory. Sets the `content_encoding` and
 /// `write_back_extension` metadata keys so downstream stages know the
 /// payload is gzipped. Already-gzipped segments (detected by magic bytes)

--- a/dial9-core/src/worker/tests.rs
+++ b/dial9-core/src/worker/tests.rs
@@ -1407,7 +1407,7 @@ mod triggered_test_support {
 #[cfg(test)]
 mod triggered_worker_tests {
     use super::triggered_test_support::*;
-    use crate::dump::{self, DumpError};
+    use crate::dump::{self, DumpError, DumpId, DumpRequest, Lookback};
     use crate::fs::{EpochWindow, Fs};
     use crate::pipeline::{ProcessError, ProcessErrorKind, SegmentData, SegmentProcessor};
     use crate::worker::epoch_to_system;
@@ -1531,6 +1531,55 @@ mod triggered_worker_tests {
 
         stop.cancel();
         worker.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn checkpoint_uses_exact_snapshot_instead_of_wall_clock_window() {
+        let fs = Fs::new_in_memory(64 * 1024, 1024).unwrap();
+        let now = now_epoch();
+
+        // Model a checkpoint segment whose creation timestamp crossed ahead
+        // of the request timestamp, then a post-boundary segment whose clock
+        // still falls inside the request's coarse one-second window.
+        seal_mem(&fs, 0, now + 1);
+        check!(fs.try_reserve_checkpoint());
+        let checkpoint_segments = fs.protect_memory_checkpoint_segments(None);
+        check!(checkpoint_segments == vec![0]);
+        seal_mem(&fs, 1, now);
+
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (receipt_tx, receipt_rx) = tokio::sync::oneshot::channel();
+        tx.send(DumpRequest {
+            id: DumpId::new(),
+            triggered_at: UNIX_EPOCH + Duration::from_secs(now),
+            lookback: Lookback::Unbounded,
+            lookforward: Duration::ZERO,
+            metadata: Vec::new(),
+            checkpoint_segments: Some(checkpoint_segments),
+            receipt_tx,
+        })
+        .unwrap();
+
+        let stop = tokio_util::sync::CancellationToken::new();
+        let (capture, captured) = CapturingProcessor::new();
+        let worker = spawn_worker(
+            Arc::clone(&fs),
+            vec![Box::new(capture)],
+            crate::dump::DumpRx { rx },
+            stop.clone(),
+        );
+
+        let receipt = receipt_rx.await.unwrap().unwrap();
+        check!(receipt.segments_processed == 1);
+        check!(captured.lock().unwrap().len() == 1);
+
+        stop.cancel();
+        worker.await.unwrap();
+
+        // The post-boundary segment was not part of the checkpoint snapshot.
+        let remaining = fs.take_files();
+        check!(remaining.segments.len() == 1);
+        check!(remaining.segments[0].seg_ref.index() == 1);
     }
 
     #[tokio::test(start_paused = true)]
@@ -1921,18 +1970,24 @@ mod triggered_worker_tests {
         seal_mem(&fs, 1, now);
 
         // Window matching nothing: ring untouched.
-        let none = fs.take_files_matching(&[EpochWindow {
-            start_secs: Some(now + 100),
-            end_secs: now + 200,
-        }]);
+        let none = fs.take_files_matching(
+            &[EpochWindow {
+                start_secs: Some(now + 100),
+                end_secs: now + 200,
+            }],
+            &Default::default(),
+        );
         check!(none.segments.is_empty());
         check!(none.queued_segments == Some(2));
 
         // Window matching only the fresh segment: the old slot stays.
-        let snap = fs.take_files_matching(&[EpochWindow {
-            start_secs: Some(now - 60),
-            end_secs: now + 60,
-        }]);
+        let snap = fs.take_files_matching(
+            &[EpochWindow {
+                start_secs: Some(now - 60),
+                end_secs: now + 60,
+            }],
+            &Default::default(),
+        );
         check!(snap.segments.len() == 1);
         check!(snap.segments[0].seg_ref.index() == 1);
         check!(snap.queued_segments == Some(1));

--- a/dial9-core/src/worker/tests.rs
+++ b/dial9-core/src/worker/tests.rs
@@ -1408,7 +1408,7 @@ mod triggered_test_support {
 mod triggered_worker_tests {
     use super::triggered_test_support::*;
     use crate::dump::{self, DumpError, DumpId, DumpRequest, Lookback};
-    use crate::fs::{EpochWindow, Fs};
+    use crate::fs::{CheckpointGuard, EpochWindow, Fs};
     use crate::pipeline::{ProcessError, ProcessErrorKind, SegmentData, SegmentProcessor};
     use crate::worker::epoch_to_system;
     use assert2::check;
@@ -1467,6 +1467,80 @@ mod triggered_worker_tests {
                 }
             })
         }
+    }
+
+    struct ProtectedRetryProbe {
+        fs: Arc<Fs>,
+        observations: Arc<Mutex<Vec<bool>>>,
+        fail_once: bool,
+    }
+
+    impl SegmentProcessor for ProtectedRetryProbe {
+        fn name(&self) -> &'static str {
+            "ProtectedRetryProbe"
+        }
+
+        fn process(
+            &mut self,
+            data: SegmentData,
+        ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
+            self.observations.lock().unwrap().push(
+                self.fs
+                    .checkpoint_segment_is_protected(data.segment().index()),
+            );
+            let fail = std::mem::take(&mut self.fail_once);
+            Box::pin(async move {
+                if fail {
+                    Err(ProcessError::new(
+                        data,
+                        ProcessErrorKind::Transfer {
+                            source: Box::from("transient"),
+                            retryable: true,
+                        },
+                    ))
+                } else {
+                    Ok(data)
+                }
+            })
+        }
+    }
+
+    async fn assert_checkpoint_stays_protected_across_retry(
+        fs: Arc<Fs>,
+        checkpoint: CheckpointGuard,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let stop = tokio_util::sync::CancellationToken::new();
+        let observations = Arc::new(Mutex::new(Vec::new()));
+        let worker = spawn_worker(
+            Arc::clone(&fs),
+            vec![Box::new(ProtectedRetryProbe {
+                fs: Arc::clone(&fs),
+                observations: Arc::clone(&observations),
+                fail_once: true,
+            })],
+            crate::dump::DumpRx { rx },
+            stop.clone(),
+        );
+
+        let (receipt_tx, receipt_rx) = tokio::sync::oneshot::channel();
+        tx.send(DumpRequest {
+            id: DumpId::new(),
+            triggered_at: std::time::SystemTime::now(),
+            lookback: Lookback::Unbounded,
+            lookforward: Duration::ZERO,
+            metadata: Vec::new(),
+            checkpoint: Some(checkpoint),
+            receipt_tx,
+        })
+        .unwrap();
+
+        check!(receipt_rx.await.unwrap().unwrap().segments_processed == 1);
+        check!(*observations.lock().unwrap() == vec![true, true]);
+        check!(!fs.checkpoint_segment_is_protected(0));
+
+        stop.cancel();
+        worker.await.unwrap();
     }
 
     #[tokio::test(start_paused = true)]
@@ -1596,6 +1670,33 @@ mod triggered_worker_tests {
         let remaining = fs.take_files();
         check!(remaining.segments.len() == 1);
         check!(remaining.segments[0].seg_ref.index() == 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn memory_checkpoint_stays_protected_across_retry() {
+        let fs = Fs::new_in_memory(64 * 1024, 1024).unwrap();
+        seal_mem(&fs, 0, now_epoch());
+
+        let mut checkpoint = crate::fs::CheckpointGuard::reserve(&fs).unwrap();
+        let protected = fs.protect_memory_checkpoint_segments(None);
+        checkpoint.track(protected);
+        assert_checkpoint_stays_protected_across_retry(fs, checkpoint).await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn disk_checkpoint_stays_protected_across_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let fs = Fs::new_disk(dir.path(), "trace");
+        std::fs::write(
+            dir.path().join("trace.0.bin"),
+            segment_with_epoch(now_epoch()),
+        )
+        .unwrap();
+
+        let mut checkpoint = crate::fs::CheckpointGuard::reserve(&fs).unwrap();
+        fs.protect_disk_checkpoint_segments(&[0]);
+        checkpoint.track(vec![0]);
+        assert_checkpoint_stays_protected_across_retry(fs, checkpoint).await;
     }
 
     #[tokio::test(start_paused = true)]

--- a/dial9-core/src/worker/tests.rs
+++ b/dial9-core/src/worker/tests.rs
@@ -1535,31 +1535,17 @@ mod triggered_worker_tests {
 
     #[tokio::test(start_paused = true)]
     async fn checkpoint_uses_exact_snapshot_instead_of_wall_clock_window() {
-        let fs = Fs::new_in_memory(64 * 1024, 1024).unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let fs = Fs::new_disk(dir.path(), "trace");
         let now = now_epoch();
 
         // Model a checkpoint segment whose creation timestamp crossed ahead
         // of the request timestamp, then a post-boundary segment whose clock
         // still falls inside the request's coarse one-second window.
-        seal_mem(&fs, 0, now + 1);
-        check!(fs.try_reserve_checkpoint());
-        let checkpoint_segments = fs.protect_memory_checkpoint_segments(None);
-        check!(checkpoint_segments == vec![0]);
-        seal_mem(&fs, 1, now);
+        std::fs::write(dir.path().join("trace.0.bin"), segment_with_epoch(now + 1)).unwrap();
+        std::fs::write(dir.path().join("trace.1.bin"), segment_with_epoch(now)).unwrap();
 
         let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-        let (receipt_tx, receipt_rx) = tokio::sync::oneshot::channel();
-        tx.send(DumpRequest {
-            id: DumpId::new(),
-            triggered_at: UNIX_EPOCH + Duration::from_secs(now),
-            lookback: Lookback::Unbounded,
-            lookforward: Duration::ZERO,
-            metadata: Vec::new(),
-            checkpoint_segments: Some(checkpoint_segments),
-            receipt_tx,
-        })
-        .unwrap();
-
         let stop = tokio_util::sync::CancellationToken::new();
         let (capture, captured) = CapturingProcessor::new();
         let worker = spawn_worker(
@@ -1568,6 +1554,36 @@ mod triggered_worker_tests {
             crate::dump::DumpRx { rx },
             stop.clone(),
         );
+
+        // Seed the disk epoch cache with both segments as out of range. A
+        // later exact checkpoint must override this cached window decision.
+        let (receipt_tx, receipt_rx) = tokio::sync::oneshot::channel();
+        tx.send(DumpRequest {
+            id: DumpId::new(),
+            triggered_at: UNIX_EPOCH + Duration::from_secs(now - 60),
+            lookback: Lookback::Window(Duration::ZERO),
+            lookforward: Duration::ZERO,
+            metadata: Vec::new(),
+            checkpoint: None,
+            receipt_tx,
+        })
+        .unwrap();
+        check!(receipt_rx.await.unwrap().unwrap().segments_processed == 0);
+
+        let mut checkpoint = crate::fs::CheckpointGuard::reserve(&fs).unwrap();
+        fs.protect_disk_checkpoint_segments(&[0]);
+        checkpoint.track(vec![0]);
+        let (receipt_tx, receipt_rx) = tokio::sync::oneshot::channel();
+        tx.send(DumpRequest {
+            id: DumpId::new(),
+            triggered_at: UNIX_EPOCH + Duration::from_secs(now),
+            lookback: Lookback::Unbounded,
+            lookforward: Duration::ZERO,
+            metadata: Vec::new(),
+            checkpoint: Some(checkpoint),
+            receipt_tx,
+        })
+        .unwrap();
 
         let receipt = receipt_rx.await.unwrap().unwrap();
         check!(receipt.segments_processed == 1);

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -22,7 +22,6 @@ pub use crate::traced::TracedFuture;
 pub use buffer::{BufferMode, Disk, DiskBuffer, Memory, MemoryBuffer, SegmentWriter};
 pub use custom_events::{CustomEventsConfig, CustomEventsContext};
 pub use dial9_core::encoder::{Encodable, ThreadLocalEncoder};
-pub use dial9_core::handle::SegmentRotation;
 pub use dial9_core::recorder::{RecorderBuilder, recorder};
 #[cfg(any(
     feature = "cpu-profiling",

--- a/dial9-tokio-telemetry/src/telemetry/mod.rs
+++ b/dial9-tokio-telemetry/src/telemetry/mod.rs
@@ -22,6 +22,7 @@ pub use crate::traced::TracedFuture;
 pub use buffer::{BufferMode, Disk, DiskBuffer, Memory, MemoryBuffer, SegmentWriter};
 pub use custom_events::{CustomEventsConfig, CustomEventsContext};
 pub use dial9_core::encoder::{Encodable, ThreadLocalEncoder};
+pub use dial9_core::handle::SegmentRotation;
 pub use dial9_core::recorder::{RecorderBuilder, recorder};
 #[cfg(any(
     feature = "cpu-profiling",

--- a/dial9-tokio-telemetry/tests/common.rs
+++ b/dial9-tokio-telemetry/tests/common.rs
@@ -1,14 +1,16 @@
 #![allow(dead_code)]
 use dial9_core::recording::Recorder;
+use dial9_core::source::{FlushContext, Source};
 use dial9_tokio_telemetry::background_task::{ProcessError, SegmentData, SegmentProcessor};
 use dial9_tokio_telemetry::telemetry::{
     Dial9HandleTokioExt, DiskBuffer, MemoryBuffer, TokioAttachOptions,
 };
-use dial9_trace_format::decoder::Decoder;
+use dial9_trace_format::{TraceEvent, decoder::Decoder};
 use serde::de::DeserializeOwned;
 use std::future::Future;
 use std::path::Path;
 use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -22,6 +24,37 @@ pub const SEAL_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 pub const SEAL_POLL_INTERVAL: Duration = Duration::from_millis(50);
 /// Trivial tasks spawned per workload burst; enough to seal a 64-byte segment.
 pub const WORKLOAD_BURST: usize = 200;
+
+#[derive(TraceEvent)]
+struct BoundaryEvent {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+}
+
+/// Test source that emits one event on every flush while armed. Use it to
+/// establish a checkpoint-local data precondition without racing retention of
+/// a segment sealed before the request.
+#[derive(Debug)]
+pub struct ArmedBoundarySource(Arc<AtomicBool>);
+
+impl Source for ArmedBoundarySource {
+    fn flush(&mut self, ctx: &FlushContext<'_>) {
+        if self.0.load(Ordering::Acquire) {
+            ctx.record_event(&BoundaryEvent {
+                timestamp_ns: dial9_tokio_telemetry::telemetry::clock_monotonic_ns(),
+            });
+        }
+    }
+
+    fn name(&self) -> &'static str {
+        "armed-boundary"
+    }
+}
+
+pub fn armed_boundary_source() -> (ArmedBoundarySource, Arc<AtomicBool>) {
+    let armed = Arc::new(AtomicBool::new(false));
+    (ArmedBoundarySource(Arc::clone(&armed)), armed)
+}
 
 /// Attach a multi-thread runtime with `workers` workers to `recorder`.
 pub fn attach(

--- a/dial9-tokio-telemetry/tests/dump_trigger.rs
+++ b/dial9-tokio-telemetry/tests/dump_trigger.rs
@@ -27,10 +27,10 @@ fn with_dump_trigger_compiles_in_all_pipeline_states() {
         .with_dump_trigger(|_| {});
 }
 
-/// A trigger without a configured pipeline never spawns the worker; the
-/// receiver is dropped and every dump resolves `WorkerStopped`.
+/// A current-data trigger without processing stages still checkpoints and
+/// resolves. Its internal retain stage leaves the raw segment on disk.
 #[test]
-fn trigger_without_pipeline_resolves_worker_stopped() {
+fn trigger_without_pipeline_retains_raw_segment() {
     let dir = tempfile::tempdir().unwrap();
     let trace_path = dir.path().join("trace.bin");
 
@@ -41,22 +41,20 @@ fn trigger_without_pipeline_resolves_worker_stopped() {
 
     let trigger = recorder.handle().dump_trigger().expect("trigger wired");
 
-    let err = rt
+    let receipt = rt
         .block_on(async { trigger.dump_current_data().await })
-        .expect_err("no worker, dump must fail");
-    assert!(matches!(err, DumpError::WorkerStopped));
+        .expect("checkpoint-only dump should succeed");
+    assert!(receipt.manifest_key.is_none());
 
     drop(rt);
     drop(recorder);
 }
 
-/// Two `dump_current_data()` calls fired concurrently both succeed with
-/// distinct dump ids and at least one captures the ring. Per-dump fan-out (a
-/// segment captured by every overlapping window) is covered by the worker
-/// unit tests; this pins the end-to-end answer to "what happens if two dumps
-/// are triggered at once": they run independently, no coordination.
+/// Concurrent current-data dumps never build an unbounded checkpoint backlog.
+/// Depending on whether the flush thread consumes the first command before the
+/// second is submitted, both may succeed or one may report a busy checkpoint.
 #[test]
-fn concurrent_dumps_both_resolve_with_distinct_ids() {
+fn concurrent_current_data_dumps_are_bounded() {
     use std::time::Duration;
 
     let dir = tempfile::tempdir().unwrap();
@@ -84,16 +82,33 @@ fn concurrent_dumps_both_resolve_with_distinct_ids() {
         )
     });
 
-    let first = first.expect("first dump resolves");
-    let second = second.expect("second dump resolves");
-    assert_ne!(
-        first.dump_id, second.dump_id,
-        "concurrent dumps get distinct ids"
-    );
+    let outcomes = [first, second];
+    let successful: Vec<_> = outcomes
+        .iter()
+        .filter_map(|outcome| outcome.as_ref().ok())
+        .collect();
     assert!(
-        first.segments_processed + second.segments_processed > 0,
-        "at least one concurrent dump captured the ring"
+        !successful.is_empty(),
+        "the single available control slot accepts at least one dump"
     );
+    if successful.len() == 2 {
+        assert_ne!(
+            successful[0].dump_id, successful[1].dump_id,
+            "accepted concurrent dumps get distinct ids"
+        );
+    }
+    for outcome in outcomes {
+        if let Err(error) = outcome {
+            assert!(
+                matches!(
+                    error,
+                    DumpError::Checkpoint(ref error)
+                        if error.kind() == std::io::ErrorKind::WouldBlock
+                ),
+                "a rejected concurrent dump reports bounded backpressure: {error}"
+            );
+        }
+    }
 
     drop(rt);
     drop(recorder);

--- a/dial9-tokio-telemetry/tests/dump_trigger.rs
+++ b/dial9-tokio-telemetry/tests/dump_trigger.rs
@@ -31,13 +31,26 @@ fn with_dump_trigger_compiles_in_all_pipeline_states() {
 /// resolves. Its internal retain stage leaves the raw segment on disk.
 #[test]
 fn trigger_without_pipeline_retains_raw_segment() {
-    let dir = tempfile::tempdir().unwrap();
-    let trace_path = dir.path().join("trace.bin");
+    #[derive(dial9_trace_format::TraceEvent)]
+    struct CheckpointEvent {
+        #[traceevent(timestamp)]
+        timestamp_ns: u64,
+    }
 
-    let writer = DiskBuffer::single_file(&trace_path).unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let writer = DiskBuffer::builder()
+        .base_path(dir.path())
+        .max_file_size(1024 * 1024)
+        .max_total_size(8 * 1024 * 1024)
+        .rotation_period(std::time::Duration::MAX)
+        .build()
+        .unwrap();
 
     let recorder = recorder(writer).with_dump_trigger(|_| {}).build();
     let rt = common::attach(&recorder, 1, TokioAttachOptions::default());
+    recorder.handle().record_event(CheckpointEvent {
+        timestamp_ns: dial9_tokio_telemetry::telemetry::clock_monotonic_ns(),
+    });
 
     let trigger = recorder.handle().dump_trigger().expect("trigger wired");
 
@@ -45,6 +58,10 @@ fn trigger_without_pipeline_retains_raw_segment() {
         .block_on(async { trigger.dump_current_data().await })
         .expect("checkpoint-only dump should succeed");
     assert!(receipt.manifest_key.is_none());
+    assert!(
+        dir.path().join("trace.0.bin").exists(),
+        "the internal retain stage leaves the raw checkpoint on disk"
+    );
 
     drop(rt);
     drop(recorder);

--- a/dial9-tokio-telemetry/tests/on_trigger_dump.rs
+++ b/dial9-tokio-telemetry/tests/on_trigger_dump.rs
@@ -6,7 +6,7 @@
 mod common;
 mod fake_s3;
 
-use common::{drive_workload, fast_sealing_writer, wait_for_sealed_segment};
+use common::{fast_sealing_writer, wait_for_sealed_segment};
 use dial9_destinations_s3::S3Config;
 use dial9_tokio_telemetry::telemetry::{
     DiskBuffer, RecorderPipelineExt, TokioAttachOptions, recorder,
@@ -259,11 +259,40 @@ fn lookforward_dump_resolves_after_deadline() {
 /// manifest (`manifest_key` is `None`).
 #[test]
 fn off_s3_pipeline_dumps_without_manifest() {
+    use dial9_core::source::{FlushContext, Source};
+    use dial9_trace_format::TraceEvent;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[derive(TraceEvent)]
+    struct BoundaryEvent {
+        #[traceevent(timestamp)]
+        timestamp_ns: u64,
+    }
+
+    struct ArmedBoundarySource(Arc<AtomicBool>);
+
+    impl Source for ArmedBoundarySource {
+        fn flush(&mut self, ctx: &FlushContext<'_>) {
+            if self.0.load(Ordering::Acquire) {
+                ctx.record_event(&BoundaryEvent {
+                    timestamp_ns: dial9_tokio_telemetry::telemetry::clock_monotonic_ns(),
+                });
+            }
+        }
+
+        fn name(&self) -> &'static str {
+            "armed-boundary"
+        }
+    }
+
     let trace_dir = tempfile::tempdir().unwrap();
+    let armed = Arc::new(AtomicBool::new(false));
 
     let writer = fast_sealing_writer(trace_dir.path());
 
     let recorder = recorder(writer)
+        .source(ArmedBoundarySource(Arc::clone(&armed)))
         .worker_poll_interval(Duration::from_millis(50))
         .with_custom_pipeline(|p| p.gzip().write_back())
         .with_dump_trigger(|_| {})
@@ -271,13 +300,16 @@ fn off_s3_pipeline_dumps_without_manifest() {
     let rt = common::attach(&recorder, 1, TokioAttachOptions::default());
 
     let trigger = recorder.handle().dump_trigger().expect("trigger wired");
-
-    wait_for_sealed_segment(&rt, trace_dir.path());
+    // Make the checkpoint's own source sample establish the test precondition:
+    // data exists at the requested boundary. Waiting for a previously sealed
+    // file would race ordinary ring retention before the request is made.
+    armed.store(true, Ordering::Release);
 
     let check_rt = assertion_runtime();
     let receipt = check_rt
         .block_on(async { trigger.dump_current_data().await })
         .unwrap();
+    armed.store(false, Ordering::Release);
     assert!(receipt.segments_processed >= 1);
     assert!(receipt.manifest_key.is_none(), "no manifest off S3");
 
@@ -311,7 +343,7 @@ fn shutdown_truncates_open_lookforward_dump() {
 
     let recorder = recorder(writer)
         .worker_poll_interval(Duration::from_millis(50))
-        .with_custom_pipeline(|p| p.gzip().s3_with_client(test_s3_config(), client))
+        .with_custom_pipeline(|p| p.gzip().s3_with_client(test_s3_config(), client.clone()))
         .with_dump_trigger(|_| {})
         .build();
     let rt = common::attach(&recorder, 1, TokioAttachOptions::default());
@@ -322,7 +354,11 @@ fn shutdown_truncates_open_lookforward_dump() {
     let fut = trigger
         .dump_time_range(Duration::from_secs(1), Duration::from_secs(3600))
         .into_future();
-    drive_workload(&rt);
+
+    // Establish the condition asserted below before initiating shutdown.
+    // Uploaded objects persist, unlike local files that the worker removes,
+    // so this does not race pipeline cleanup.
+    wait_for_uploaded_segment(&rt, &client, "test-bucket");
 
     drop(rt);
     recorder.graceful_shutdown(Duration::from_secs(2));

--- a/dial9-tokio-telemetry/tests/on_trigger_dump.rs
+++ b/dial9-tokio-telemetry/tests/on_trigger_dump.rs
@@ -6,7 +6,7 @@
 mod common;
 mod fake_s3;
 
-use common::{fast_sealing_writer, wait_for_sealed_segment};
+use common::{armed_boundary_source, fast_sealing_writer, wait_for_sealed_segment};
 use dial9_destinations_s3::S3Config;
 use dial9_tokio_telemetry::telemetry::{
     DiskBuffer, RecorderPipelineExt, TokioAttachOptions, recorder,
@@ -259,40 +259,13 @@ fn lookforward_dump_resolves_after_deadline() {
 /// manifest (`manifest_key` is `None`).
 #[test]
 fn off_s3_pipeline_dumps_without_manifest() {
-    use dial9_core::source::{FlushContext, Source};
-    use dial9_trace_format::TraceEvent;
-    use std::sync::Arc;
-    use std::sync::atomic::{AtomicBool, Ordering};
-
-    #[derive(TraceEvent)]
-    struct BoundaryEvent {
-        #[traceevent(timestamp)]
-        timestamp_ns: u64,
-    }
-
-    struct ArmedBoundarySource(Arc<AtomicBool>);
-
-    impl Source for ArmedBoundarySource {
-        fn flush(&mut self, ctx: &FlushContext<'_>) {
-            if self.0.load(Ordering::Acquire) {
-                ctx.record_event(&BoundaryEvent {
-                    timestamp_ns: dial9_tokio_telemetry::telemetry::clock_monotonic_ns(),
-                });
-            }
-        }
-
-        fn name(&self) -> &'static str {
-            "armed-boundary"
-        }
-    }
-
     let trace_dir = tempfile::tempdir().unwrap();
-    let armed = Arc::new(AtomicBool::new(false));
+    let (boundary_source, armed) = armed_boundary_source();
 
     let writer = fast_sealing_writer(trace_dir.path());
 
     let recorder = recorder(writer)
-        .source(ArmedBoundarySource(Arc::clone(&armed)))
+        .source(boundary_source)
         .worker_poll_interval(Duration::from_millis(50))
         .with_custom_pipeline(|p| p.gzip().write_back())
         .with_dump_trigger(|_| {})
@@ -303,13 +276,13 @@ fn off_s3_pipeline_dumps_without_manifest() {
     // Make the checkpoint's own source sample establish the test precondition:
     // data exists at the requested boundary. Waiting for a previously sealed
     // file would race ordinary ring retention before the request is made.
-    armed.store(true, Ordering::Release);
+    armed.store(true, std::sync::atomic::Ordering::Release);
 
     let check_rt = assertion_runtime();
     let receipt = check_rt
         .block_on(async { trigger.dump_current_data().await })
         .unwrap();
-    armed.store(false, Ordering::Release);
+    armed.store(false, std::sync::atomic::Ordering::Release);
     assert!(receipt.segments_processed >= 1);
     assert!(receipt.manifest_key.is_none(), "no manifest off S3");
 

--- a/dial9-tokio-telemetry/tests/s3_integration.rs
+++ b/dial9-tokio-telemetry/tests/s3_integration.rs
@@ -98,6 +98,9 @@ fn client_future_runs_once_when_pipeline_starts() {
             future_calls_inner.fetch_add(1, Ordering::SeqCst);
             client_for_future
         })
+        // Keep this dump deliberately empty: current-data dumps now flush and
+        // seal in-flight recorder data before dispatching the pipeline.
+        .paused()
         .with_dump_trigger(|_| {})
         .build();
     let rt = common::attach(&recorder, 1, TokioAttachOptions::default());

--- a/dial9-tokio-telemetry/tests/s3_integration.rs
+++ b/dial9-tokio-telemetry/tests/s3_integration.rs
@@ -985,14 +985,15 @@ fn dump_trigger_uploads_segments_and_writes_manifest() {
         "triggered mode must not upload until a dump is requested"
     );
 
-    // A triggered worker parks until a dump is requested, so a confirmed-sealed
-    // segment persists and the unbounded `dump_current_data` window is
-    // guaranteed to match it.
+    // End this bounded workload at the checkpoint. Closing the recording gate
+    // on the flush thread prevents a slow runner from producing enough
+    // post-boundary telemetry to evict the snapshot before the worker claims
+    // it.
     wait_for_sealed_segment(&rt, trace_dir.path());
 
     let receipt = rt.block_on(async {
         trigger
-            .dump_current_data()
+            .stop_recording_and_dump_current_data()
             .with_metadata("reason", "test")
             .await
             .expect("dump resolves")

--- a/dial9-tokio-telemetry/tests/s3_integration.rs
+++ b/dial9-tokio-telemetry/tests/s3_integration.rs
@@ -6,11 +6,13 @@ mod fake_s3;
 
 use aws_config::Region;
 use aws_sdk_s3::Client;
-use common::{fast_sealing_writer, wait_for_sealed_segment};
+use common::fast_sealing_writer;
+use dial9_core::source::{FlushContext, Source};
 use dial9_destinations_s3::S3Config;
 use dial9_tokio_telemetry::telemetry::{
     DiskBuffer, RecorderPipelineExt, RecorderS3ClientExt, TokioAttachOptions, recorder, spawn,
 };
+use dial9_trace_format::TraceEvent;
 use fake_s3::{
     fake_s3_client, fake_s3_client_always_failing, fake_s3_client_flaky, fake_s3_client_hanging,
     fake_s3_client_with_region,
@@ -19,7 +21,7 @@ use flate2::read::GzDecoder;
 use std::collections::HashMap;
 use std::io::Read;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Duration;
 
 /// Create a dummy S3 config + client for tests.
@@ -933,8 +935,31 @@ fn permanently_broken_s3_produces_failure_metrics() {
 /// `end_to_end_trace_to_s3_roundtrip` but on the on-demand path.
 #[test]
 fn dump_trigger_uploads_segments_and_writes_manifest() {
+    #[derive(TraceEvent)]
+    struct BoundaryEvent {
+        #[traceevent(timestamp)]
+        timestamp_ns: u64,
+    }
+
+    struct ArmedBoundarySource(Arc<AtomicBool>);
+
+    impl Source for ArmedBoundarySource {
+        fn flush(&mut self, ctx: &FlushContext<'_>) {
+            if self.0.load(Ordering::Acquire) {
+                ctx.record_event(&BoundaryEvent {
+                    timestamp_ns: dial9_tokio_telemetry::telemetry::clock_monotonic_ns(),
+                });
+            }
+        }
+
+        fn name(&self) -> &'static str {
+            "armed-boundary"
+        }
+    }
+
     let s3_root = tempfile::tempdir().unwrap();
     let trace_dir = tempfile::tempdir().unwrap();
+    let armed = Arc::new(AtomicBool::new(false));
 
     std::fs::create_dir(s3_root.path().join("dump-bucket")).unwrap();
     let client = fake_s3_client(s3_root.path());
@@ -950,6 +975,7 @@ fn dump_trigger_uploads_segments_and_writes_manifest() {
         .build();
 
     let recorder = recorder(writer)
+        .source(ArmedBoundarySource(Arc::clone(&armed)))
         .worker_poll_interval(Duration::from_millis(50))
         .with_s3_uploader_client(s3_config.clone(), client.clone())
         .with_dump_trigger(|_| {})
@@ -985,11 +1011,10 @@ fn dump_trigger_uploads_segments_and_writes_manifest() {
         "triggered mode must not upload until a dump is requested"
     );
 
-    // End this bounded workload at the checkpoint. Closing the recording gate
-    // on the flush thread prevents a slow runner from producing enough
-    // post-boundary telemetry to evict the snapshot before the worker claims
-    // it.
-    wait_for_sealed_segment(&rt, trace_dir.path());
+    // Guarantee that the capture boundary itself contains data. Waiting for a
+    // previously sealed file is racy under a busy runner: queued telemetry can
+    // keep rotating and evict that file before the checkpoint is established.
+    armed.store(true, Ordering::Release);
 
     let receipt = rt.block_on(async {
         trigger
@@ -998,6 +1023,7 @@ fn dump_trigger_uploads_segments_and_writes_manifest() {
             .await
             .expect("dump resolves")
     });
+    armed.store(false, Ordering::Release);
 
     assert!(
         receipt.segments_processed > 0,

--- a/dial9-tokio-telemetry/tests/s3_integration.rs
+++ b/dial9-tokio-telemetry/tests/s3_integration.rs
@@ -6,13 +6,11 @@ mod fake_s3;
 
 use aws_config::Region;
 use aws_sdk_s3::Client;
-use common::fast_sealing_writer;
-use dial9_core::source::{FlushContext, Source};
+use common::{armed_boundary_source, fast_sealing_writer};
 use dial9_destinations_s3::S3Config;
 use dial9_tokio_telemetry::telemetry::{
     DiskBuffer, RecorderPipelineExt, RecorderS3ClientExt, TokioAttachOptions, recorder, spawn,
 };
-use dial9_trace_format::TraceEvent;
 use fake_s3::{
     fake_s3_client, fake_s3_client_always_failing, fake_s3_client_flaky, fake_s3_client_hanging,
     fake_s3_client_with_region,
@@ -21,7 +19,7 @@ use flate2::read::GzDecoder;
 use std::collections::HashMap;
 use std::io::Read;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 /// Create a dummy S3 config + client for tests.
@@ -935,31 +933,9 @@ fn permanently_broken_s3_produces_failure_metrics() {
 /// `end_to_end_trace_to_s3_roundtrip` but on the on-demand path.
 #[test]
 fn dump_trigger_uploads_segments_and_writes_manifest() {
-    #[derive(TraceEvent)]
-    struct BoundaryEvent {
-        #[traceevent(timestamp)]
-        timestamp_ns: u64,
-    }
-
-    struct ArmedBoundarySource(Arc<AtomicBool>);
-
-    impl Source for ArmedBoundarySource {
-        fn flush(&mut self, ctx: &FlushContext<'_>) {
-            if self.0.load(Ordering::Acquire) {
-                ctx.record_event(&BoundaryEvent {
-                    timestamp_ns: dial9_tokio_telemetry::telemetry::clock_monotonic_ns(),
-                });
-            }
-        }
-
-        fn name(&self) -> &'static str {
-            "armed-boundary"
-        }
-    }
-
     let s3_root = tempfile::tempdir().unwrap();
     let trace_dir = tempfile::tempdir().unwrap();
-    let armed = Arc::new(AtomicBool::new(false));
+    let (boundary_source, armed) = armed_boundary_source();
 
     std::fs::create_dir(s3_root.path().join("dump-bucket")).unwrap();
     let client = fake_s3_client(s3_root.path());
@@ -975,7 +951,7 @@ fn dump_trigger_uploads_segments_and_writes_manifest() {
         .build();
 
     let recorder = recorder(writer)
-        .source(ArmedBoundarySource(Arc::clone(&armed)))
+        .source(boundary_source)
         .worker_poll_interval(Duration::from_millis(50))
         .with_s3_uploader_client(s3_config.clone(), client.clone())
         .with_dump_trigger(|_| {})

--- a/dial9/src/lib.rs
+++ b/dial9/src/lib.rs
@@ -3,7 +3,7 @@
 
 // Core recording API
 pub use dial9_core::buffer::{Disk, DiskBuffer, Memory, MemoryBuffer};
-pub use dial9_core::handle::{Dial9Handle, InstallGlobalHandleError};
+pub use dial9_core::handle::{Dial9Handle, InstallGlobalHandleError, SegmentRotation};
 pub use dial9_core::recorder::{
     RecorderBuilder, RecorderSourceExt, recorder, recorder_disabled, recorder_or_disabled,
 };

--- a/dial9/src/lib.rs
+++ b/dial9/src/lib.rs
@@ -3,7 +3,7 @@
 
 // Core recording API
 pub use dial9_core::buffer::{Disk, DiskBuffer, Memory, MemoryBuffer};
-pub use dial9_core::handle::{Dial9Handle, InstallGlobalHandleError, SegmentRotation};
+pub use dial9_core::handle::{Dial9Handle, InstallGlobalHandleError};
 pub use dial9_core::recorder::{
     RecorderBuilder, RecorderSourceExt, recorder, recorder_disabled, recorder_or_disabled,
 };

--- a/docs/design/on-trigger-pipeline-runs.md
+++ b/docs/design/on-trigger-pipeline-runs.md
@@ -61,9 +61,11 @@ async fn main() {
 ```
 
 `dump_trigger()` returns `Some` only when the runtime was built with
-`with_dump_trigger`; in continuous mode it returns `None`. If no pipeline is
-configured the worker never spawns and every dump resolves
-`DumpError::WorkerStopped`.
+`with_dump_trigger`; in continuous mode it returns `None`. A triggered disk
+recorder with no explicit pipeline gets an internal retain stage so
+current-data checkpoints can complete while leaving their raw segments in
+place. A memory recorder with no pipeline has no consumer: current-data dumps
+resolve `DumpError::WorkerStopped` and the sealed segment remains in the ring.
 
 ## Requesting a dump
 
@@ -135,7 +137,7 @@ match trigger.dump_current_data().with_metadata("reason", "idle-drop").await {
     Err(DumpError::Coalesced { into }) => {
         // A near-simultaneous trip already covers this; `into` is its id.
     }
-    Err(e) => { /* WorkerStopped or Pipeline */ }
+    Err(e) => { /* WorkerStopped, Checkpoint, or Pipeline */ }
 }
 ```
 
@@ -200,10 +202,19 @@ approach points at the files instead of moving them.
 
 ## Best-effort semantics
 
-Both sides of a dump are strictly best-effort. There is no ring resizing, no
-segment pinning, and no duplication of buffered data. If the requested window
-cannot be fully covered, the dump gets whatever survived and the application
-keeps running.
+Time-range dumps are strictly best-effort. There is no ring resizing, segment
+pinning, or duplication of buffered data for their look-back and look-forward
+windows. If the requested window cannot be fully covered, the dump gets
+whatever survived and the application keeps running.
+
+`dump_current_data` and `stop_recording_and_dump_current_data` establish a
+stronger boundary. The flush thread reserves the sole current-data checkpoint,
+drains registered thread-local buffers, protects the exact retained snapshot
+from eviction, and rotates a non-empty active segment before dispatch. The
+protection lasts through retries and is released at a terminal pipeline
+outcome. These operations therefore require a rotating buffer; a non-empty
+`DiskBuffer::single_file` request resolves `DumpError::Checkpoint` with
+`ErrorKind::Unsupported` rather than changing the single-file layout.
 
 The look-back is bounded by what the ring retained. The ring keeps only what
 `max_total_size` lets it keep, so a `lookback` wider than the retained history
@@ -223,8 +234,8 @@ window; it is the same seal/pop/upload path, gated by a deadline.
 
 A dump that captures some segments while others fail terminally still resolves
 `Ok`; `receipt.segments_processed` counts only the survivors. `Err` is reserved
-for `WorkerStopped`, `Coalesced`, and total `Pipeline` failure (every captured
-segment failed and nothing landed).
+for `WorkerStopped`, current-data `Checkpoint` failures, `Coalesced`, and total
+`Pipeline` failure (every captured segment failed and nothing landed).
 
 ## Custom pipelines
 
@@ -329,11 +340,12 @@ channel they already use (incidents-table row, Slack message, etc.).
 
 ## What the library does for you
 
-When you call `dump_current_data` or `dump_time_range`, the trigger mints a
-`DumpId`, packs the look-back and look-forward (either may be zero) and any
-`with_metadata` entries into a request, and (on drop/await) forwards it to the
-worker over the trigger channel. Awaiting the returned run is optional and only
-retrieves the receipt.
+Every request mints a `DumpId` and packs its window plus any `with_metadata`
+entries when the run is dropped or awaited. Time-range requests go directly to
+the worker. Recorder-bound current-data requests go through the bounded flush
+control channel first so it can establish the exact checkpoint described
+above, then the flush thread dispatches them to the worker. Awaiting the
+returned run is optional and only retrieves the receipt.
 
 The worker stamps the following onto each captured segment's metadata before
 the pipeline runs:
@@ -393,6 +405,12 @@ With a trigger set, the same loop selects on:
 - `self.fs.writer_done` (existing, used to start drain-to-empty)
 - the new trigger receiver populated by `DumpTrigger`
 - a deadline branch for the nearest open forward window
+
+Recorder-bound current-data requests first pass through the flush thread. It
+creates and temporarily protects an exact segment snapshot, then hands the
+request and its lease to the worker. At most one such snapshot may be active;
+an overlapping request reports bounded `WouldBlock` backpressure. Ordinary
+time-range requests continue to enter the worker directly and do not pin data.
 
 It does not call `take_files` between triggers. When a request arrives, it
 registers the dump with its window `[trigger - lookback, trigger +
@@ -457,6 +475,10 @@ impl DumpTrigger {
     /// Capture everything the ring still holds, right now. No forward window.
     pub fn dump_current_data(&self) -> DumpRun<'_>;
 
+    /// Close the recording gate after one final source sample, then capture
+    /// everything accumulated through that boundary. Never debounced.
+    pub fn stop_recording_and_dump_current_data(&self) -> DumpRun<'_>;
+
     /// Capture the window `[trigger - lookback, trigger + lookforward]`. Either
     /// side may be `Duration::ZERO`. Never errors and never resizes or pins the
     /// ring; the actual covered span is reported on `DumpReceipt::time_range`.
@@ -505,6 +527,9 @@ pub struct DumpReceipt {
 pub enum DumpError {
     /// The worker is shutting down or already stopped.
     WorkerStopped,
+    /// The flush thread could not reserve, drain, or seal a current-data
+    /// checkpoint. The wrapped kind includes `WouldBlock` and `Unsupported`.
+    Checkpoint(std::io::Error),
     /// Every captured segment failed in a pipeline stage (total failure).
     Pipeline(ProcessErrorKind),
     /// The trigger was coalesced into an in-flight dump by the debounce gate.


### PR DESCRIPTION
## Summary

- integrate current-data checkpoints with recorder-installed dump triggers instead of adding a separate segment-rotation API
- make `DumpTrigger::dump_current_data()` synchronize in-flight writers, drain thread-local and flush-thread buffers, seal the active fragment, and dispatch that stable snapshot while recording continues in a fresh segment
- add `stop_recording_and_dump_current_data()` as the preferred bounded-capture endpoint: it takes one final source sample, closes the recording gate on the flush thread, drains in-flight events, and checkpoints the result
- keep the checkpoint control path bounded: the single-slot queue and single active checkpoint reservation return `WouldBlock` instead of allowing an unbounded backlog
- arm debounce only after a dump is accepted and, for recorder checkpoints, after snapshot reservation succeeds, so `WouldBlock` and disconnected dispatches do not suppress later retries
- protect current-data checkpoint segments from ring eviction until each segment reaches a terminal pipeline outcome, retaining protection across retryable disk and memory failures; disk mode restores the configured retention budget after success, terminal failure, panic, or a protection release after the flush thread has shut down, while memory mode bounds temporary overshoot to the protected snapshot plus the newly sealed checkpoint segment
- own the checkpoint reservation and protected segment set with one drop guard, so construction failures, failed dispatch, queued shutdown, and normal resolution all use the same cleanup path
- match recorder checkpoints by their exact protected segment snapshot rather than coarse wall-clock windows, preventing both boundary-crossing omissions and post-boundary inclusion even when a disk segment was previously cached as out of range
- preserve the existing memory-ring floor that keeps a lone oversized segment while sharing one eviction routine between sealing and checkpoint cleanup
- document that `dump_time_range()` remains best-effort and does not pin segments
- install the terminal `RetainProcessor` only for disk-backed on-trigger mode with no processing stages, so a checkpoint can be acknowledged without rewriting or deleting its raw segment; memory mode keeps its ring intact and reports `WorkerStopped` when no consumer is configured
- preserve `DiskBuffer::single_file` as a true no-rotation mode by rejecting non-empty current-data checkpoints with `Unsupported`
- preserve standalone `dump::channel()` behavior, keep the writer retryable after a strict pre-seal flush failure, and dispatch an already-sealed checkpoint even when opening its replacement writer fails
- count only events actually written through the enabled-gate encoder path, share its encode/flush body with the ordinary path, and pair producer epoch publication with an acquire read before the flush thread skips a busy buffer
- gate dump-trigger test fixtures on the `pipeline` feature so featureless `dial9-core` builds do not compile pipeline-only APIs
- harden checkpoint fixtures against expected concurrency: the S3 bounded capture emits a dedicated event in the final source sample, the retention-budget assertion tolerates a file disappearing during the cleanup pass it is observing, and the shared boundary source removes duplicate setup

If recording was disabled before `dump_current_data()`, sources are deliberately not sampled because a source flush could pull post-boundary state into the capture. Source-owned pre-disable data may remain buffered; callers ending a bounded capture should use `stop_recording_and_dump_current_data()`.

No trace wire-format changes are included.

## Retention and concurrency

A recorder-installed current-data dump establishes its boundary on the flush thread, then holds an eviction reservation until the worker has claimed and processed every checkpoint segment. Only one protected checkpoint may be active. This prevents the checkpoint rotation itself from evicting the snapshot it was created to preserve.

Time-range dumps retain their existing semantics: lookback/lookforward coverage is best-effort, and matching segments can be evicted while the request is pending or processing.

## Validation

Current rebased PR branch:

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p dial9-core --no-default-features`
- `cargo check -p dial9-core --all-features`
- `cargo clippy --all-targets --features __nonlinux_all_features -- -D warnings` (FreeBSD)
- `cargo test -p dial9-core --all-features` — 250 passed; doc tests passed
- `cargo nextest run` — 1,357 passed
- `cargo nextest run --stress-duration 20s` — one complete 1,357-test iteration passed
- `./scripts/test-shuttle.sh` — 25 passed, 1 intentionally ignored
- focused integration regression: disk no-pipeline current-data checkpoint retains its raw segment
