### PR TITLE
fix(perf-self-profile): detect missing frame pointers before install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,13 +351,32 @@ jobs:
         # paranoid=3 blocks perf_event_open to trigger the ctimer fallback path
         run: sudo sysctl kernel.perf_event_paranoid=3
       - name: Run perf-self-profile tests (auto-fallback path)
-        # With paranoid=3, /proc/kallsyms also shows zero kernel addresses on this runner 
-        # (exact mechanism is kernel/distro specific), so resolve_kernel_symbol_returns_name fails. 
+        # With paranoid=3, /proc/kallsyms also shows zero kernel addresses on this runner
+        # (exact mechanism is kernel/distro specific), so resolve_kernel_symbol_returns_name fails.
         # Kernel symbolization is also irrelevant to this path: frame-pointer unwinding only captures
         # userspace addresses.
         run: |
           cargo test -p dial9-perf-self-profile --lib --all-features \
             -- --skip sys::linux::symbolize::tests::resolve_kernel_symbol_returns_name
+
+  frame-pointer-detection:
+    name: Missing frame pointers are detected
+    runs-on: ubuntu-latest
+    env:
+      RUST_BACKTRACE: 1
+      # Deliberately omits `-C force-frame-pointers=yes` so the ignored test below exercises a real
+      # missing-frame-pointers build.
+      RUSTFLAGS: "--cfg tokio_unstable"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: ${{ env.STABLE_TOOLCHAIN }}
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Verify MemoryProfiler::install() detects missing frame pointers
+        run: |
+          cargo test -p dial9 --features memory-profiling \
+            --test memory_profiling_missing_frame_pointers -- --ignored
 
   shuttle:
     name: Shuttle tests
@@ -462,7 +481,7 @@ jobs:
   ci-pass:
     name: CI Pass
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, build, android-aarch64-build, feature-check, no-tokio-unstable, check-docs, trace-integrity, ui, asan, ecs-sim, shuttle, package, doctests]
+    needs: [fmt, clippy, build, android-aarch64-build, feature-check, no-tokio-unstable, check-docs, trace-integrity, ui, asan, ecs-sim, frame-pointer-detection, shuttle, package, doctests]
     if: always()
     steps:
       - run: |

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -444,7 +444,7 @@ dial9 = { version = "0.5", features = ["memory-profiling"] }
 rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]
 ```
 
-This must go in `.cargo/config.toml`, not `Cargo.toml` — a `rustflags` entry under `[profile.*]` or elsewhere in `Cargo.toml` is silently ignored by Cargo. If you get it wrong, `MemoryProfiler::install()` won't succeed quietly and fail later: it runs a self-test and returns `InstallError::MissingFramePointers` with the exact fix, letting you decide whether to crash out (as in the example below) or continue without memory profiling.
+If this is misconfigured, `MemoryProfiler::install()` runs a self-test and returns `InstallError::MissingFramePointers`, so you can choose to crash out (as in the example below) or continue without memory profiling.
 
 **Install the allocator and profiler:**
 
@@ -473,6 +473,8 @@ let _guard = MemoryProfiler::from_config(config)
 # }
 # fn main() {}
 ```
+
+To continue without memory profiling instead of crashing out on `InstallError::MissingFramePointers`, set `MemoryProfilingConfig::builder().skip_frame_pointer_check(true)`.
 
 The `sample_rate_bytes` controls how frequently allocations are sampled. At the default of 512 KiB, a service allocating 1 GB/s produces ~2000 samples/sec. Set to `1` to sample every allocation (useful for tests, not production).
 

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -444,7 +444,7 @@ dial9 = { version = "0.5", features = ["memory-profiling"] }
 rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]
 ```
 
-If this is misconfigured, `MemoryProfiler::install()` runs a self-test and returns `InstallError::MissingFramePointers`, so you can choose to crash out (as in the example below) or continue without memory profiling.
+If this is misconfigured, `MemoryProfiler::install()` runs a self-test and returns `InstallError::MissingFramePointers`, so you can choose to crash out (as in the example below) or install anyway with near-empty allocation stacks.
 
 **Install the allocator and profiler:**
 
@@ -474,7 +474,7 @@ let _guard = MemoryProfiler::from_config(config)
 # fn main() {}
 ```
 
-To continue without memory profiling instead of crashing out on `InstallError::MissingFramePointers`, set `MemoryProfilingConfig::builder().skip_frame_pointer_check(true)`.
+To install despite missing frame pointers instead of crashing out on `InstallError::MissingFramePointers`, set `MemoryProfilingConfig::builder().fail_on_missing_frame_pointers(false)`; a warning is logged instead.
 
 The `sample_rate_bytes` controls how frequently allocations are sampled. At the default of 512 KiB, a service allocating 1 GB/s produces ~2000 samples/sec. Set to `1` to sample every allocation (useful for tests, not production).
 

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -444,6 +444,8 @@ dial9 = { version = "0.5", features = ["memory-profiling"] }
 rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes"]
 ```
 
+This must go in `.cargo/config.toml`, not `Cargo.toml` — a `rustflags` entry under `[profile.*]` or elsewhere in `Cargo.toml` is silently ignored by Cargo. If you get it wrong, `MemoryProfiler::install()` won't succeed quietly and fail later: it runs a self-test and returns `InstallError::MissingFramePointers` with the exact fix, letting you decide whether to crash out (as in the example below) or continue without memory profiling.
+
 **Install the allocator and profiler:**
 
 ```rust,no_run

--- a/dial9/tests/memory_profiling_missing_frame_pointers.rs
+++ b/dial9/tests/memory_profiling_missing_frame_pointers.rs
@@ -1,19 +1,47 @@
 #![cfg(feature = "memory-profiling")]
 #![cfg(target_os = "linux")]
-//! Negative test for the frame-pointer self-test in `MemoryProfiler::install()`.
+//! Tests for the frame-pointer self-test in `MemoryProfiler::install()`: the
+//! default hard-fail behavior, `fail_on_missing_frame_pointers`'s opt-out
+//! (install succeeds instead of failing), and that a failed self-test always
+//! logs a warning regardless of that setting.
 //!
-//! This only exercises the intended failure mode when the binary is built
+//! These only exercise the intended failure mode when the binary is built
 //! WITHOUT `-C force-frame-pointers=yes` — every other job in
-//! `.github/workflows/ci.yml` builds with it, so running this under a normal
-//! build would (correctly) fail the assertion below. `#[ignore]`d so normal
-//! `cargo test`/`cargo nextest run` skip it; run explicitly (`-- --ignored`)
-//! from a job whose `RUSTFLAGS` omits the flag. See the
-//! `frame-pointer-detection` CI job.
+//! `.github/workflows/ci.yml` builds with it, so running these under a normal
+//! build would (correctly) fail. `#[ignore]`d so normal `cargo test`/
+//! `cargo nextest run` skip them; run explicitly (`-- --ignored`) from a job
+//! whose `RUSTFLAGS` omits the flag. See the `frame-pointer-detection` CI job.
 
-use dial9::memory::{InstallError, MemoryProfiler};
+use dial9::memory::{InstallError, MemoryProfiler, MemoryProfilingConfig};
 use dial9::{Dial9HandleTokioExt, TokioAttachOptions, recorder};
+use std::sync::{Arc, Mutex};
 
 mod common;
