### PR TITLE
fix(trace-format-derive): resolve the crate path from the caller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2042,6 +2042,7 @@ version = "0.5.0-rc2.1"
 dependencies = [
  "insta",
  "prettyplease",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4017,6 +4018,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error-attr2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5072,6 +5082,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tests-build"
+version = "0.1.0"
+dependencies = [
+ "dial9",
+ "dial9-utils",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5256,6 +5274,36 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -5833,6 +5881,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "examples/metrics-service",
     "examples/simple-local",
     "examples/memory-local",
+    "tests-build",
 ]
 exclude = [
     "dial9-trace-format/fuzz",

--- a/dial9-trace-format-derive/Cargo.toml
+++ b/dial9-trace-format-derive/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "2", features = ["full"] }
+proc-macro-crate = "3"
 quote = "1"
 proc-macro2 = "1"
 

--- a/dial9-trace-format-derive/src/lib.rs
+++ b/dial9-trace-format-derive/src/lib.rs
@@ -4,6 +4,7 @@
 //! attributes.
 
 use proc_macro::TokenStream;
+use proc_macro_crate::{Error as CrateNameError, FoundCrate, crate_name};
 use quote::quote;
 use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
@@ -78,6 +79,46 @@ fn parse_field_attrs(field: &syn::Field) -> Result<FieldAttrs, syn::Error> {
     Ok(parsed)
 }
 
+/// Crates that can supply `dial9-trace-format`, and where it sits inside each.
+/// Checked in order, so the most direct dependency wins.
+const CANDIDATES: &[(&str, Option<&str>)] = &[
+    ("dial9-trace-format", None),
+    ("dial9", Some("__trace_format")),
+];
+
+/// Where the expansion should look for `dial9-trace-format`.
+///
+/// Since a bare `::dial9_trace_format` resolves against the caller's dependencies,
+/// it does not exist for anyone reaching the derive through a re-export.
+/// Instead, we read the caller's manifest to find the path.
+fn resolve_crate_path() -> proc_macro2::TokenStream {
+    for (dep, suffix) in CANDIDATES {
+        let found = match crate_name(dep) {
+            Ok(found) => found,
+            Err(CrateNameError::CrateNotFound { .. }) => continue,
+            // Every lookup reads the same manifest, so retrying is pointless.
+            Err(_) => break,
+        };
+        let root = match found {
+            // Compiling dial9-trace-format's own lib or examples,
+            // `extern crate self` in its lib makes this resolve.
+            FoundCrate::Itself => dep.replace('-', "_"),
+            // The name the caller declared it under, renames included.
+            FoundCrate::Name(name) => name,
+        };
+        let root = proc_macro2::Ident::new(&root, proc_macro2::Span::call_site());
+        return match suffix {
+            None => quote!(::#root),
+            Some(module) => {
+                let module = proc_macro2::Ident::new(module, proc_macro2::Span::call_site());
+                quote!(::#root::#module)
+            }
+        };
+    }
+    // Fall back to the direct dependency
+    quote!(::dial9_trace_format)
+}
+
 fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStream, syn::Error> {
     let name = &input.ident;
 
@@ -131,6 +172,8 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
             })?;
         }
     }
+    let krate = resolve_crate_path();
+
     // The wire event name expression returned by `event_name()`: either the
     // `name = ...` override (evaluated at the override's call site, so builtins
     // like `file!()`/`line!()` resolve there) or the struct name as a literal.
