### PR TITLE
fix(viewer): resolve the diff view's API through the FlamegraphApi global

### DIFF
--- a/dial9-viewer/ui/flamegraph_diff_view.js
+++ b/dial9-viewer/ui/flamegraph_diff_view.js
@@ -20,18 +20,10 @@
     if (typeof FlamegraphDiff !== "undefined") return FlamegraphDiff;
     throw new Error("FlamegraphDiff not found. Load flamegraph_diff.js first.");
   }
-  function browserApi(root) {
-    return {
-      formatCoverageBadge: root.formatCoverageBadge,
-      foldErrorNotice: root.foldErrorNotice,
-      nextMaxFiles: root.nextMaxFiles,
-      refinementWorkDepth: root.refinementWorkDepth,
-      shouldAdoptRefinementSnapshot: root.shouldAdoptRefinementSnapshot,
-    };
-  }
   function getApi() {
     if (typeof require !== "undefined") return require("./flamegraph_api.js");
-    return browserApi(window);
+    if (typeof FlamegraphApi !== "undefined") return FlamegraphApi;
+    throw new Error("FlamegraphApi not found. Load flamegraph_api.js first.");
   }
   function getSse() {
     if (typeof require !== "undefined") return require("./sse.js");
@@ -729,7 +721,7 @@
     apiUrlFor,
     scopeLabel,
     isSearchFocusKey,
-    browserApi,
+    getApi,
     refinementLifecycleBadge,
   };
   if (typeof module !== "undefined" && module.exports) module.exports = ex;

--- a/dial9-viewer/ui/src/lib/canvas/diff-globals.test.ts
+++ b/dial9-viewer/ui/src/lib/canvas/diff-globals.test.ts
@@ -1,0 +1,36 @@
+// The frozen flamegraph_diff_view.js reads a bare `FlamegraphApi` global in the
+// browser; flamegraph_api.js publishes it only as a classic <script> tag.
+import { expect, it } from "vitest";
+
+// Seam first: it pulls in ./diff-globals for its side effect.
+import "./flamegraph_diff_view.js";
+// `getApi` is internal to the frozen module, so it is not on the typed seam.
+import * as frozen from "../../../flamegraph_diff_view.js";
+
+const getApi = (frozen as unknown as {
+  getApi: () => Record<string, unknown>;
+}).getApi;
+
+const seeded = (globalThis as Record<string, unknown>).FlamegraphApi as
+  | Record<string, unknown>
+  | undefined;
+
+it("seeds a FlamegraphApi global covering the resolved module surface", () => {
+  expect(seeded).toBeDefined();
+  // Under Node getApi() takes the require branch, so it is the canonical surface.
+  const missing = Object.entries(getApi())
+    .filter(([k, v]) => typeof v === "function" && typeof seeded?.[k] !== "function")
+    .map(([k]) => k);
+  expect(missing).toEqual([]);
+});
+
+it("seeds the real helpers, not empty stubs", () => {
+  const shouldAdopt = seeded?.shouldAdoptRefinementSnapshot as (
+    preserveExisting: boolean,
+    baseline: number,
+    incoming: number,
+  ) => boolean;
+  // A same-scope refine ignores a snapshot shallower than what is on screen.
+  expect(shouldAdopt(true, 5, 3)).toBe(false);
+  expect(shouldAdopt(true, 5, 7)).toBe(true);
+});

--- a/dial9-viewer/ui/src/lib/canvas/diff-globals.ts
+++ b/dial9-viewer/ui/src/lib/canvas/diff-globals.ts
@@ -1,14 +1,17 @@
 // Seeds the bare globals that the frozen flamegraph_diff_view.js reads at
-// evaluation time: the `FlamegraphDiff` namespace (from flamegraph_diff.js) and
-// `formatHumanDuration`. It MUST be a SEPARATE module, imported for side effect
+// evaluation time: the `FlamegraphDiff` and `FlamegraphApi` namespaces and
+// `formatHumanDuration`. Those modules self-publish onto the window only as
+// classic <script> tags. It MUST be a SEPARATE module, imported for side effect
 // before flamegraph_diff_view.js is re-exported: an `export ... from` re-export
 // evaluates its target during the linking phase, before the importing module's
 // own body runs, so an inline seed would land too late. Mirrors the widget's
 // export-globals.js / core-globals.js seed chain.
 