+
+#[derive(Clone, Default)]
+struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for SharedBuf {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn capturing_subscriber() -> (SharedBuf, impl tracing::Subscriber) {
+    let buf = SharedBuf::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer({
+            let buf = buf.clone();
+            move || buf.clone()
+        })
+        .with_ansi(false)
+        .finish();
+    (buf, subscriber)
+}
 
 #[test]
 #[ignore = "only meaningful when built without -C force-frame-pointers=yes"]
@@ -26,13 +54,56 @@ fn install_without_frame_pointers_returns_missing_frame_pointers() {
         .attach_tokio_runtime(builder, TokioAttachOptions::default())
         .expect("attach tokio");
 
+    let (buf, subscriber) = capturing_subscriber();
     let handle = recorder.handle().clone();
-    let err = MemoryProfiler::with_defaults()
-        .install(handle)
-        .expect_err("install should detect missing frame pointers");
+    let err = tracing::subscriber::with_default(subscriber, || {
+        MemoryProfiler::with_defaults().install(handle)
+    })
+    .expect_err("install should detect missing frame pointers");
 
     assert!(
         matches!(err, InstallError::MissingFramePointers { .. }),
         "expected MissingFramePointers, got: {err:?}"
+    );
+
+    let logged = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+    assert!(
+        logged.contains("frame-pointer self-test failed")
+            && logged.contains("fail_on_missing_frame_pointers=true"),
+        "expected a warning about the failed frame-pointer check even in the \
+         hard-fail path, got: {logged:?}"
+    );
+}
+
+// The memory profiler is a process-global singleton -- install() only
+// succeeds once per process. Both assertions (success, and the warning it
+// logs) have to share the one successful install() call in this test
+// binary, rather than living in separate tests that would race for it.
+#[test]
+#[ignore = "only meaningful when built without -C force-frame-pointers=yes"]
+fn install_without_frame_pointers_succeeds_and_warns_when_fail_is_disabled() {
+    let recorder = recorder(common::small_mem_writer()).build();
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all().worker_threads(1);
+    let _rt = recorder
+        .handle()
+        .attach_tokio_runtime(builder, TokioAttachOptions::default())
+        .expect("attach tokio");
+
+    let (buf, subscriber) = capturing_subscriber();
+    let handle = recorder.handle().clone();
+    let config = MemoryProfilingConfig::builder()
+        .fail_on_missing_frame_pointers(false)
+        .build();
+    let _guard = tracing::subscriber::with_default(subscriber, || {
+        MemoryProfiler::from_config(config).install(handle)
+    })
+    .expect("install should proceed despite missing frame pointers");
+
+    let logged = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+    assert!(
+        logged.contains("frame-pointer self-test failed")
+            && logged.contains("fail_on_missing_frame_pointers=false"),
+        "expected a warning about the failed frame-pointer check, got: {logged:?}"
     );
 }

--- a/dial9/tests/memory_profiling_missing_frame_pointers.rs
+++ b/dial9/tests/memory_profiling_missing_frame_pointers.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "memory-profiling")]
+#![cfg(target_os = "linux")]
+//! Negative test for the frame-pointer self-test in `MemoryProfiler::install()`.
+//!
+//! This only exercises the intended failure mode when the binary is built
+//! WITHOUT `-C force-frame-pointers=yes` — every other job in
+//! `.github/workflows/ci.yml` builds with it, so running this under a normal
+//! build would (correctly) fail the assertion below. `#[ignore]`d so normal
+//! `cargo test`/`cargo nextest run` skip it; run explicitly (`-- --ignored`)
+//! from a job whose `RUSTFLAGS` omits the flag. See the
+//! `frame-pointer-detection` CI job.
+
+use dial9::memory::{InstallError, MemoryProfiler};
+use dial9::{Dial9HandleTokioExt, TokioAttachOptions, recorder};
+
+mod common;
+
+#[test]
+#[ignore = "only meaningful when built without -C force-frame-pointers=yes"]
+fn install_without_frame_pointers_returns_missing_frame_pointers() {
+    let recorder = recorder(common::small_mem_writer()).build();
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all().worker_threads(1);
+    let _rt = recorder
+        .handle()
+        .attach_tokio_runtime(builder, TokioAttachOptions::default())
+        .expect("attach tokio");
+
+    let handle = recorder.handle().clone();
+    let err = MemoryProfiler::with_defaults()
+        .install(handle)
+        .expect_err("install should detect missing frame pointers");
+
+    assert!(
+        matches!(err, InstallError::MissingFramePointers { .. }),
+        "expected MissingFramePointers, got: {err:?}"
+    );
+}