@@ -229,7 +272,7 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
             // excludes the timestamp field.
             let idx = field_def_tokens.len() as u16;
             annotation_tokens.push(quote! {
-                ::dial9_trace_format::schema::FieldAnnotation::new(#idx, "unit", #unit)
+                #krate::schema::FieldAnnotation::new(#idx, "unit", #unit)
             });
         }
         if let Some(role) = &attrs.role {
@@ -245,7 +288,7 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
             }
             let idx = field_def_tokens.len() as u16;
             annotation_tokens.push(quote! {
-                ::dial9_trace_format::schema::FieldAnnotation::new(
+                #krate::schema::FieldAnnotation::new(
                     #idx,
                     #ROLE_ANNOTATION_KEY,
                     #role,
@@ -267,18 +310,18 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
             }
             let idx = field_def_tokens.len() as u16;
             annotation_tokens.push(quote! {
-                ::dial9_trace_format::schema::FieldAnnotation::new(#idx, "kind", #kind)
+                #krate::schema::FieldAnnotation::new(#idx, "kind", #kind)
             });
         }
 
         field_def_tokens.push(quote! {
-            ::dial9_trace_format::schema::FieldDef::new(
+            #krate::schema::FieldDef::new(
                 #field_name_lit,
-                <#ty as ::dial9_trace_format::TraceField>::field_type(),
+                <#ty as #krate::TraceField>::field_type(),
             )
         });
         encode_tokens.push(quote! {
-            <#ty as ::dial9_trace_format::TraceField>::encode(&self.#field_name, enc)?;
+            <#ty as #krate::TraceField>::encode(&self.#field_name, enc)?;
         });
     }
 
@@ -301,7 +344,7 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
                 if cached != 0 {
                     return cached;
                 }
-                let new = ::dial9_trace_format::__NEXT_TYPE_SLOT
+                let new = #krate::__NEXT_TYPE_SLOT
                     .fetch_add(1, ::std::sync::atomic::Ordering::Relaxed);
                 match SLOT.compare_exchange(
                     0,
@@ -324,8 +367,8 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
         quote! {}
     } else {
         quote! {
-            fn schema_entry() -> ::dial9_trace_format::schema::SchemaEntry {
-                ::dial9_trace_format::schema::SchemaEntry::with_annotations(
+            fn schema_entry() -> #krate::schema::SchemaEntry {
+                #krate::schema::SchemaEntry::with_annotations(
                     Self::event_name(),
                     Self::field_defs(),
                     vec![#(#annotation_tokens),*],
@@ -335,15 +378,15 @@ fn derive_trace_event_impl(input: DeriveInput) -> Result<proc_macro2::TokenStrea
     };
 
     Ok(quote! {
-        impl #impl_generics ::dial9_trace_format::TraceEvent for #name #ty_generics #where_clause {
+        impl #impl_generics #krate::TraceEvent for #name #ty_generics #where_clause {
             fn event_name() -> &'static str { #event_name_expr }
             #type_slot_impl
-            fn field_defs() -> Vec<::dial9_trace_format::schema::FieldDef> {
+            fn field_defs() -> Vec<#krate::schema::FieldDef> {
                 vec![#(#field_def_tokens),*]
             }
             #schema_entry_impl
             #timestamp_impl
-            fn encode_fields<W: ::std::io::Write>(&self, enc: &mut ::dial9_trace_format::EventEncoder<'_, W>) -> ::std::io::Result<()> {
+            fn encode_fields<W: ::std::io::Write>(&self, enc: &mut #krate::EventEncoder<'_, W>) -> ::std::io::Result<()> {
                 #(#encode_tokens)*
                 Ok(())
             }

--- a/dial9-trace-format/src/lib.rs
+++ b/dial9-trace-format/src/lib.rs
@@ -18,6 +18,9 @@
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+// Lets derive expansions name `::dial9_trace_format` inside this crate too.
+extern crate self as dial9_trace_format;
+
 pub mod codec;
 #[cfg(feature = "serde-deserialize")]
 pub mod de;

--- a/dial9/src/lib.rs
+++ b/dial9/src/lib.rs
@@ -9,6 +9,10 @@ pub use dial9_core::recorder::{
 };
 pub use dial9_core::recording::Recorder;
 
+/// What `#[derive(TraceEvent)]` expansions resolve against.
+#[doc(hidden)]
+pub use dial9_trace_format as __trace_format;
+
 /// The trace format: define events with `#[derive(TraceEvent)]`, encode your own
 /// types with [`TraceField`](format::TraceField), read a trace back with
 /// [`Decoder`](format::Decoder).

--- a/tests-build/Cargo.toml
+++ b/tests-build/Cargo.toml
@@ -1,0 +1,10 @@
+# Tests that verify downstream users can build against dial9 reaching entirely through `dial9`.
+[package]
+name = "tests-build"
+edition = "2024"
+version = "0.1.0"
+publish = false
+
+[dependencies]
+dial9 = { path = "../dial9", default-features = false, features = ["tokio"] }
+dial9-utils = { path = "../dial9-utils", features = ["span"] }

--- a/tests-build/tests/macro_paths.rs
+++ b/tests-build/tests/macro_paths.rs
@@ -1,0 +1,43 @@
+//! dial9's macros expand to `dial9-trace-format` paths, they have to resolve
+//! for callers that only depend on the facades. Compiling means they do.
+
+use dial9::format::TraceEvent;
+
+#[derive(TraceEvent)]
+struct ViaFacade {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    #[traceevent(unit = "ms", kind = "gauge")]
+    latency_ms: u64,
+    label: Option<String>,
+}
+
+/// Borrowed fields take the same paths.
+#[derive(TraceEvent)]
+struct BorrowedViaFacade<'a> {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    path: &'a str,
+}
+
+/// `wire_slot` reaches `__NEXT_TYPE_SLOT`, which the others do not.
+#[derive(TraceEvent)]
+#[traceevent(wire_slot)]
+struct SlottedViaFacade {
+    #[traceevent(timestamp)]
+    timestamp_ns: u64,
+    value: u32,
+}
+
+#[test]
+fn derive_resolves_through_dial9() {
+    assert_eq!(ViaFacade::event_name(), "ViaFacade");
+    assert_eq!(BorrowedViaFacade::event_name(), "BorrowedViaFacade");
+    assert_ne!(SlottedViaFacade::type_slot(), 0);
+}
+
+/// `dial9_span!` expands a derive of its own, and the user writes none of it.
+#[test]
+fn dial9_span_resolves_through_dial9_utils() {
+    let _span = dial9_utils::dial9_span!("facade", n: u64 = 1);
+}


### PR DESCRIPTION
### Context

`#[derive(TraceEvent)]` generated code naming `::dial9_trace_format` directly, and that path resolves against the caller's own dependencies, so it only worked for crates depending on `dial9-trace-format`. Anyone reaching the derive
through a re-export got a compilation error.

That breaks `dial9-utils`' `span` and `tower` features completely, since `dial9_span!` expands a derive and nothing the user writes mentions the missing crate, so there is nothing they can add to fix it. It also breaks `dial9::format::TraceEvent`, which we added on #734 so  that custom events would not need a second dependency.

### Changes
The derive now checks in the caller's manifest where `dial9-trace-format` lives, checking it first, then `dial9`, which now has a `#[doc(hidden)]` re-export for it to find.

Re-exporting alone isn't enough (e.g. hardcoding a `::dial9::__trace_format`) because dial9-core, dial9-tokio-telemetry, dial9-perf-self-profile and dial9-trace-format use the derive too and can't depend on dial9.
## Test

New compilation tests in a new `tests-build` member, setup in its own crate because we're precisely testing this from the downstream user's perspective (the manifest is the fixture in this case).