### PR TITLE
fix: safely bootstrap frame-pointer capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,17 @@ jobs:
           sudo prlimit --pid $$ --memlock=unlimited:unlimited
           cargo test -p dial9-perf-self-profile --lib --all-features \
             -Z build-std --target x86_64-unknown-linux-gnu
+      - name: Run memory profiler under ASAN without frame pointers
+        env:
+          CARGO_TARGET_DIR: target/asan-no-frame-pointers
+          RUSTFLAGS: "--cfg tokio_unstable -C force-frame-pointers=no -Zsanitizer=address"
+        run: |
+          cargo test --release \
+            -p dial9-perf-self-profile \
+            --test memory_profiler_no_frame_pointers \
+            --features memory-profiling \
+            -Z build-std --target x86_64-unknown-linux-gnu \
+            -- --exact allocation_hook_survives_best_effort_stack_capture
       - name: Restrict perf_event_open to force ctimer path
         run: sudo sysctl kernel.perf_event_paranoid=3
       - name: Run perf-self-profile tests under ASAN (ctimer path)

--- a/perf-self-profile/src/memory_profiling/profiler.rs
+++ b/perf-self-profile/src/memory_profiling/profiler.rs
@@ -136,9 +136,9 @@ impl std::error::Error for InstallError {
 /// Install is permanent for the life of the process.
 ///
 /// # Requirements
-/// - Frame pointers: allocation stacks are captured with a frame-pointer
-///   unwinder, so the binary must be built with
-///   `-C force-frame-pointers=yes`.
+/// - Frame pointers are required for complete allocation stacks (build with
+///   `-C force-frame-pointers=yes`). Without them, profiling remains safe but
+///   records empty or shallow stacks.
 /// - [`Dial9Allocator`](crate::memory_profiling::Dial9Allocator) must be
 ///   installed as the `#[global_allocator]` for allocations to reach the
 ///   sampling hook.
@@ -160,8 +160,8 @@ impl MemoryProfiler {
 
     /// Install the profiler with the given handle.
     ///
-    /// Requires a binary built with `-C force-frame-pointers=yes`; see the
-    /// [type-level requirements](MemoryProfiler#requirements).
+    /// Build with `-C force-frame-pointers=yes` for complete allocation stacks;
+    /// see the [type-level requirements](MemoryProfiler#requirements).
     ///
     /// On a disconnected handle, install is a no-op (returns `Ok` but does
     /// not publish state). `ACTIVE.get()` remains `None` so the allocator

--- a/perf-self-profile/src/sys/linux/fp_profiler/mod.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/mod.rs
@@ -20,6 +20,7 @@ compile_error!(
 
 mod supported {
     use std::ptr;
+    use std::sync::Mutex;
     use std::sync::atomic::AtomicPtr;
     use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -73,7 +74,46 @@ mod supported {
         unsafe { safe_load(ptr) }
     }
 
-    static HANDLER_INSTALLED: AtomicBool = AtomicBool::new(false);
+    struct HandlerInstallation {
+        installed: AtomicBool,
+        lock: Mutex<()>,
+    }
+
+    impl HandlerInstallation {
+        const fn new() -> Self {
+            Self {
+                installed: AtomicBool::new(false),
+                lock: Mutex::new(()),
+            }
+        }
+
+        fn install(
+            &self,
+            install: impl FnOnce() -> Result<(), std::io::Error>,
+        ) -> Result<(), std::io::Error> {
+            if self.installed.load(Ordering::Acquire) {
+                return Ok(());
+            }
+
+            let _guard = self
+                .lock
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if self.installed.load(Ordering::Relaxed) {
+                return Ok(());
+            }
+
+            install()?;
+            self.installed.store(true, Ordering::Release);
+            Ok(())
+        }
+
+        fn is_installed(&self) -> bool {
+            self.installed.load(Ordering::Acquire)
+        }
+    }
+
+    static HANDLER_INSTALLATION: HandlerInstallation = HandlerInstallation::new();
     static OLD_HANDLER: AtomicPtr<libc::sigaction> = AtomicPtr::new(ptr::null_mut());
     /// `true` after we have successfully registered with `libsigchain`. On
     /// non-Android platforms this is always `false` and unused.
@@ -110,15 +150,7 @@ mod supported {
     /// Modifies process-global signal state. Call once during initialization.
     #[cfg(not(target_os = "android"))]
     pub unsafe fn install_handler() -> Result<(), std::io::Error> {
-        if HANDLER_INSTALLED.swap(true, Ordering::SeqCst) {
-            return Ok(()); // already installed
-        }
-
-        if let Err(err) = unsafe { install_sigaction_handler() } {
-            HANDLER_INSTALLED.store(false, Ordering::SeqCst);
-            return Err(err);
-        }
-        Ok(())
+        HANDLER_INSTALLATION.install(|| unsafe { install_sigaction_handler() })
     }
 
     /// Android variant: register our safe_load fault handler with ART's
@@ -127,27 +159,23 @@ mod supported {
     /// (e.g. a plain adb-shell binary, no ART), installs the direct handler.
     #[cfg(target_os = "android")]
     pub unsafe fn install_handler() -> Result<(), std::io::Error> {
-        if HANDLER_INSTALLED.swap(true, Ordering::SeqCst) {
-            return Ok(()); // already attempted
-        }
-        // SAFETY: `sigchain_safe_load_handler` is async-signal-safe, returns
-        // `false` for non-safe_load faults, and lives for the lifetime of the
-        // process.
-        let ok = unsafe { super::android_sigchain::try_register(sigchain_safe_load_handler) };
-        if ok {
-            SIGCHAIN_REGISTERED.store(true, Ordering::SeqCst);
-            tracing::info!(
-                "libsigchain safe_load handler registered; frame-pointer unwinding enabled"
-            );
-        } else {
-            if let Err(err) = unsafe { install_sigaction_handler() } {
-                HANDLER_INSTALLED.store(false, Ordering::SeqCst);
-                return Err(err);
+        HANDLER_INSTALLATION.install(|| {
+            // SAFETY: `sigchain_safe_load_handler` is async-signal-safe,
+            // returns `false` for non-safe_load faults, and lives for the
+            // lifetime of the process.
+            let ok = unsafe { super::android_sigchain::try_register(sigchain_safe_load_handler) };
+            if ok {
+                SIGCHAIN_REGISTERED.store(true, Ordering::SeqCst);
+                tracing::info!(
+                    "libsigchain safe_load handler registered; frame-pointer unwinding enabled"
+                );
+            } else {
+                unsafe { install_sigaction_handler() }?;
+                DIRECT_HANDLER_INSTALLED.store(true, Ordering::SeqCst);
+                tracing::info!("libsigchain not loaded; direct safe_load handler registered");
             }
-            DIRECT_HANDLER_INSTALLED.store(true, Ordering::SeqCst);
-            tracing::info!("libsigchain not loaded; direct safe_load handler registered");
-        }
-        Ok(())
+            Ok(())
+        })
     }
 
     /// Check whether our SIGSEGV handler is still the active handler for
@@ -162,7 +190,7 @@ mod supported {
     #[cfg(not(target_os = "android"))]
     pub fn handler_is_installed() -> bool {
         // If we never installed, we cannot be installed.
-        if !HANDLER_INSTALLED.load(Ordering::SeqCst) {
+        if !HANDLER_INSTALLATION.is_installed() {
             return false;
         }
 
@@ -186,6 +214,9 @@ mod supported {
     /// registered for the lifetime of the process.
     #[cfg(target_os = "android")]
     pub fn handler_is_installed() -> bool {
+        if !HANDLER_INSTALLATION.is_installed() {
+            return false;
+        }
         if SIGCHAIN_REGISTERED.load(Ordering::SeqCst) {
             return true;
         }
@@ -340,6 +371,52 @@ mod supported {
     #[cfg(all(target_arch = "aarch64", target_os = "android"))]
     unsafe fn set_result_reg(uc: *mut libc::c_void, val: usize) {
         unsafe { super::bionic_arm64::android_ucontext_set_result_reg(uc, val as u64) };
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::HandlerInstallation;
+        use std::sync::{Arc, mpsc};
+        use std::time::Duration;
+
+        #[test]
+        fn concurrent_installer_waits_for_installation_to_finish() {
+            let installation = Arc::new(HandlerInstallation::new());
+            let (entered_tx, entered_rx) = mpsc::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+            let first = {
+                let installation = Arc::clone(&installation);
+                std::thread::spawn(move || {
+                    installation.install(|| {
+                        entered_tx.send(()).unwrap();
+                        release_rx.recv().unwrap();
+                        Ok(())
+                    })
+                })
+            };
+            entered_rx.recv().unwrap();
+
+            let (started_tx, started_rx) = mpsc::channel();
+            let (returned_tx, returned_rx) = mpsc::channel();
+            let second = {
+                let installation = Arc::clone(&installation);
+                std::thread::spawn(move || {
+                    started_tx.send(()).unwrap();
+                    let result = installation.install(|| panic!("installer ran twice"));
+                    returned_tx.send(result).unwrap();
+                })
+            };
+            started_rx.recv().unwrap();
+            assert!(
+                returned_rx.recv_timeout(Duration::from_millis(50)).is_err(),
+                "concurrent installer returned before installation completed"
+            );
+
+            release_tx.send(()).unwrap();
+            first.join().unwrap().unwrap();
+            second.join().unwrap();
+            returned_rx.recv().unwrap().unwrap();
+        }
     }
 }
 

--- a/perf-self-profile/src/sys/linux/fp_profiler/mod.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/mod.rs
@@ -170,6 +170,8 @@ mod supported {
                     "libsigchain safe_load handler registered; frame-pointer unwinding enabled"
                 );
             } else {
+                // SAFETY: the outer `install_handler` call accepts process-global
+                // signal-state mutation, which `HANDLER_INSTALLATION` serializes.
                 unsafe { install_sigaction_handler() }?;
                 DIRECT_HANDLER_INSTALLED.store(true, Ordering::SeqCst);
                 tracing::info!("libsigchain not loaded; direct safe_load handler registered");

--- a/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
+++ b/perf-self-profile/src/sys/linux/fp_profiler/unwind.rs
@@ -25,11 +25,11 @@ use crate::unwinder::CaptureResult;
 pub const MAX_FRAMES: usize = 128;
 
 // Minimum distance from address-space edges for a plausible return address.
-const DEAD_ZONE: usize = 0x1000;
+pub(crate) const DEAD_ZONE: usize = 0x1000;
 
 /// Maximum plausible single-frame advance of the frame pointer (256 KiB).
 /// Rejects wild pointers that happen to be above fp but aren't real frames.
-const MAX_FRAME_SIZE: usize = 0x40000;
+pub(crate) const MAX_FRAME_SIZE: usize = 0x40000;
 
 /// Strip pointer authentication (PAC) bits from a return address.
 ///

--- a/perf-self-profile/src/unwinder.rs
+++ b/perf-self-profile/src/unwinder.rs
@@ -45,8 +45,9 @@ impl Unwinder {
     /// Returns `Err` if `sigaction` fails (Linux) or if the platform is
     /// unsupported.
     ///
-    /// # Requirements
-    /// - Frame pointers (build with `-C force-frame-pointers=yes`).
+    /// Frame pointers are required for complete stacks (build with
+    /// `-C force-frame-pointers=yes`). Without them, capture safely returns an
+    /// empty or shallow stack.
     pub fn install() -> std::io::Result<Self> {
         platform::install()?;
         Ok(Self { _private: () })
@@ -87,6 +88,13 @@ impl Unwinder {
     /// are kept and outer frames are dropped; `CaptureResult::truncated`
     /// is set to `true`.
     ///
+    /// If the current frame record is implausible or unreadable, capture
+    /// returns no frames. If only the caller's frame pointer is unusable,
+    /// capture returns frame 0 and stops. This lets binaries without frame
+    /// pointers degrade to an empty or shallow stack instead of crashing,
+    /// although arbitrary register values can occasionally resemble a valid
+    /// frame record.
+    ///
     /// # Safety
     /// - [`install`](Self::install) must have succeeded and the SIGSEGV
     ///   handler it registered must still be active. If another library
@@ -97,10 +105,6 @@ impl Unwinder {
     ///   installation.
     /// - Must not be called from inside a signal handler for SIGSEGV
     ///   (that would recurse into our own handler without bound).
-    /// - The calling thread's stack must be valid for frame-pointer walking
-    ///   (binary compiled with `-C force-frame-pointers=yes`, no code
-    ///   currently executing in a prologue/epilogue window where `rbp`
-    ///   does not point at a saved-fp slot).
     // Takes `&self` to prove that `Unwinder::install()` succeeded, even though
     // no instance data is accessed internally.
     #[inline(never)]
@@ -115,8 +119,7 @@ impl Unwinder {
              something replaced it without chaining. See Unwinder::verify_handler."
         );
         // SAFETY: forwarding Unwinder::capture's own safety contract to
-        // platform::capture (handler installed, not in a SIGSEGV handler,
-        // frame pointers enabled).
+        // platform::capture (handler installed, not in a SIGSEGV handler).
         unsafe { platform::capture(out) }
     }
 }
@@ -127,7 +130,10 @@ impl Unwinder {
 ))]
 mod platform {
     use super::CaptureResult;
-    use crate::sys::fp_profiler::{handler_is_installed, install_handler, unwind::unwind};
+    use crate::sys::fp_profiler::{
+        SAFE_LOAD_FAULT, handler_is_installed, install_handler, load,
+        unwind::{DEAD_ZONE, MAX_FRAME_SIZE, strip_pac, unwind},
+    };
 
     pub fn install() -> std::io::Result<()> {
         // SAFETY: installs the SIGSEGV handler for safe_load; idempotent.
@@ -145,14 +151,18 @@ mod platform {
     /// test.
     ///
     /// # Safety
-    /// Same obligations as [`Unwinder::capture`]: handler installed,
-    /// not inside a SIGSEGV handler, frame pointers enabled.
+    /// Same obligations as [`Unwinder::capture`]: handler installed and not
+    /// inside a SIGSEGV handler.
     #[inline(always)]
     pub unsafe fn capture(out: &mut [u64]) -> CaptureResult {
-        // SAFETY: called from Unwinder::capture which forwards the full
-        // safety contract (handler installed, frame pointers enabled, not
-        // inside a SIGSEGV handler, not in a prologue/epilogue window).
-        let (pc, fp, sp) = unsafe { read_caller_regs() };
+        // SAFETY: called from Unwinder::capture which forwards the safety
+        // contract (handler installed and not inside a SIGSEGV handler).
+        let Some((pc, fp, sp)) = (unsafe { read_caller_regs() }) else {
+            return CaptureResult {
+                frames_written: 0,
+                truncated: false,
+            };
+        };
         // SAFETY: handler is installed (caller holds Unwinder), and we are
         // not inside a SIGSEGV handler (see Unwinder::capture safety
         // contract).
@@ -169,33 +179,20 @@ mod platform {
     /// - `*rbp` / `*x29` is the saved fp of the caller of `Unwinder::capture`
     ///   → where we start walking the chain.
     ///
+    /// Returns `None` when the current frame record is implausible or its
+    /// return-address slot cannot be read safely. An unusable caller frame
+    /// pointer is returned as zero so the unwind retains frame 0 and stops.
+    ///
     /// # Safety
-    /// - Must be called with `#[inline(always)]` preserved so the read
-    ///   observes `Unwinder::capture`'s frame, not this helper's. If ever
-    ///   actually inlined into a different caller or promoted to a
-    ///   standalone frame, the returned `fp`/return-address semantics
-    ///   change and the frame-0 contract breaks.
-    /// - Must only be called after [`install_handler`] has succeeded.
-    ///   Reading `*fp` and `*(fp+8)` is a raw dereference of the stack;
-    ///   the SIGSEGV handler installed by `install_handler` does *not*
-    ///   cover these reads (it only covers `safe_load`). The reads are
-    ///   safe only because — on a thread built with
-    ///   `-C force-frame-pointers=yes` — the kernel/ABI guarantees that
-    ///   `rbp`/`x29` always points at a valid `[saved_fp, ret_addr]`
-    ///   pair for the currently executing function.
-    /// - The calling binary must be compiled with
-    ///   `-C force-frame-pointers=yes`. Without frame pointers, `rbp`
-    ///   may be used as a general-purpose register and the raw reads
-    ///   will dereference arbitrary memory.
-    /// - Must not be called during function prologue/epilogue or other
-    ///   windows where `rbp`/`x29` does not yet (or no longer) points at
-    ///   a saved-fp slot. For the intended call site inside
-    ///   `Unwinder::capture`'s body this is always satisfied; calling
-    ///   from hand-written asm shims, signal-trampoline code, or from
-    ///   within another `naked` function is not supported.
+    /// - Must be called with `#[inline(always)]` preserved so the register
+    ///   read observes `Unwinder::capture`'s frame, not this helper's. If
+    ///   inlined into a different caller or promoted to a standalone frame,
+    ///   the returned `fp`/return-address semantics change.
+    /// - Must only be called after [`install_handler`] has succeeded and not
+    ///   from inside a SIGSEGV handler.
     #[cfg(target_arch = "x86_64")]
     #[inline(always)]
-    unsafe fn read_caller_regs() -> (usize, usize, usize) {
+    unsafe fn read_caller_regs() -> Option<(usize, usize, usize)> {
         let fp: usize;
         let sp: usize;
         // SAFETY: Reading `rbp`/`rsp` with `nostack, nomem` has no memory
@@ -210,20 +207,13 @@ mod platform {
                 options(nostack, nomem),
             );
         }
-        // SAFETY: `fp` is `Unwinder::capture`'s frame pointer (see top-level
-        // # Safety note). On x86_64 System V, with frame pointers enabled,
-        // a compiler-generated frame begins with
-        //   [saved_rbp : usize, return_addr : usize, ...]
-        // so `*fp` and `*(fp + 8)` are guaranteed to be valid reads of
-        // currently-live stack memory for this frame.
-        let ret_addr = unsafe { *(fp as *const usize).add(1) };
-        let caller_fp = unsafe { *(fp as *const usize) };
-        (ret_addr, caller_fp, sp)
+        // SAFETY: the caller guarantees the safe-load handler is active.
+        unsafe { read_frame_record(fp, sp) }
     }
 
     #[cfg(target_arch = "aarch64")]
     #[inline(always)]
-    unsafe fn read_caller_regs() -> (usize, usize, usize) {
+    unsafe fn read_caller_regs() -> Option<(usize, usize, usize)> {
         let fp: usize;
         let sp: usize;
         // SAFETY: Reading `x29`/`sp` with `nostack, nomem` has no memory
@@ -238,15 +228,111 @@ mod platform {
                 options(nostack, nomem),
             );
         }
-        // SAFETY: Same layout as x86_64 under AAPCS64 with frame pointers:
-        //   [saved_fp (x29) : u64, saved_lr : u64, ...]
-        // so `*fp` and `*(fp + 8)` are valid reads of live stack memory.
-        let ret_addr = unsafe { *(fp as *const usize).add(1) };
-        // Strip pointer authentication bits (ARMv8.3-A PAC). The saved LR may
-        // be signed when compiled with `-Z branch-protection=pac-ret`.
-        let ret_addr = crate::sys::fp_profiler::unwind::strip_pac(ret_addr);
-        let caller_fp = unsafe { *(fp as *const usize) };
-        (ret_addr, caller_fp, sp)
+        // SAFETY: the caller guarantees the safe-load handler is active.
+        unsafe { read_frame_record(fp, sp) }
+    }
+
+    #[inline(always)]
+    unsafe fn read_frame_record(fp: usize, sp: usize) -> Option<(usize, usize, usize)> {
+        let word = core::mem::size_of::<usize>();
+        if fp < sp || fp - sp > MAX_FRAME_SIZE || fp & (word - 1) != 0 {
+            return None;
+        }
+
+        let ret_addr_slot = fp.checked_add(word)?;
+        // SAFETY: the slot is aligned and the caller guarantees the
+        // safe-load handler is active.
+        let ret_addr = strip_pac(unsafe { load(ret_addr_slot as *const usize) });
+        if ret_addr == SAFE_LOAD_FAULT || !(DEAD_ZONE..=usize::MAX - DEAD_ZONE).contains(&ret_addr)
+        {
+            return None;
+        }
+
+        // SAFETY: `fp` is aligned and the safe-load handler is active.
+        let caller_fp = unsafe { load(fp as *const usize) };
+        let caller_fp =
+            if caller_fp != SAFE_LOAD_FAULT && caller_fp > fp && caller_fp - fp <= MAX_FRAME_SIZE {
+                caller_fp
+            } else {
+                0
+            };
+
+        Some((ret_addr, caller_fp, sp))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        fn install() {
+            // SAFETY: tests install the process-global handler idempotently.
+            unsafe { install_handler().unwrap() };
+        }
+
+        fn page_size() -> usize {
+            let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+            assert!(page_size > 0);
+            page_size as usize
+        }
+
+        #[test]
+        fn unreadable_return_address_degrades_to_no_frames() {
+            install();
+            let page_size = page_size();
+            let page = unsafe {
+                libc::mmap(
+                    core::ptr::null_mut(),
+                    page_size,
+                    libc::PROT_NONE,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                    -1,
+                    0,
+                )
+            };
+            assert_ne!(page, libc::MAP_FAILED);
+
+            let result = unsafe { read_frame_record(page as usize, page as usize) };
+
+            assert_eq!(unsafe { libc::munmap(page, page_size) }, 0);
+            assert_eq!(result, None);
+        }
+
+        #[test]
+        fn unreadable_caller_fp_retains_frame_zero() {
+            install();
+            let page_size = page_size();
+            let region = unsafe {
+                libc::mmap(
+                    core::ptr::null_mut(),
+                    2 * page_size,
+                    libc::PROT_NONE,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                    -1,
+                    0,
+                )
+            };
+            assert_ne!(region, libc::MAP_FAILED);
+
+            let second_page = unsafe { region.cast::<u8>().add(page_size) };
+            assert_eq!(
+                unsafe {
+                    libc::mprotect(
+                        second_page.cast(),
+                        page_size,
+                        libc::PROT_READ | libc::PROT_WRITE,
+                    )
+                },
+                0
+            );
+            let ret_addr = DEAD_ZONE + 1;
+            unsafe { second_page.cast::<usize>().write(ret_addr) };
+            let fp = second_page as usize - core::mem::size_of::<usize>();
+
+            let result = unsafe { read_frame_record(fp, fp) };
+
+            assert_eq!(unsafe { libc::munmap(region, 2 * page_size) }, 0);
+            assert_eq!(result, Some((ret_addr, 0, fp)));
+        }
     }
 }
 

--- a/perf-self-profile/src/unwinder.rs
+++ b/perf-self-profile/src/unwinder.rs
@@ -75,12 +75,15 @@ impl Unwinder {
     /// whether the walk was truncated. Never allocates.
     ///
     /// # Frame-0 contract
-    /// `out[0]` is the return address of `capture` itself — i.e. a PC
-    /// *inside the caller of `capture`*. Subsequent frames walk outward
-    /// via the frame-pointer chain. Any `#[inline(never)]` shim inserted
-    /// between the user's code and `capture` will appear as an extra
-    /// frame; plain function calls with frame pointers enabled behave as
-    /// expected.
+    /// With frame pointers enabled, `out[0]` is the return address of `capture`
+    /// itself — i.e. a PC *inside the caller of `capture`*. Subsequent frames
+    /// walk outward via the frame-pointer chain. Any `#[inline(never)]` shim
+    /// inserted between the user's code and `capture` will appear as an extra
+    /// frame.
+    ///
+    /// Without frame pointers, capture is crash-safe but best-effort: output
+    /// may be empty or shallow, and frame 0 is not guaranteed to identify the
+    /// direct caller.
     ///
     /// # Buffer and truncation
     /// At most `out.len().min(MAX_FRAMES)` frames are written (where
@@ -261,6 +264,7 @@ mod platform {
     }
 
     #[cfg(test)]
+    #[allow(unused_assignments)] // frame records are read through safe_load assembly
     mod tests {
         use super::*;
 
@@ -273,6 +277,73 @@ mod platform {
             let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
             assert!(page_size > 0);
             page_size as usize
+        }
+
+        #[test]
+        fn valid_frame_record_is_read() {
+            install();
+            let mut frame = [0usize; 2];
+            let fp = frame.as_mut_ptr() as usize;
+            let caller_fp = fp + 2 * core::mem::size_of::<usize>();
+            let ret_addr = DEAD_ZONE + 1;
+            frame[0] = caller_fp;
+            frame[1] = ret_addr;
+
+            let result = unsafe { read_frame_record(fp, fp) };
+
+            assert_eq!(result, Some((ret_addr, caller_fp, fp)));
+        }
+
+        #[test]
+        fn implausible_frame_pointer_degrades_to_no_frames() {
+            install();
+            let word = core::mem::size_of::<usize>();
+            let sp = 0x10_000usize;
+            let aligned_max = usize::MAX & !(word - 1);
+            let cases = [
+                (sp - word, sp, "below stack pointer"),
+                (
+                    sp + MAX_FRAME_SIZE + word,
+                    sp,
+                    "too far above stack pointer",
+                ),
+                (sp + 1, sp, "misaligned"),
+                (aligned_max, aligned_max, "return-address slot overflows"),
+            ];
+
+            for (fp, sp, case) in cases {
+                let result = unsafe { read_frame_record(fp, sp) };
+                assert_eq!(result, None, "{case}");
+            }
+        }
+
+        #[test]
+        fn implausible_return_address_degrades_to_no_frames() {
+            install();
+            let mut frame = [0usize; 2];
+            let fp = frame.as_mut_ptr() as usize;
+            frame[0] = fp + 2 * core::mem::size_of::<usize>();
+
+            for ret_addr in [SAFE_LOAD_FAULT, DEAD_ZONE - 1] {
+                frame[1] = ret_addr;
+                let result = unsafe { read_frame_record(fp, fp) };
+                assert_eq!(result, None, "return address {ret_addr:#x}");
+            }
+        }
+
+        #[test]
+        fn implausible_caller_frame_pointer_retains_frame_zero() {
+            install();
+            let mut frame = [0usize; 2];
+            let fp = frame.as_mut_ptr() as usize;
+            let ret_addr = DEAD_ZONE + 1;
+            frame[1] = ret_addr;
+
+            for caller_fp in [fp, fp + MAX_FRAME_SIZE + core::mem::size_of::<usize>()] {
+                frame[0] = caller_fp;
+                let result = unsafe { read_frame_record(fp, fp) };
+                assert_eq!(result, Some((ret_addr, 0, fp)));
+            }
         }
 
         #[test]

--- a/perf-self-profile/tests/memory_profiler_no_frame_pointers.rs
+++ b/perf-self-profile/tests/memory_profiler_no_frame_pointers.rs
@@ -1,0 +1,34 @@
+#![cfg(all(
+    feature = "memory-profiling",
+    target_os = "linux",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
+
+use dial9_core::buffer::MemoryBuffer;
+use dial9_core::recorder::recorder;
+use dial9_perf_self_profile::memory_profiling::{
+    Dial9Allocator, MemoryProfiler, MemoryProfilingConfig,
+};
+use std::time::Duration;
+
+#[global_allocator]
+static ALLOC: Dial9Allocator = Dial9Allocator::system();
+
+#[test]
+fn allocation_hook_survives_best_effort_stack_capture() {
+    let recorder = recorder(MemoryBuffer::new(1 << 20).expect("memory buffer")).build();
+    let config = MemoryProfilingConfig::builder()
+        .sample_rate_bytes(1)
+        .ring_capacity(4096)
+        .build();
+    let _guard = MemoryProfiler::from_config(config)
+        .install(recorder.handle().clone())
+        .expect("memory profiler install");
+
+    for size in 1..=2048 {
+        let allocation = vec![0u8; size];
+        std::hint::black_box(allocation);
+    }
+
+    recorder.graceful_shutdown(Duration::from_secs(1));
+}


### PR DESCRIPTION
## Summary

- validate the current frame pointer against the stack pointer before reading its frame record
- route bootstrap return-address and saved-frame-pointer reads through the existing fault-tolerant `safe_load` trampoline
- degrade missing or unusable frame pointers to empty or one-frame captures instead of crashing
- share the existing return-address and frame-size plausibility limits across bootstrap and chain walking

## Tests

- add protected-page coverage for an unreadable return-address slot
- add protected-page coverage proving a readable frame-zero PC survives an unreadable saved frame pointer
- `cargo nextest run` (1,402 passed)
- `cargo nextest run --stress-duration 20s` (1,402 passed)
- `cargo clippy --all-targets --all-features`
- `cargo fmt --all -- --check`

## Performance

The fault-free path adds two direct `safe_load` calls and fixed validation per synchronous `Unwinder::capture`. The existing unwind benchmark indicates this is approximately one frame's fixed overhead; signal-based CPU unwinding and per-frame chain walking are unchanged.