--- a/docs/design/memory-profiling.md
+++ b/docs/design/memory-profiling.md
@@ -322,16 +322,22 @@ The memory profiler uses the existing `Unwinder` (from
 
 - **No allocations.** Captures into an on-stack `[u64; 128]` buffer.
 - **Safe against corrupted frame chains** via the `safe_load` SIGSEGV
-  handler (installed once at startup).
+  handler (installed once at startup). Frame 0 is derived the same way as
+  every later frame — `Unwinder::capture` never raw-dereferences a live
+  register value — so a missing frame pointer degrades a capture to
+  near-empty rather than risking a segfault.
 - **~5 ns per frame, ~110 ns for a 20-frame walk** on x86_64. Add
   ~50–200 ns in production for cold caches; faulting frames that hit
   the SIGSEGV safe-load path cost ~1–5 µs for the single faulting
   frame.
-- **Requires frame pointers** (`-C force-frame-pointers=yes`).
+- **Requires frame pointers** (`-C force-frame-pointers=yes`), checked by a
+  self-test at install time. `MemoryProfiler::install()` returns
+  `InstallError::MissingFramePointers` rather than installing a profiler
+  that would produce useless allocation stacks.
 
-`MemoryProfiler::install()` calls `Unwinder::install()` and stores the
-returned handle. The hook accesses it via the process-global
-`MemoryProfilerInner`:
+`MemoryProfiler::install()` calls `Unwinder::install()`, runs that
+self-test, and stores the returned handle. The hook accesses it via the
+process-global `MemoryProfilerInner`:
 
 ```rust
 // 128 frames × 8 B = 1 KiB stack buffer. Rust async call stacks

--- a/perf-self-profile/src/memory_profiling/config.rs
+++ b/perf-self-profile/src/memory_profiling/config.rs
@@ -70,20 +70,20 @@ pub struct MemoryProfilingConfig {
     #[builder(default = DEFAULT_RING_CAPACITY)]
     ring_capacity: usize,
 
-    /// Skip the frame-pointer self-test that [`MemoryProfiler::install`]
-    /// runs by default. Default `false`.
+    /// Whether a failed frame-pointer self-test is a hard install error.
+    /// Default `true`.
     ///
-    /// Only set this if you've independently verified frame pointers are
-    /// enabled, or are prepared to accept near-empty allocation stacks
-    /// otherwise — with this set, `install()` cannot return
-    /// [`InstallError::MissingFramePointers`], so a missing
-    /// `-C force-frame-pointers=yes` produces useless stacks silently
-    /// instead of a clear error at install time.
+    /// [`MemoryProfiler::install`] always runs the self-test and always logs
+    /// a warning on failure. By default a failure also returns
+    /// [`InstallError::MissingFramePointers`]; set this to `false` to have
+    /// `install()` proceed instead, relying on the warning alone. Only do
+    /// that if you've independently verified frame pointers are enabled, or
+    /// are prepared to accept near-empty allocation stacks.
     ///
     /// [`MemoryProfiler::install`]: crate::memory_profiling::MemoryProfiler::install
     /// [`InstallError::MissingFramePointers`]: crate::memory_profiling::InstallError::MissingFramePointers
-    #[builder(default = false)]
-    skip_frame_pointer_check: bool,
+    #[builder(default = true)]
+    fail_on_missing_frame_pointers: bool,
 }
 
 impl<S: memory_profiling_config_builder::IsComplete> MemoryProfilingConfigBuilder<S> {
@@ -129,9 +129,9 @@ impl MemoryProfilingConfig {
     pub fn ring_capacity(&self) -> usize {
         self.ring_capacity
     }
-    /// Whether the install-time frame-pointer self-test is skipped.
-    pub fn skip_frame_pointer_check(&self) -> bool {
-        self.skip_frame_pointer_check
+    /// Whether a failed frame-pointer self-test is a hard install error.
+    pub fn fail_on_missing_frame_pointers(&self) -> bool {
+        self.fail_on_missing_frame_pointers
     }
 }
 
@@ -170,16 +170,16 @@ mod tests {
     }
 
     #[test]
-    fn skip_frame_pointer_check_defaults_to_false() {
+    fn fail_on_missing_frame_pointers_defaults_to_true() {
         let cfg = MemoryProfilingConfig::default();
-        assert!(!cfg.skip_frame_pointer_check());
+        assert!(cfg.fail_on_missing_frame_pointers());
     }
 
     #[test]
-    fn skip_frame_pointer_check_can_be_set() {
+    fn fail_on_missing_frame_pointers_can_be_set() {
         let cfg = MemoryProfilingConfig::builder()
-            .skip_frame_pointer_check(true)
+            .fail_on_missing_frame_pointers(false)
             .build();
-        assert!(cfg.skip_frame_pointer_check());
+        assert!(!cfg.fail_on_missing_frame_pointers());
     }
 }

--- a/perf-self-profile/src/memory_profiling/config.rs
+++ b/perf-self-profile/src/memory_profiling/config.rs
@@ -69,6 +69,21 @@ pub struct MemoryProfilingConfig {
     /// The free queue is sized 8× this.
     #[builder(default = DEFAULT_RING_CAPACITY)]
     ring_capacity: usize,
+
+    /// Skip the frame-pointer self-test that [`MemoryProfiler::install`]
+    /// runs by default. Default `false`.
+    ///
+    /// Only set this if you've independently verified frame pointers are
+    /// enabled, or are prepared to accept near-empty allocation stacks
+    /// otherwise — with this set, `install()` cannot return
+    /// [`InstallError::MissingFramePointers`], so a missing
+    /// `-C force-frame-pointers=yes` produces useless stacks silently
+    /// instead of a clear error at install time.
+    ///
+    /// [`MemoryProfiler::install`]: crate::memory_profiling::MemoryProfiler::install
+    /// [`InstallError::MissingFramePointers`]: crate::memory_profiling::InstallError::MissingFramePointers
+    #[builder(default = false)]
+    skip_frame_pointer_check: bool,
 }
 
 impl<S: memory_profiling_config_builder::IsComplete> MemoryProfilingConfigBuilder<S> {
@@ -114,6 +129,10 @@ impl MemoryProfilingConfig {
     pub fn ring_capacity(&self) -> usize {
         self.ring_capacity
     }
+    /// Whether the install-time frame-pointer self-test is skipped.
+    pub fn skip_frame_pointer_check(&self) -> bool {
+        self.skip_frame_pointer_check
+    }
 }
 
 #[cfg(test)]
@@ -148,5 +167,19 @@ mod tests {
     fn build_accepts_liveset() {
         let cfg = MemoryProfilingConfig::builder().track_liveset(true).build();
         assert!(cfg.track_liveset());
+    }
+
+    #[test]
+    fn skip_frame_pointer_check_defaults_to_false() {
+        let cfg = MemoryProfilingConfig::default();
+        assert!(!cfg.skip_frame_pointer_check());
+    }
+
+    #[test]
+    fn skip_frame_pointer_check_can_be_set() {
+        let cfg = MemoryProfilingConfig::builder()
+            .skip_frame_pointer_check(true)
+            .build();
+        assert!(cfg.skip_frame_pointer_check());
     }
 }

--- a/perf-self-profile/src/memory_profiling/profiler.rs
+++ b/perf-self-profile/src/memory_profiling/profiler.rs
@@ -202,22 +202,31 @@ impl MemoryProfiler {
 
         let unwinder = Unwinder::install().map_err(InstallError::Unwinder)?;
 
-        if let Some(self_test) = unwinder.self_test_frame_pointers()
-            && !self_test.passed()
-        {
-            tracing::warn!(
-                frames_captured = self_test.frames_captured,
-                expected_min = self_test.expected_min,
-                fail_on_missing_frame_pointers = self.config.fail_on_missing_frame_pointers(),
-                "frame-pointer self-test failed; this binary is likely missing \
-                 -C force-frame-pointers=yes"
-            );
-            if self.config.fail_on_missing_frame_pointers() {
-                return Err(InstallError::MissingFramePointers {
-                    frames_captured: self_test.frames_captured,
-                    expected_min: self_test.expected_min,
-                });
+        match unwinder.self_test_frame_pointers() {
+            Ok(self_test) if !self_test.passed() => {
+                tracing::warn!(
+                    frames_captured = self_test.frames_captured,
+                    expected_min = self_test.expected_min,
+                    fail_on_missing_frame_pointers = self.config.fail_on_missing_frame_pointers(),
+                    "frame-pointer self-test failed; this binary is likely missing \
+                     -C force-frame-pointers=yes"
+                );
+                if self.config.fail_on_missing_frame_pointers() {
+                    return Err(InstallError::MissingFramePointers {
+                        frames_captured: self_test.frames_captured,
+                        expected_min: self_test.expected_min,
+                    });
+                }
             }
+            Ok(_) => {}
+            // Inconclusive (thread spawn failed, or the self-test panicked) --
+            // not evidence of missing frame pointers, so this doesn't affect
+            // whether install() proceeds. Logged so the cause isn't silently
+            // discarded.
+            Err(e) => tracing::warn!(
+                "frame-pointer self-test could not run: {e}; proceeding without \
+                 verifying frame pointers"
+            ),
         }
 
         let rings = Arc::new(RingBuffers::new(

--- a/perf-self-profile/src/memory_profiling/profiler.rs
+++ b/perf-self-profile/src/memory_profiling/profiler.rs
@@ -161,8 +161,9 @@ impl std::error::Error for InstallError {
 ///   [`InstallError::MissingFramePointers`] instead of silently
 ///   installing a profiler whose allocation stacks would be near-empty
 ///   and useless; see
-///   [`skip_frame_pointer_check`](crate::memory_profiling::MemoryProfilingConfig::skip_frame_pointer_check)
-///   to opt out.
+///   [`fail_on_missing_frame_pointers`](crate::memory_profiling::MemoryProfilingConfig::fail_on_missing_frame_pointers)
+///   to downgrade this to a warning instead. A failed self-test always
+///   logs a `tracing::warn!`, regardless of that setting.
 /// - [`Dial9Allocator`](crate::memory_profiling::Dial9Allocator) must be
 ///   installed as the `#[global_allocator]` for allocations to reach the
 ///   sampling hook.
@@ -200,14 +201,22 @@ impl MemoryProfiler {
 
         let unwinder = Unwinder::install().map_err(InstallError::Unwinder)?;
 
-        if !self.config.skip_frame_pointer_check()
-            && let Some(self_test) = unwinder.self_test_frame_pointers()
+        if let Some(self_test) = unwinder.self_test_frame_pointers()
             && !self_test.passed()
         {
-            return Err(InstallError::MissingFramePointers {
-                frames_captured: self_test.frames_captured,
-                expected_min: self_test.expected_min,
-            });
+            tracing::warn!(
+                frames_captured = self_test.frames_captured,
+                expected_min = self_test.expected_min,
+                fail_on_missing_frame_pointers = self.config.fail_on_missing_frame_pointers(),
+                "frame-pointer self-test failed; this binary is likely missing \
+                 -C force-frame-pointers=yes"
+            );
+            if self.config.fail_on_missing_frame_pointers() {
+                return Err(InstallError::MissingFramePointers {
+                    frames_captured: self_test.frames_captured,
+                    expected_min: self_test.expected_min,
+                });
+            }
         }
 
         let rings = Arc::new(RingBuffers::new(

--- a/perf-self-profile/src/memory_profiling/profiler.rs
+++ b/perf-self-profile/src/memory_profiling/profiler.rs
@@ -130,8 +130,7 @@ impl std::fmt::Display for InstallError {
                 "memory profiler self-test captured only {frames_captured} stack frames \
                  (expected at least {expected_min}); this binary is likely missing \
                  `-C force-frame-pointers=yes`. Add it to `[build] rustflags` in \
-                 `.cargo/config.toml` — a `rustflags` entry under `[profile.*]` or in \
-                 `Cargo.toml` itself is silently ignored by Cargo."
+                 `.cargo/config.toml`."
             ),
         }
     }

--- a/perf-self-profile/src/memory_profiling/profiler.rs
+++ b/perf-self-profile/src/memory_profiling/profiler.rs
@@ -109,6 +109,7 @@ pub enum InstallError {
     /// The frame-pointer self-test run at install time indicates this
     /// binary was not built with `-C force-frame-pointers=yes`; allocation
     /// stacks would be near-empty and useless for profiling.
+    #[non_exhaustive]
     MissingFramePointers {
         frames_captured: usize,
         expected_min: usize,

--- a/perf-self-profile/src/memory_profiling/profiler.rs
+++ b/perf-self-profile/src/memory_profiling/profiler.rs
@@ -106,6 +106,13 @@ pub enum InstallError {
     AlreadyInstalled,
     /// The SIGSEGV handler used by the FP unwinder failed to install.
     Unwinder(std::io::Error),
+    /// The frame-pointer self-test run at install time indicates this
+    /// binary was not built with `-C force-frame-pointers=yes`; allocation
+    /// stacks would be near-empty and useless for profiling.
+    MissingFramePointers {
+        frames_captured: usize,
+        expected_min: usize,
+    },
 }
 
 impl std::fmt::Display for InstallError {
@@ -115,6 +122,17 @@ impl std::fmt::Display for InstallError {
                 f.write_str("memory profiler already installed in this process")
             }
             Self::Unwinder(e) => write!(f, "failed to install SIGSEGV handler for unwinder: {e}"),
+            Self::MissingFramePointers {
+                frames_captured,
+                expected_min,
+            } => write!(
+                f,
+                "memory profiler self-test captured only {frames_captured} stack frames \
+                 (expected at least {expected_min}); this binary is likely missing \
+                 `-C force-frame-pointers=yes`. Add it to `[build] rustflags` in \
+                 `.cargo/config.toml` — a `rustflags` entry under `[profile.*]` or in \
+                 `Cargo.toml` itself is silently ignored by Cargo."
+            ),
         }
     }
 }
@@ -124,6 +142,7 @@ impl std::error::Error for InstallError {
         match self {
             Self::AlreadyInstalled => None,
             Self::Unwinder(e) => Some(e),
+            Self::MissingFramePointers { .. } => None,
         }
     }
 }
@@ -136,9 +155,15 @@ impl std::error::Error for InstallError {
 /// Install is permanent for the life of the process.
 ///
 /// # Requirements
-/// - Frame pointers are required for complete allocation stacks (build with
-///   `-C force-frame-pointers=yes`). Without them, profiling remains safe but
-///   records empty or shallow stacks.
+/// - Frame pointers: allocation stacks are captured with a frame-pointer
+///   unwinder, so the binary must be built with
+///   `-C force-frame-pointers=yes`. [`install`](Self::install) runs a
+///   self-test for this and returns
+///   [`InstallError::MissingFramePointers`] instead of silently
+///   installing a profiler whose allocation stacks would be near-empty
+///   and useless; see
+///   [`skip_frame_pointer_check`](crate::memory_profiling::MemoryProfilingConfig::skip_frame_pointer_check)
+///   to opt out.
 /// - [`Dial9Allocator`](crate::memory_profiling::Dial9Allocator) must be
 ///   installed as the `#[global_allocator]` for allocations to reach the
 ///   sampling hook.
@@ -160,8 +185,10 @@ impl MemoryProfiler {
 
     /// Install the profiler with the given handle.
     ///
-    /// Build with `-C force-frame-pointers=yes` for complete allocation stacks;
-    /// see the [type-level requirements](MemoryProfiler#requirements).
+    /// Requires a binary built with `-C force-frame-pointers=yes`, checked
+    /// by a self-test run here; see the
+    /// [type-level requirements](MemoryProfiler#requirements) and
+    /// [`InstallError::MissingFramePointers`].
     ///
     /// On a disconnected handle, install is a no-op (returns `Ok` but does
     /// not publish state). `ACTIVE.get()` remains `None` so the allocator
@@ -173,6 +200,16 @@ impl MemoryProfiler {
         }
 
         let unwinder = Unwinder::install().map_err(InstallError::Unwinder)?;
+
+        if !self.config.skip_frame_pointer_check()
+            && let Some(self_test) = unwinder.self_test_frame_pointers()
+            && !self_test.passed()
+        {
+            return Err(InstallError::MissingFramePointers {
+                frames_captured: self_test.frames_captured,
+                expected_min: self_test.expected_min,
+            });
+        }
 
         let rings = Arc::new(RingBuffers::new(
             self.config.ring_capacity(),

--- a/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
@@ -47,31 +47,23 @@ pub(crate) fn strip_pac(addr: usize) -> usize {
     addr
 }
 
-/// Walk the frame-pointer chain starting from the given (pc, fp, sp) triple,
-/// usually obtained from a signal handler's ucontext.
+/// Shared walk loop: given a frame pointer `fp` that has *not yet been
+/// validated or dereferenced*, fault-tolerantly walk the frame-pointer chain,
+/// writing return addresses into `out[n..]`.
 ///
-/// `truncated` is `true` if the walk stopped because the output buffer (or
-/// [`MAX_FRAMES`]) was full *and* at least one additional frame would have been
-/// valid. A natural stop (end of chain, faulty load, implausible pointer)
-/// produces `truncated = false`.
+/// Every frame — including the first one this loop processes — goes through
+/// the same bounds/alignment check and `safe_load`-guarded reads. There is no
+/// "trusted" frame here; callers that do have a trusted PC for frame 0 (e.g.
+/// [`unwind`], seeded from a signal handler's ucontext) write it directly and
+/// start this loop at `n = 1` to fill in the rest of the chain.
 ///
 /// # Safety
 /// - `install_handler` must have been called.
 /// - Should generally be called from a signal handler where the target thread
-///   is stopped; walking a running thread's stack races with mutations.
-pub unsafe fn unwind(pc: usize, mut fp: usize, sp: usize, out: &mut [u64]) -> CaptureResult {
+///   is stopped, or from the frame whose own `fp` is passed in; walking a
+///   running thread's stack from another thread races with mutations.
+unsafe fn unwind_loop(mut fp: usize, sp: usize, out: &mut [u64], mut n: usize) -> CaptureResult {
     let limit = out.len().min(MAX_FRAMES);
-    if limit == 0 {
-        // No room even for the interrupted PC. The walk would have produced
-        // at least one frame, so this is truncation.
-        return CaptureResult {
-            frames_written: 0,
-            truncated: true,
-        };
-    }
-
-    out[0] = pc as u64;
-    let mut n = 1;
 
     let stack_lo = sp;
     let stack_hi = sp.saturating_add(8 * 1024 * 1024);
@@ -136,6 +128,61 @@ pub unsafe fn unwind(pc: usize, mut fp: usize, sp: usize, out: &mut [u64]) -> Ca
         n += 1;
         fp = saved_fp;
     }
+}
+
+/// Walk the frame-pointer chain starting from the given (pc, fp, sp) triple,
+/// usually obtained from a signal handler's ucontext.
+///
+/// `pc` is trusted as-is and written directly to `out[0]` — the caller must
+/// already know it's a valid instruction pointer (e.g. the kernel-supplied
+/// interrupted PC). `fp` is *not* trusted: it is validated and read through
+/// the same `safe_load`-guarded path as every other frame in the chain. If
+/// there is no trusted `pc` to seed frame 0 with, use
+/// [`unwind_from_frame_pointer`] instead.
+///
+/// `truncated` is `true` if the walk stopped because the output buffer (or
+/// [`MAX_FRAMES`]) was full *and* at least one additional frame would have been
+/// valid. A natural stop (end of chain, faulty load, implausible pointer)
+/// produces `truncated = false`.
+///
+/// # Safety
+/// - `install_handler` must have been called.
+/// - Should generally be called from a signal handler where the target thread
+///   is stopped; walking a running thread's stack races with mutations.
+pub unsafe fn unwind(pc: usize, fp: usize, sp: usize, out: &mut [u64]) -> CaptureResult {
+    let limit = out.len().min(MAX_FRAMES);
+    if limit == 0 {
+        // No room even for the interrupted PC. The walk would have produced
+        // at least one frame, so this is truncation.
+        return CaptureResult {
+            frames_written: 0,
+            truncated: true,
+        };
+    }
+
+    out[0] = pc as u64;
+    unsafe { unwind_loop(fp, sp, out, 1) }
+}
+
+/// Derive frame 0 from a live frame pointer and walk the rest of the chain,
+/// without trusting any raw dereference of `fp`.
+///
+/// Unlike [`unwind`], there is no separately-trusted PC here: `fp` is
+/// expected to be the *current* frame's own frame pointer (e.g. read directly
+/// from the `rbp`/`x29` register, with no memory access at all). Frame 0 is
+/// derived by validating and `safe_load`-ing `fp` exactly like every
+/// subsequent frame — there is nothing "trusted" about it. On a binary built
+/// without `-C force-frame-pointers=yes`, `fp` may not point at a real
+/// `[saved_fp, return_addr]` pair at all; this degrades to an empty,
+/// non-truncated result instead of a raw dereference of arbitrary memory.
+///
+/// # Safety
+/// - `install_handler` must have been called.
+/// - Must be called such that `fp` is a live frame pointer of the calling
+///   thread's own stack (not another thread's, and not a value obtained by
+///   dereferencing memory) and `sp` is that thread's current stack pointer.
+pub unsafe fn unwind_from_frame_pointer(fp: usize, sp: usize, out: &mut [u64]) -> CaptureResult {
+    unsafe { unwind_loop(fp, sp, out, 0) }
 }
 
 /// Unwind from inside a signal handler given the raw ucontext.
@@ -449,5 +496,149 @@ mod tests {
         assert_eq!(n, 1, "unwind must stop when ret_addr load faults");
         assert!(!truncated);
         assert_eq!(out[0], 0x40_0000);
+    }
+
+    // `unwind_from_frame_pointer` derives frame 0 itself via the same
+    // validated, `safe_load`-guarded path used for every other frame,
+    // instead of trusting a raw dereference of a live register value. These
+    // mirror the `unwind()` synthetic-stack tests above, but exercise frame
+    // 0's derivation directly.
+
+    #[test]
+    fn from_frame_pointer_walks_valid_chain() {
+        install();
+        let sz = std::mem::size_of::<usize>();
+        let mut stack = [0usize; 8];
+        let base = stack.as_mut_ptr() as usize;
+
+        // Frame C (4,5) is its own saved fp, with a non-zero return address
+        // so the walk stops on the "must advance" check rather than an
+        // incidental dead-zone rejection of a zeroed slot.
+        stack[0] = base + 2 * sz;
+        stack[1] = 0x40_1000;
+        stack[2] = base + 4 * sz;
+        stack[3] = 0x40_2000;
+        stack[4] = base + 4 * sz;
+        stack[5] = 0x40_3000;
+
+        let mut out = [0u64; MAX_FRAMES];
+        let CaptureResult {
+            frames_written: n,
+            truncated,
+        } = unsafe { unwind_from_frame_pointer(base, base, &mut out) };
+
+        assert_eq!(n, 2);
+        assert!(!truncated);
+        assert_eq!(out[0], 0x40_1000);
+        assert_eq!(out[1], 0x40_2000);
+    }
+
+    #[test]
+    fn from_frame_pointer_reports_zero_frames_on_misaligned_fp() {
+        install();
+        let sp = 0x7fff_0000_0000usize;
+        let mut out = [0u64; MAX_FRAMES];
+        let CaptureResult {
+            frames_written: n,
+            truncated,
+        } = unsafe { unwind_from_frame_pointer(sp + 1, sp, &mut out) };
+        assert_eq!(
+            n, 0,
+            "a misaligned live fp must produce zero frames, not a dereference"
+        );
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn from_frame_pointer_reports_zero_frames_when_fp_out_of_range() {
+        install();
+        let sp = 0x7fff_0000_0000usize;
+        let mut out = [0u64; MAX_FRAMES];
+        // fp below sp is out of the assumed [sp, sp + 8MiB) stack range.
+        let CaptureResult {
+            frames_written: n,
+            truncated,
+        } = unsafe { unwind_from_frame_pointer(sp.wrapping_sub(8), sp, &mut out) };
+        assert_eq!(n, 0);
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn from_frame_pointer_stops_safely_when_live_fp_load_faults() {
+        install();
+        let ps = page_size();
+        // Simulates a build without frame pointers handing back a garbage
+        // `fp` that happens to point at unmapped memory: the walk must
+        // degrade to zero frames, not dereference it directly.
+        let guard = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                ps,
+                libc::PROT_NONE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        assert_ne!(guard, libc::MAP_FAILED);
+        let fp = guard as usize;
+
+        let mut out = [0u64; MAX_FRAMES];
+        let CaptureResult {
+            frames_written: n,
+            truncated,
+        } = unsafe { unwind_from_frame_pointer(fp, fp, &mut out) };
+
+        assert_eq!(unsafe { libc::munmap(guard, ps) }, 0);
+
+        assert_eq!(
+            n, 0,
+            "a faulting live fp must produce zero frames, not a crash"
+        );
+        assert!(!truncated);
+    }
+
+    #[test]
+    fn from_frame_pointer_respects_output_buffer_limit() {
+        install();
+        let sz = std::mem::size_of::<usize>();
+        let mut stack = [0usize; 8];
+        let base = stack.as_mut_ptr() as usize;
+
+        stack[0] = base + 2 * sz;
+        stack[1] = 0x40_1000;
+        stack[2] = base + 4 * sz;
+        stack[3] = 0x40_2000;
+        stack[4] = base + 4 * sz;
+
+        let mut out = [0u64; 1];
+        let CaptureResult {
+            frames_written: n,
+            truncated,
+        } = unsafe { unwind_from_frame_pointer(base, base, &mut out) };
+        assert_eq!(n, 1);
+        assert!(truncated, "a valid next frame existed but had no room");
+        assert_eq!(out[0], 0x40_1000);
+    }
+
+    #[test]
+    fn from_frame_pointer_with_empty_buffer_reports_truncation_only_if_valid() {
+        install();
+        let sz = std::mem::size_of::<usize>();
+        let mut stack = [0usize; 2];
+        let base = stack.as_mut_ptr() as usize;
+        stack[0] = base + 2 * sz; // would advance validly if there were room
+        stack[1] = 0x40_1000;
+
+        let mut out: [u64; 0] = [];
+        let CaptureResult {
+            frames_written: n,
+            truncated,
+        } = unsafe { unwind_from_frame_pointer(base, base, &mut out) };
+        assert_eq!(n, 0);
+        assert!(
+            truncated,
+            "a genuinely valid frame existed; zero room means truncated"
+        );
     }
 }

--- a/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
@@ -47,23 +47,37 @@ pub(crate) fn strip_pac(addr: usize) -> usize {
     addr
 }
 
-/// Shared walk loop: given a frame pointer `fp` that has *not yet been
-/// validated or dereferenced*, fault-tolerantly walk the frame-pointer chain,
-/// writing return addresses into `out[n..]`.
+/// Walk the frame-pointer chain starting from the given (pc, fp, sp) triple,
+/// usually obtained from a signal handler's ucontext.
 ///
-/// Every frame — including the first one this loop processes — goes through
-/// the same bounds/alignment check and `safe_load`-guarded reads. There is no
-/// "trusted" frame here; callers that do have a trusted PC for frame 0 (e.g.
-/// [`unwind`], seeded from a signal handler's ucontext) write it directly and
-/// start this loop at `n = 1` to fill in the rest of the chain.
+/// `pc` is trusted as-is and written directly to `out[0]` — the caller must
+/// already know it's a valid instruction pointer (e.g. the kernel-supplied
+/// interrupted PC). `fp` is *not* trusted: every frame from here on,
+/// including the first, goes through the same bounds/alignment check and
+/// `safe_load`-guarded reads.
+///
+/// `truncated` is `true` if the walk stopped because the output buffer (or
+/// [`MAX_FRAMES`]) was full *and* at least one additional frame would have been
+/// valid. A natural stop (end of chain, faulty load, implausible pointer)
+/// produces `truncated = false`.
 ///
 /// # Safety
 /// - `install_handler` must have been called.
 /// - Should generally be called from a signal handler where the target thread
-///   is stopped, or from the frame whose own `fp` is passed in; walking a
-///   running thread's stack from another thread races with mutations.
-unsafe fn unwind_loop(mut fp: usize, sp: usize, out: &mut [u64], mut n: usize) -> CaptureResult {
+///   is stopped; walking a running thread's stack races with mutations.
+pub unsafe fn unwind(pc: usize, mut fp: usize, sp: usize, out: &mut [u64]) -> CaptureResult {
     let limit = out.len().min(MAX_FRAMES);
+    if limit == 0 {
+        // No room even for the interrupted PC. The walk would have produced
+        // at least one frame, so this is truncation.
+        return CaptureResult {
+            frames_written: 0,
+            truncated: true,
+        };
+    }
+
+    out[0] = pc as u64;
+    let mut n = 1;
 
     let stack_lo = sp;
     let stack_hi = sp.saturating_add(8 * 1024 * 1024);
@@ -128,38 +142,6 @@ unsafe fn unwind_loop(mut fp: usize, sp: usize, out: &mut [u64], mut n: usize) -
         n += 1;
         fp = saved_fp;
     }
-}
-
-/// Walk the frame-pointer chain starting from the given (pc, fp, sp) triple,
-/// usually obtained from a signal handler's ucontext.
-///
-/// `pc` is trusted as-is and written directly to `out[0]` — the caller must
-/// already know it's a valid instruction pointer (e.g. the kernel-supplied
-/// interrupted PC). `fp` is *not* trusted: it is validated and read through
-/// the same `safe_load`-guarded path as every other frame in the chain.
-///
-/// `truncated` is `true` if the walk stopped because the output buffer (or
-/// [`MAX_FRAMES`]) was full *and* at least one additional frame would have been
-/// valid. A natural stop (end of chain, faulty load, implausible pointer)
-/// produces `truncated = false`.
-///
-/// # Safety
-/// - `install_handler` must have been called.
-/// - Should generally be called from a signal handler where the target thread
-///   is stopped; walking a running thread's stack races with mutations.
-pub unsafe fn unwind(pc: usize, fp: usize, sp: usize, out: &mut [u64]) -> CaptureResult {
-    let limit = out.len().min(MAX_FRAMES);
-    if limit == 0 {
-        // No room even for the interrupted PC. The walk would have produced
-        // at least one frame, so this is truncation.
-        return CaptureResult {
-            frames_written: 0,
-            truncated: true,
-        };
-    }
-
-    out[0] = pc as u64;
-    unsafe { unwind_loop(fp, sp, out, 1) }
 }
 
 /// Unwind from inside a signal handler given the raw ucontext.

--- a/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
@@ -136,9 +136,7 @@ unsafe fn unwind_loop(mut fp: usize, sp: usize, out: &mut [u64], mut n: usize) -
 /// `pc` is trusted as-is and written directly to `out[0]` — the caller must
 /// already know it's a valid instruction pointer (e.g. the kernel-supplied
 /// interrupted PC). `fp` is *not* trusted: it is validated and read through
-/// the same `safe_load`-guarded path as every other frame in the chain. If
-/// there is no trusted `pc` to seed frame 0 with, use
-/// [`unwind_from_frame_pointer`] instead.
+/// the same `safe_load`-guarded path as every other frame in the chain.
 ///
 /// `truncated` is `true` if the walk stopped because the output buffer (or
 /// [`MAX_FRAMES`]) was full *and* at least one additional frame would have been
@@ -162,27 +160,6 @@ pub unsafe fn unwind(pc: usize, fp: usize, sp: usize, out: &mut [u64]) -> Captur
 
     out[0] = pc as u64;
     unsafe { unwind_loop(fp, sp, out, 1) }
-}
-
-/// Derive frame 0 from a live frame pointer and walk the rest of the chain,
-/// without trusting any raw dereference of `fp`.
-///
-/// Unlike [`unwind`], there is no separately-trusted PC here: `fp` is
-/// expected to be the *current* frame's own frame pointer (e.g. read directly
-/// from the `rbp`/`x29` register, with no memory access at all). Frame 0 is
-/// derived by validating and `safe_load`-ing `fp` exactly like every
-/// subsequent frame — there is nothing "trusted" about it. On a binary built
-/// without `-C force-frame-pointers=yes`, `fp` may not point at a real
-/// `[saved_fp, return_addr]` pair at all; this degrades to an empty,
-/// non-truncated result instead of a raw dereference of arbitrary memory.
-///
-/// # Safety
-/// - `install_handler` must have been called.
-/// - Must be called such that `fp` is a live frame pointer of the calling
-///   thread's own stack (not another thread's, and not a value obtained by
-///   dereferencing memory) and `sp` is that thread's current stack pointer.
-pub unsafe fn unwind_from_frame_pointer(fp: usize, sp: usize, out: &mut [u64]) -> CaptureResult {
-    unsafe { unwind_loop(fp, sp, out, 0) }
 }
 
 /// Unwind from inside a signal handler given the raw ucontext.
@@ -496,149 +473,5 @@ mod tests {
         assert_eq!(n, 1, "unwind must stop when ret_addr load faults");
         assert!(!truncated);
         assert_eq!(out[0], 0x40_0000);
-    }
-
-    // `unwind_from_frame_pointer` derives frame 0 itself via the same
-    // validated, `safe_load`-guarded path used for every other frame,
-    // instead of trusting a raw dereference of a live register value. These
-    // mirror the `unwind()` synthetic-stack tests above, but exercise frame
-    // 0's derivation directly.
-
-    #[test]
-    fn from_frame_pointer_walks_valid_chain() {
-        install();
-        let sz = std::mem::size_of::<usize>();
-        let mut stack = [0usize; 8];
-        let base = stack.as_mut_ptr() as usize;
-
-        // Frame C (4,5) is its own saved fp, with a non-zero return address
-        // so the walk stops on the "must advance" check rather than an
-        // incidental dead-zone rejection of a zeroed slot.
-        stack[0] = base + 2 * sz;
-        stack[1] = 0x40_1000;
-        stack[2] = base + 4 * sz;
-        stack[3] = 0x40_2000;
-        stack[4] = base + 4 * sz;
-        stack[5] = 0x40_3000;
-
-        let mut out = [0u64; MAX_FRAMES];
-        let CaptureResult {
-            frames_written: n,
-            truncated,
-        } = unsafe { unwind_from_frame_pointer(base, base, &mut out) };
-
-        assert_eq!(n, 2);
-        assert!(!truncated);
-        assert_eq!(out[0], 0x40_1000);
-        assert_eq!(out[1], 0x40_2000);
-    }
-
-    #[test]
-    fn from_frame_pointer_reports_zero_frames_on_misaligned_fp() {
-        install();
-        let sp = 0x7fff_0000_0000usize;
-        let mut out = [0u64; MAX_FRAMES];
-        let CaptureResult {
-            frames_written: n,
-            truncated,
-        } = unsafe { unwind_from_frame_pointer(sp + 1, sp, &mut out) };
-        assert_eq!(
-            n, 0,
-            "a misaligned live fp must produce zero frames, not a dereference"
-        );
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn from_frame_pointer_reports_zero_frames_when_fp_out_of_range() {
-        install();
-        let sp = 0x7fff_0000_0000usize;
-        let mut out = [0u64; MAX_FRAMES];
-        // fp below sp is out of the assumed [sp, sp + 8MiB) stack range.
-        let CaptureResult {
-            frames_written: n,
-            truncated,
-        } = unsafe { unwind_from_frame_pointer(sp.wrapping_sub(8), sp, &mut out) };
-        assert_eq!(n, 0);
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn from_frame_pointer_stops_safely_when_live_fp_load_faults() {
-        install();
-        let ps = page_size();
-        // Simulates a build without frame pointers handing back a garbage
-        // `fp` that happens to point at unmapped memory: the walk must
-        // degrade to zero frames, not dereference it directly.
-        let guard = unsafe {
-            libc::mmap(
-                std::ptr::null_mut(),
-                ps,
-                libc::PROT_NONE,
-                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
-                -1,
-                0,
-            )
-        };
-        assert_ne!(guard, libc::MAP_FAILED);
-        let fp = guard as usize;
-
-        let mut out = [0u64; MAX_FRAMES];
-        let CaptureResult {
-            frames_written: n,
-            truncated,
-        } = unsafe { unwind_from_frame_pointer(fp, fp, &mut out) };
-
-        assert_eq!(unsafe { libc::munmap(guard, ps) }, 0);
-
-        assert_eq!(
-            n, 0,
-            "a faulting live fp must produce zero frames, not a crash"
-        );
-        assert!(!truncated);
-    }
-
-    #[test]
-    fn from_frame_pointer_respects_output_buffer_limit() {
-        install();
-        let sz = std::mem::size_of::<usize>();
-        let mut stack = [0usize; 8];
-        let base = stack.as_mut_ptr() as usize;
-
-        stack[0] = base + 2 * sz;
-        stack[1] = 0x40_1000;
-        stack[2] = base + 4 * sz;
-        stack[3] = 0x40_2000;
-        stack[4] = base + 4 * sz;
-
-        let mut out = [0u64; 1];
-        let CaptureResult {
-            frames_written: n,
-            truncated,
-        } = unsafe { unwind_from_frame_pointer(base, base, &mut out) };
-        assert_eq!(n, 1);
-        assert!(truncated, "a valid next frame existed but had no room");
-        assert_eq!(out[0], 0x40_1000);
-    }
-
-    #[test]
-    fn from_frame_pointer_with_empty_buffer_reports_truncation_only_if_valid() {
-        install();
-        let sz = std::mem::size_of::<usize>();
-        let mut stack = [0usize; 2];
-        let base = stack.as_mut_ptr() as usize;
-        stack[0] = base + 2 * sz; // would advance validly if there were room
-        stack[1] = 0x40_1000;
-
-        let mut out: [u64; 0] = [];
-        let CaptureResult {
-            frames_written: n,
-            truncated,
-        } = unsafe { unwind_from_frame_pointer(base, base, &mut out) };
-        assert_eq!(n, 0);
-        assert!(
-            truncated,
-            "a genuinely valid frame existed; zero room means truncated"
-        );
     }
 }

--- a/perf-self-profile/src/unwinder.rs
+++ b/perf-self-profile/src/unwinder.rs
@@ -96,7 +96,9 @@ impl Unwinder {
     /// capture returns frame 0 and stops. This lets binaries without frame
     /// pointers degrade to an empty or shallow stack instead of crashing,
     /// although arbitrary register values can occasionally resemble a valid
-    /// frame record.
+    /// frame record. Detect missing frame pointers with
+    /// [`self_test_frame_pointers`](Self::self_test_frame_pointers) rather
+    /// than relying on `capture` to fail loudly.
     ///
     /// # Safety
     /// - [`install`](Self::install) must have succeeded and the SIGSEGV
@@ -124,6 +126,136 @@ impl Unwinder {
         // SAFETY: forwarding Unwinder::capture's own safety contract to
         // platform::capture (handler installed, not in a SIGSEGV handler).
         unsafe { platform::capture(out) }
+    }
+
+    /// Checks whether this binary looks like it was built with
+    /// `-C force-frame-pointers=yes`.
+    ///
+    /// Recurses a fixed depth through this module's own `#[inline(never)]`
+    /// function on a dedicated thread, then inspects the captured stack —
+    /// by symbol name where available (layout-independent), falling back
+    /// to a raw frame-count threshold otherwise.
+    ///
+    /// Returns `None` if the self-test itself couldn't run (thread spawn
+    /// or panic) — inconclusive, not evidence of missing frame pointers.
+    pub fn self_test_frame_pointers(&self) -> Option<FramePointerSelfTest> {
+        let unwinder = *self;
+        let join = std::thread::Builder::new()
+            .name("dial9-fp-selftest".to_string())
+            .spawn(move || self_test::run(&unwinder))
+            .ok()?;
+        join.join().ok()
+    }
+}
+
+/// Result of [`Unwinder::self_test_frame_pointers`].
+///
+/// `#[non_exhaustive]` so new fields can be added without breaking callers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct FramePointerSelfTest {
+    /// A match count if `matched_by_symbol`, otherwise a raw frame count.
+    pub frames_captured: usize,
+    /// Minimum `frames_captured` needed to pass.
+    pub expected_min: usize,
+    pub matched_by_symbol: bool,
+}
+
+impl FramePointerSelfTest {
+    /// Whether the self-test result looks like a healthy, frame-pointer-enabled build.
+    pub fn passed(&self) -> bool {
+        self.frames_captured >= self.expected_min
+    }
+}
+
+mod self_test {
+    use super::{FramePointerSelfTest, Unwinder};
+
+    /// Recursion depth used by the self-test. Chosen with slack above
+    /// `EXPECTED_MIN` so ordinary variance (e.g. a couple of frames lost to
+    /// `MAX_FRAME_SIZE`/dead-zone gating near the top of the walk) doesn't
+    /// produce false positives on a healthy build.
+    pub(super) const DEPTH: usize = 16;
+    /// Minimum evidence count required to pass. Tuned empirically.
+    pub(super) const EXPECTED_MIN: usize = 12;
+
+    pub(super) fn run(unwinder: &Unwinder) -> FramePointerSelfTest {
+        let mut frames = [0u64; DEPTH + 4];
+        let written = recurse(unwinder, DEPTH, &mut frames);
+        let captured = &frames[..written];
+
+        if let Some(matched) = verify_by_symbol(captured) {
+            return FramePointerSelfTest {
+                frames_captured: matched,
+                expected_min: EXPECTED_MIN,
+                matched_by_symbol: true,
+            };
+        }
+
+        FramePointerSelfTest {
+            frames_captured: captured.len(),
+            expected_min: EXPECTED_MIN,
+            matched_by_symbol: false,
+        }
+    }
+
+    #[inline(never)]
+    fn recurse(unwinder: &Unwinder, depth: usize, out: &mut [u64]) -> usize {
+        if depth == 0 {
+            // SAFETY: called only from `run`, on the thread
+            // `Unwinder::self_test_frame_pointers` just spawned, after
+            // `Unwinder::install()` has already succeeded (the caller holds
+            // an `Unwinder`); not inside a signal handler.
+            let result = unsafe { unwinder.capture(out) };
+            return result.frames_written;
+        }
+        // Not a tail call (the `black_box` after it forces the recursive
+        // call's result to actually be used), so this frame is guaranteed
+        // to still be on the stack when the base case captures.
+        let n = recurse(unwinder, depth - 1, out);
+        std::hint::black_box(n)
+    }
+
+    /// `None` means nothing resolved at all (e.g. no symbolizer, or a
+    /// stripped binary) — callers should fall back to the frame-count
+    /// check, not read it as "no match". `Some(n)` is the match count,
+    /// which may be 0.
+    #[cfg(any(
+        target_os = "linux",
+        all(target_os = "android", target_arch = "aarch64")
+    ))]
+    fn verify_by_symbol(frames: &[u64]) -> Option<usize> {
+        use blazesym::symbolize::Symbolizer;
+
+        let maps = crate::read_proc_maps();
+        let symbolizer = Symbolizer::new();
+        let mut matched = 0;
+        let mut any_resolved = false;
+        for &addr in frames {
+            match crate::resolve_symbol_with_maps(addr, &symbolizer, &maps).name {
+                Some(name) => {
+                    any_resolved = true;
+                    if name.ends_with("self_test::recurse") {
+                        matched += 1;
+                    } else {
+                        // Walked past the self-test's own recursion into its
+                        // caller (`run`, the thread closure, etc.) — the
+                        // chain of interest ends here.
+                        break;
+                    }
+                }
+                None => break,
+            }
+        }
+        any_resolved.then_some(matched)
+    }
+
+    #[cfg(not(any(
+        target_os = "linux",
+        all(target_os = "android", target_arch = "aarch64")
+    )))]
+    fn verify_by_symbol(_frames: &[u64]) -> Option<usize> {
+        None
     }
 }
 