+import * as FlamegraphApi from "../../../flamegraph_api.js";
 import * as FlamegraphDiff from "../../../flamegraph_diff.js";
 import { formatHumanDuration } from "../../../format.js";
 
 const g = globalThis as Record<string, unknown>;
 g["FlamegraphDiff"] ??= FlamegraphDiff;
+g["FlamegraphApi"] ??= FlamegraphApi;
 g["formatHumanDuration"] ??= formatHumanDuration;

--- a/dial9-viewer/ui/src/lib/canvas/flamegraph_diff_view.ts
+++ b/dial9-viewer/ui/src/lib/canvas/flamegraph_diff_view.ts
@@ -3,14 +3,12 @@
 // container and owns the per-side `/api/flamegraph` SSE streams. Pages compose
 // it through this re-export instead of importing the core module directly.
 //
-// flamegraph_diff_view.js resolves flamegraph_api.js / sse.js with literal
-// require(...) calls that Vite's CommonJS interop resolves at build time, so
-// those ride into the bundle with it. It also reads two BARE globals at
-// evaluation time (`FlamegraphDiff` + `formatHumanDuration`); ./diff-globals
-// seeds them, imported FIRST so it runs before this file's re-export links the
-// view. The seeding is load-order critical: the canvas barrel pulls this seam
-// into EVERY page (the viewer included, for the shared widget), so an unseeded
-// FlamegraphDiff would throw on plain page load.
+// flamegraph_diff_view.js resolves its dependencies through BARE globals in the
+// browser (`FlamegraphDiff`, `FlamegraphApi`, `formatHumanDuration`);
+// ./diff-globals seeds them, imported FIRST so it runs before this file's
+// re-export links the view. The seeding is load-order critical: the canvas
+// barrel pulls this seam into EVERY page (the viewer included, for the shared
+// widget), so an unseeded FlamegraphDiff would throw on plain page load.
 import "./diff-globals.js";
 
 export {

--- a/dial9-viewer/ui/tests/core/flamegraph_diff_view_state.test.js
+++ b/dial9-viewer/ui/tests/core/flamegraph_diff_view_state.test.js
@@ -128,7 +128,7 @@ function makeDom() {
 const {
   apiUrlFor,
   createDiffView,
-  browserApi,
+  getApi,
   isSearchFocusKey,
   refinementLifecycleBadge,
   scopeLabel,
@@ -306,19 +306,12 @@ test("a user zoom cancels a not-yet-landed pending restore", () => {
   }
 });
 
-test("browser API fallback exposes Refine work-depth and adoption helpers", () => {
-  const root = {
-    formatCoverageBadge() {},
-    foldErrorNotice() {},
-    nextMaxFiles() {},
-    refinementWorkDepth() {},
-    shouldAdoptRefinementSnapshot() {},
-  };
-  const api = browserApi(root);
-  assert.strictEqual(api.refinementWorkDepth, root.refinementWorkDepth,
-    "browser fallback carries refinementWorkDepth");
-  assert.strictEqual(api.shouldAdoptRefinementSnapshot, root.shouldAdoptRefinementSnapshot,
-    "browser fallback carries snapshot adoption helper");
+test("resolved API exposes Refine work-depth and adoption helpers", () => {
+  const api = getApi();
+  assert.strictEqual(typeof api.refinementWorkDepth, "function",
+    "resolved API carries refinementWorkDepth");
+  assert.strictEqual(typeof api.shouldAdoptRefinementSnapshot, "function",
+    "resolved API carries snapshot adoption helper");
 });
 
 test("Load more keeps each side visible until cached coverage recovers its baseline", () => {


### PR DESCRIPTION
closes #827

`flamegraph_diff_view.js` hand-copied five helpers off bare window names. Those only exist under a classic `<script>` tag, so as an ES module they were all undefined and the first SSE event threw. 
It now reads `FlamegraphApi` like the two getters above it, seeded for the ESM path in `diff-globals.ts`.
