### PR TITLE
feat: improve FreeBSD runtime telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,9 @@ jobs:
             . "$HOME/.cargo/env"
             freebsd-version
             rustc --version
-            cargo test -p dial9-core --all-features \
+            cargo test -p dial9-core \
               freebsd_tid_matches_kernel_thread_id
             cargo test -p dial9-tokio-telemetry \
-              --features __nonlinux_all_features \
               --test park_unpark_tid \
               --test process_resource_usage
             cargo test -p dial9-perf-self-profile \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
   freebsd:
     name: FreeBSD 15.1
     runs-on: ubuntu-latest
-    timeout-minutes: 75
+    continue-on-error: true
+    timeout-minutes: 30
     env:
       RUST_BACKTRACE: 1
       RUSTFLAGS: "--cfg tokio_unstable -C force-frame-pointers=yes"
@@ -82,22 +83,22 @@ jobs:
           cache-after-prepare: true
           envs: "RUST_BACKTRACE RUSTFLAGS"
           prepare: |
-            pkg install -y node24 rustup-init
+            pkg install -y rustup-init
             rustup-init -y --profile minimal --default-toolchain "${{ env.STABLE_TOOLCHAIN }}"
             . "$HOME/.cargo/env"
-            rustup component add clippy
           run: |
             . "$HOME/.cargo/env"
             freebsd-version
             rustc --version
-            cargo test -p dial9-core --all-features
-            cargo test -p dial9-tokio-telemetry --features __nonlinux_all_features
+            cargo test -p dial9-core --all-features \
+              freebsd_tid_matches_kernel_thread_id
+            cargo test -p dial9-tokio-telemetry \
+              --features __nonlinux_all_features \
+              --test park_unpark_tid \
+              --test process_resource_usage
             cargo test -p dial9-perf-self-profile \
               --features "process-resource test-util" \
               process_resource
-            cargo clippy --all-targets \
-              --features __nonlinux_all_features \
-              -- -D warnings
 
   windows-cli-check:
     name: Windows CLI check
@@ -497,7 +498,7 @@ jobs:
   ci-pass:
     name: CI Pass
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, build, freebsd, android-aarch64-build, feature-check, no-tokio-unstable, check-docs, trace-integrity, ui, asan, ecs-sim, shuttle, package, doctests]
+    needs: [fmt, clippy, build, android-aarch64-build, feature-check, no-tokio-unstable, check-docs, trace-integrity, ui, asan, ecs-sim, shuttle, package, doctests]
     if: always()
     steps:
       - run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,41 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+  freebsd:
+    name: FreeBSD 15.1
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    env:
+      RUST_BACKTRACE: 1
+      RUSTFLAGS: "--cfg tokio_unstable -C force-frame-pointers=yes"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Build and test in FreeBSD
+        uses: vmactions/freebsd-vm@77ed28d336d03fe19a3f4f7266c1d2c4714dd79d # v1.5.2
+        with:
+          release: "15.1"
+          usesh: true
+          copyback: false
+          cache-after-prepare: true
+          envs: "RUST_BACKTRACE RUSTFLAGS"
+          prepare: |
+            pkg install -y node24 rustup-init
+            rustup-init -y --profile minimal --default-toolchain "${{ env.STABLE_TOOLCHAIN }}"
+            . "$HOME/.cargo/env"
+            rustup component add clippy
+          run: |
+            . "$HOME/.cargo/env"
+            freebsd-version
+            rustc --version
+            cargo test -p dial9-core --all-features
+            cargo test -p dial9-tokio-telemetry --features __nonlinux_all_features
+            cargo test -p dial9-perf-self-profile \
+              --features "process-resource test-util" \
+              process_resource
+            cargo clippy --all-targets \
+              --features __nonlinux_all_features \
+              -- -D warnings
+
   windows-cli-check:
     name: Windows CLI check
     runs-on: windows-latest
@@ -462,7 +497,7 @@ jobs:
   ci-pass:
     name: CI Pass
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, build, android-aarch64-build, feature-check, no-tokio-unstable, check-docs, trace-integrity, ui, asan, ecs-sim, shuttle, package, doctests]
+    needs: [fmt, clippy, build, freebsd, android-aarch64-build, feature-check, no-tokio-unstable, check-docs, trace-integrity, ui, asan, ecs-sim, shuttle, package, doctests]
     if: always()
     steps:
       - run: |