@@ -172,15 +304,14 @@ mod platform {
         unsafe { unwind(pc, fp, sp, out) }
     }
 
-    /// Read `(pc, fp, sp)` such that `pc` is the PC to use for frame 0 and
-    /// `fp` is the saved frame pointer of the frame *above* the current one.
+    /// Read `(pc, fp, sp)` for the caller of [`Unwinder::capture`], reading
+    /// every field through `safe_load` rather than trusting a raw
+    /// dereference.
     ///
     /// Because this is `#[inline(always)]`, the `rbp`/`x29` read observes
     /// `Unwinder::capture`'s frame (its one and only non-inlined ancestor).
-    /// - `*(rbp + 8)` on x86_64 / LR save slot on aarch64 is
-    ///   `Unwinder::capture`'s return address → goes to `out[0]`.
-    /// - `*rbp` / `*x29` is the saved fp of the caller of `Unwinder::capture`
-    ///   → where we start walking the chain.
+    /// `pc` is the return address of `capture` (frame 0); `fp` is the saved
+    /// frame pointer to continue walking from.
     ///
     /// Returns `None` when the current frame record is implausible or its
     /// return-address slot cannot be read safely. An unusable caller frame

--- a/perf-self-profile/src/unwinder.rs
+++ b/perf-self-profile/src/unwinder.rs
@@ -197,10 +197,10 @@ impl std::error::Error for SelfTestError {
 #[non_exhaustive]
 pub struct FramePointerSelfTest {
     /// A match count if `matched_by_symbol`, otherwise a raw frame count.
-    pub frames_captured: usize,
+    pub(crate) frames_captured: usize,
     /// Minimum `frames_captured` needed to pass.
-    pub expected_min: usize,
-    pub matched_by_symbol: bool,
+    pub(crate) expected_min: usize,
+    pub(crate) matched_by_symbol: bool,
 }
 
 impl FramePointerSelfTest {

--- a/perf-self-profile/src/unwinder.rs
+++ b/perf-self-profile/src/unwinder.rs
@@ -132,9 +132,8 @@ impl Unwinder {
     /// `-C force-frame-pointers=yes`.
     ///
     /// Recurses a fixed depth through this module's own `#[inline(never)]`
-    /// function on a dedicated thread, then inspects the captured stack —
-    /// by symbol name where available (layout-independent), falling back
-    /// to a raw frame-count threshold otherwise.
+    /// function on a dedicated thread, then checks the captured frame
+    /// count against a threshold.
     ///
     /// Returns `Err` if the self-test itself couldn't run (thread spawn
     /// failure or panic) — inconclusive, not evidence of missing frame
@@ -196,11 +195,10 @@ impl std::error::Error for SelfTestError {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct FramePointerSelfTest {
-    /// A match count if `matched_by_symbol`, otherwise a raw frame count.
+    /// Number of frames captured by the self-test's recursion.
     pub(crate) frames_captured: usize,
     /// Minimum `frames_captured` needed to pass.
     pub(crate) expected_min: usize,
-    pub(crate) matched_by_symbol: bool,
 }
 
 impl FramePointerSelfTest {
@@ -224,20 +222,9 @@ mod self_test {
     pub(super) fn run(unwinder: &Unwinder) -> FramePointerSelfTest {
         let mut frames = [0u64; DEPTH + 4];
         let written = recurse(unwinder, DEPTH, &mut frames);
-        let captured = &frames[..written];
-
-        if let Some(matched) = verify_by_symbol(captured) {
-            return FramePointerSelfTest {
-                frames_captured: matched,
-                expected_min: EXPECTED_MIN,
-                matched_by_symbol: true,
-            };
-        }
-
         FramePointerSelfTest {
-            frames_captured: captured.len(),
+            frames_captured: written,
             expected_min: EXPECTED_MIN,
-            matched_by_symbol: false,
         }
     }
 
@@ -256,48 +243,6 @@ mod self_test {
         // to still be on the stack when the base case captures.
         let n = recurse(unwinder, depth - 1, out);
         std::hint::black_box(n)
-    }
-
-    /// `None` means nothing resolved at all (e.g. no symbolizer, or a
-    /// stripped binary) — callers should fall back to the frame-count
-    /// check, not read it as "no match". `Some(n)` is the match count,
-    /// which may be 0.
-    #[cfg(any(
-        target_os = "linux",
-        all(target_os = "android", target_arch = "aarch64")
-    ))]
-    fn verify_by_symbol(frames: &[u64]) -> Option<usize> {
-        use blazesym::symbolize::Symbolizer;
-
-        let maps = crate::read_proc_maps();
-        let symbolizer = Symbolizer::new();
-        let mut matched = 0;
-        let mut any_resolved = false;
-        for &addr in frames {
-            match crate::resolve_symbol_with_maps(addr, &symbolizer, &maps).name {
-                Some(name) => {
-                    any_resolved = true;
-                    if name.ends_with("self_test::recurse") {
-                        matched += 1;
-                    } else {
-                        // Walked past the self-test's own recursion into its
-                        // caller (`run`, the thread closure, etc.) — the
-                        // chain of interest ends here.
-                        break;
-                    }
-                }
-                None => break,
-            }
-        }
-        any_resolved.then_some(matched)
-    }
-
-    #[cfg(not(any(
-        target_os = "linux",
-        all(target_os = "android", target_arch = "aarch64")
-    )))]
-    fn verify_by_symbol(_frames: &[u64]) -> Option<usize> {
-        None
     }
 }
 

--- a/perf-self-profile/src/unwinder.rs
+++ b/perf-self-profile/src/unwinder.rs
@@ -136,15 +136,57 @@ impl Unwinder {
     /// by symbol name where available (layout-independent), falling back
     /// to a raw frame-count threshold otherwise.
     ///
-    /// Returns `None` if the self-test itself couldn't run (thread spawn
-    /// or panic) — inconclusive, not evidence of missing frame pointers.
-    pub fn self_test_frame_pointers(&self) -> Option<FramePointerSelfTest> {
+    /// Returns `Err` if the self-test itself couldn't run (thread spawn
+    /// failure or panic) — inconclusive, not evidence of missing frame
+    /// pointers, but the cause is preserved rather than discarded.
+    pub fn self_test_frame_pointers(&self) -> Result<FramePointerSelfTest, SelfTestError> {
         let unwinder = *self;
         let join = std::thread::Builder::new()
             .name("dial9-fp-selftest".to_string())
             .spawn(move || self_test::run(&unwinder))
-            .ok()?;
-        join.join().ok()
+            .map_err(SelfTestError::Spawn)?;
+        join.join().map_err(SelfTestError::from_panic_payload)
+    }
+}
+
+/// Error from [`Unwinder::self_test_frame_pointers`] when the self-test
+/// itself couldn't run — inconclusive, not evidence of missing frame
+/// pointers.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum SelfTestError {
+    /// Failed to spawn the dedicated self-test thread.
+    Spawn(std::io::Error),
+    /// The self-test thread panicked.
+    Panicked(String),
+}
+
+impl SelfTestError {
+    fn from_panic_payload(payload: Box<dyn std::any::Any + Send>) -> Self {
+        let msg = payload
+            .downcast_ref::<&str>()
+            .map(|s| s.to_string())
+            .or_else(|| payload.downcast_ref::<String>().cloned())
+            .unwrap_or_else(|| "non-string panic payload".to_string());
+        Self::Panicked(msg)
+    }
+}
+
+impl std::fmt::Display for SelfTestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Spawn(e) => write!(f, "failed to spawn frame-pointer self-test thread: {e}"),
+            Self::Panicked(msg) => write!(f, "frame-pointer self-test thread panicked: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for SelfTestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Spawn(e) => Some(e),
+            Self::Panicked(_) => None,
+        }
     }
 }
 