--- a/dial9-core/src/thread.rs
+++ b/dial9-core/src/thread.rs
@@ -54,10 +54,10 @@ impl Drop for ThreadTrackingGuard {
 
 /// OS thread ID (tid) of the calling thread.
 ///
-/// `gettid()` on Linux/Android (a vDSO/syscall); a stable per-thread counter
-/// elsewhere. Allocation-free, so it is safe to call from the allocator hook.
-/// On hot paths prefer [`cached_tid`], which pays the syscall once per
-/// thread.
+/// `gettid()` on Linux/Android, `pthread_getthreadid_np()` on FreeBSD, and a
+/// stable per-thread counter elsewhere. Allocation-free, so it is safe to call
+/// from the allocator hook. On hot paths prefer [`cached_tid`], which pays the
+/// syscall once per thread.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 pub fn current_tid() -> u32 {
     // SAFETY: gettid takes no args and only returns the caller's tid.
@@ -85,7 +85,14 @@ pub fn cached_tid() -> u32 {
     })
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[cfg(target_os = "freebsd")]
+pub fn current_tid() -> u32 {
+    // SAFETY: pthread_getthreadid_np takes no arguments and returns the
+    // calling kernel thread's id.
+    unsafe { libc::pthread_getthreadid_np() as u32 }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd")))]
 pub fn current_tid() -> u32 {
     use std::sync::atomic::{AtomicU32, Ordering};
     static NEXT: AtomicU32 = AtomicU32::new(1);
@@ -117,6 +124,14 @@ mod tests {
     use crate::source::{FlushContext, Source};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[cfg(target_os = "freebsd")]
+    #[test]
+    fn freebsd_tid_matches_kernel_thread_id() {
+        // SAFETY: pthread_getthreadid_np has no preconditions.
+        let expected = unsafe { libc::pthread_getthreadid_np() as u32 };
+        assert_eq!(current_tid(), expected);
+    }
 
     #[derive(Default)]
     struct Counts {

--- a/dial9-tokio-telemetry/src/telemetry/format.rs
+++ b/dial9-tokio-telemetry/src/telemetry/format.rs
@@ -110,8 +110,9 @@ pub struct WorkerParkEvent {
     pub local_queue: u8,
     /// Thread CPU time in nanoseconds.
     pub cpu_time_ns: u64,
-    /// OS thread ID of the parking thread. On Linux/Android, the result of gettid();
-    /// on other platforms, a synthetic per-process counter — see `events::current_tid`.
+    /// OS thread ID of the parking thread: `gettid()` on Linux/Android,
+    /// `pthread_getthreadid_np()` on FreeBSD, or a synthetic per-process
+    /// counter on other platforms — see `events::current_tid`.
     pub tid: u32,
 }
 
@@ -133,8 +134,9 @@ pub struct WorkerUnparkEvent {
     /// pair was not sampled for schedstat (see `DIAL9_SCHED_WAIT_SAMPLE_RATE`).
     /// `None` is distinct from `Some(0)`: the latter means "sampled, no wait".
     pub sched_wait_ns: Option<u64>,
-    /// OS thread ID of the unparking thread. On Linux/Android, the result of gettid();
-    /// on other platforms, a synthetic per-process counter — see `events::current_tid`.
+    /// OS thread ID of the unparking thread: `gettid()` on Linux/Android,
+    /// `pthread_getthreadid_np()` on FreeBSD, or a synthetic per-process
+    /// counter on other platforms — see `events::current_tid`.
     pub tid: u32,
 }
 

--- a/dial9-tokio-telemetry/tests/process_resource_usage.rs
+++ b/dial9-tokio-telemetry/tests/process_resource_usage.rs
@@ -38,6 +38,12 @@ fn traced_runtime_records_process_resource_usage() {
         "expected at least one process resource usage event"
     );
     assert!(metrics[0].timestamp_ns > 0);
+    // A newly started FreeBSD process may report ru_maxrss == 0 until the
+    // kernel's first resource-accounting tick, so validate a resource counter
+    // populated at startup instead.
+    #[cfg(target_os = "freebsd")]
+    assert!(metrics[0].minor_faults > 0);
+    #[cfg(not(target_os = "freebsd"))]
     assert!(metrics[0].max_rss_bytes > 0);
 }
 

--- a/dial9-tokio-telemetry/tests/process_resource_usage.rs
+++ b/dial9-tokio-telemetry/tests/process_resource_usage.rs
@@ -10,8 +10,56 @@ use dial9_tokio_telemetry::telemetry::{
 };
 use std::time::Duration;
 
+#[cfg(target_os = "freebsd")]
+fn wait_for_rss_accounting_tick() {
+    use std::mem::MaybeUninit;
+    use std::time::Instant;
+
+    let deadline = Instant::now() + Duration::from_secs(1);
+    let mut working_set = vec![0_u8; 1024 * 1024];
+    loop {
+        // FreeBSD updates ru_maxrss from its statclock path while the process
+        // is running. Sleeping alone may leave it at zero, so exercise a
+        // resident working set through at least one likely clock tick.
+        let work_until = Instant::now() + Duration::from_millis(10);
+        while Instant::now() < work_until {
+            for page in working_set.chunks_mut(4096) {
+                page[0] = page[0].wrapping_add(1);
+            }
+            std::hint::black_box(&working_set);
+        }
+
+        let mut usage = MaybeUninit::<libc::rusage>::uninit();
+        // SAFETY: `usage.as_mut_ptr()` points to valid storage for getrusage
+        // to initialize, and RUSAGE_SELF has no additional preconditions.
+        let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, usage.as_mut_ptr()) };
+        assert_eq!(
+            rc,
+            0,
+            "getrusage failed while waiting for RSS accounting: {}",
+            std::io::Error::last_os_error()
+        );
+        // SAFETY: getrusage returned success and initialized `usage`.
+        let usage = unsafe { usage.assume_init() };
+        if usage.ru_maxrss > 0 {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "ru_maxrss remained zero after waiting for a resource-accounting tick"
+        );
+    }
+}
+
+#[cfg(not(target_os = "freebsd"))]
+fn wait_for_rss_accounting_tick() {}
+
 #[test]
 fn traced_runtime_records_process_resource_usage() {
+    // FreeBSD may need one accounting tick before ru_maxrss becomes non-zero.
+    // Since it is a process maximum, every later source sample must retain it.
+    wait_for_rss_accounting_tick();
+
     let (capture, batches) = capture_processor();
 
     let recorder = recorder(MemoryBuffer::new(CAPTURE_BUFFER_SIZE).unwrap())
@@ -38,12 +86,6 @@ fn traced_runtime_records_process_resource_usage() {
         "expected at least one process resource usage event"
     );
     assert!(metrics[0].timestamp_ns > 0);
-    // A newly started FreeBSD process may report ru_maxrss == 0 until the
-    // kernel's first resource-accounting tick, so validate a resource counter
-    // populated at startup instead.
-    #[cfg(target_os = "freebsd")]
-    assert!(metrics[0].minor_faults > 0);
-    #[cfg(not(target_os = "freebsd"))]
     assert!(metrics[0].max_rss_bytes > 0);
 }
 

--- a/perf-self-profile/src/process_resource.rs
+++ b/perf-self-profile/src/process_resource.rs
@@ -275,15 +275,37 @@ mod unix {
             events
         }
 
+        fn read_after_rss_accounting_tick() -> ProcessResourceUsageSnapshot {
+            let deadline = Instant::now() + Duration::from_secs(1);
+            let mut working_set = vec![0_u8; 1024 * 1024];
+            loop {
+                // FreeBSD updates ru_maxrss from its statclock path while the
+                // process is running. Sleeping alone may never trigger that
+                // accounting, so touch resident pages through at least one
+                // likely clock tick before retrying getrusage.
+                let work_until = Instant::now() + Duration::from_millis(10);
+                while Instant::now() < work_until {
+                    for page in working_set.chunks_mut(4096) {
+                        page[0] = page[0].wrapping_add(1);
+                    }
+                    std::hint::black_box(&working_set);
+                }
+
+                let snapshot = read_process_resource_usage()
+                    .expect("getrusage should succeed for the current process");
+                if snapshot.max_rss_bytes > 0 {
+                    return snapshot;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "ru_maxrss remained zero after waiting for a resource-accounting tick"
+                );
+            }
+        }
+
         #[test]
         fn read_process_resource_usage_returns_metrics() {
-            let snapshot = read_process_resource_usage()
-                .expect("getrusage should succeed for the current process");
-            // FreeBSD may report ru_maxrss == 0 until its first accounting
-            // tick, so validate a resource counter populated at startup.
-            #[cfg(target_os = "freebsd")]
-            assert!(snapshot.minor_faults > 0);
-            #[cfg(not(target_os = "freebsd"))]
+            let snapshot = read_after_rss_accounting_tick();
             assert!(snapshot.max_rss_bytes > 0);
         }
 
@@ -298,6 +320,11 @@ mod unix {
 
         #[test]
         fn source_emits_process_resource_usage_event() {
+            // FreeBSD can report ru_maxrss == 0 before its first accounting
+            // tick. Once it becomes non-zero it is a process maximum, so the
+            // source sample below must retain the real RSS assertion.
+            read_after_rss_accounting_tick();
+
             let shared = SharedState::new(0);
             let ctx = shared.flush_context();
             let mut source = ProcessResourceUsageSource::new(ProcessResourceUsageConfig::default());
@@ -311,9 +338,6 @@ mod unix {
             assert_eq!(events.len(), 1);
             let event = &events[0];
             assert!(event.timestamp_ns > 0);
-            #[cfg(target_os = "freebsd")]
-            assert!(event.minor_faults > 0);
-            #[cfg(not(target_os = "freebsd"))]
             assert!(event.max_rss_bytes > 0);
         }
 

--- a/perf-self-profile/src/process_resource.rs
+++ b/perf-self-profile/src/process_resource.rs
@@ -279,7 +279,21 @@ mod unix {
         fn read_process_resource_usage_returns_metrics() {
             let snapshot = read_process_resource_usage()
                 .expect("getrusage should succeed for the current process");
+            // FreeBSD may report ru_maxrss == 0 until its first accounting
+            // tick, so validate a resource counter populated at startup.
+            #[cfg(target_os = "freebsd")]
+            assert!(snapshot.minor_faults > 0);
+            #[cfg(not(target_os = "freebsd"))]
             assert!(snapshot.max_rss_bytes > 0);
+        }
+
+        #[test]
+        fn max_rss_scales_to_bytes_and_rejects_negative_values() {
+            assert_eq!(
+                max_rss_to_bytes(4).expect("positive ru_maxrss should convert"),
+                4 * RU_MAXRSS_MULTIPLIER
+            );
+            assert!(max_rss_to_bytes(-1).is_err());
         }
 
         #[test]
@@ -297,6 +311,9 @@ mod unix {
             assert_eq!(events.len(), 1);
             let event = &events[0];
             assert!(event.timestamp_ns > 0);
+            #[cfg(target_os = "freebsd")]
+            assert!(event.minor_faults > 0);
+            #[cfg(not(target_os = "freebsd"))]
             assert!(event.max_rss_bytes > 0);
         }
 


### PR DESCRIPTION
## Summary

- use `pthread_getthreadid_np()` for real FreeBSD kernel thread IDs instead of process-local synthetic IDs
- keep the end-to-end `max_rss_bytes > 0` assertion reliable on FreeBSD by touching a bounded resident working set while waiting up to one second for a resource-accounting tick
- add focused conversion coverage for FreeBSD's `ru_maxrss` units and negative-value rejection
- add a non-blocking FreeBSD 15.1 CI job using `vmactions/freebsd-vm` pinned to `77ed28d336d03fe19a3f4f7266c1d2c4714dd79d` (`v1.5.2`)
- bound the VM job to 30 minutes and cache its prepared minimal Rust toolchain
- keep the VM workload focused and featureless: the FreeBSD TID test, Tokio park/unpark and process-resource integration tests, and process-resource self-profile tests with only their required features

The FreeBSD job uses `continue-on-error: true` and is not part of the aggregate `CI Pass` gate. It is intended to provide native-platform signal without making the VM action a required merge dependency.

Thread CPU time remains unsupported on FreeBSD. FreeBSD services `CLOCK_THREAD_CPUTIME_ID` with a syscall rather than its vDSO, and reading it on every Tokio worker park and unpark would add unsampled hot-path overhead. Supporting sampled CPU time requires explicit missing-sample semantics and is left for separate work.

No trace wire-format changes are included.

## Validation

Native FreeBSD 16.0-CURRENT amd64, using the same focused commands as the workflow:

- `cargo test -p dial9-core freebsd_tid_matches_kernel_thread_id` — 1 passed
- `cargo test -p dial9-tokio-telemetry --test park_unpark_tid --test process_resource_usage` — 3 passed
- `cargo test -p dial9-perf-self-profile --features "process-resource test-util" process_resource` — 7 passed

Additional branch validation:

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --features __nonlinux_all_features -- -D warnings`
- `git diff --check`

The exact FreeBSD 15.1 and Rust 1.94.1 pairing runs in the pull request GitHub Actions job.