@@ -759,5 +801,36 @@ mod tests {
             let err = Unwinder::install().unwrap_err();
             assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
         }
+    }
+
+    // `SelfTestError::from_panic_payload` is pure platform-independent logic
+    // (no threading needed to exercise it), so these run on every target.
+    use super::SelfTestError;
+
+    #[test]
+    fn from_panic_payload_extracts_str_message() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new("boom");
+        assert!(matches!(
+            SelfTestError::from_panic_payload(payload),
+            SelfTestError::Panicked(m) if m == "boom"
+        ));
+    }
+
+    #[test]
+    fn from_panic_payload_extracts_string_message() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new(String::from("kaboom"));
+        assert!(matches!(
+            SelfTestError::from_panic_payload(payload),
+            SelfTestError::Panicked(m) if m == "kaboom"
+        ));
+    }
+
+    #[test]
+    fn from_panic_payload_falls_back_on_unknown_type() {
+        let payload: Box<dyn std::any::Any + Send> = Box::new(42i32);
+        assert!(matches!(
+            SelfTestError::from_panic_payload(payload),
+            SelfTestError::Panicked(m) if m == "non-string panic payload"
+        ));
     }
 }


### PR DESCRIPTION
closes #779

- add a frame-pointer self-test run at MemoryProfiler::install() time
  - detection uses frame count
  - log a warning whenever the self-test fails
  - configurable behavior through `fail_on_missing_frame_pointers`:
    - return `InstallError::MissingFramePointers` on failure (default) - `fail_on_missing_frame_pointers(true)`
    - proceed (return Ok) - `fail_on_missing_frame_pointers(false)`
- add CI job verifying the self-test catches a build without -C force-frame-pointers=yes

Tests
- add coverage for the hard-fail and fail_on_missing_frame_pointers(false) paths
- Ran
  - cargo check -p dial9-perf-self-profile / -p dial9 --features memory-profiling
  -  cargo test -p dial9-perf-self-profile --lib (28 passed)
  -  cargo fmt --check, clippy clean
  -  cargo test -p dial9 --features memory-profiling --test memory_profiling_missing_frame_pointers -- --ignored, in Docker (2 passed)
  - cargo nextest run --stress-duration 20s (1301 passed, 0 failed)
