### PR TITLE
fix(viewer): preserve stable issue navigation

### DIFF
--- a/dial9-viewer/ui/README.md
+++ b/dial9-viewer/ui/README.md
@@ -229,6 +229,7 @@ list escaping. Previously emitted comma/pre-encoded list values remain readable.
 | `issue` | POI detector id | Issues filter. |
 | `issue-sort` | `<worker\|kind\|time\|duration>,<asc\|desc>` | Issues ordering. |
 | `issue-index` | non-negative integer | Current issues cursor. |
+| `issue-anchor` | `<worker>:<timeNs>:<spanStartNs>:<taskId\|->` | Stable identity for the current issue; takes precedence over its sorted index. |
 | `span-pct` | `50` \| `90` \| `95` \| `99` | Span percentile floor. |
 | `span-names` | `v1:` + TAB-joined names | Enabled span legend chips. |
 | `event-names` | same | Enabled custom-event legend chips. |

--- a/dial9-viewer/ui/src/lib/url/view-state.ts
+++ b/dial9-viewer/ui/src/lib/url/view-state.ts
@@ -113,6 +113,8 @@ export interface ViewState {
   poiSort?: string;
   /** Current POI index in the filtered+sorted rail list, when >= 0. */
   poiIndex?: number;
+  /** Stable identity of the current POI; the numeric index is only a fallback. */
+  poiAnchor?: string;
   /** Span percentile filter (50/90/95/99), when not 0 (All). */
   spanPct?: number;
   /** Span legend name chips toggled on for display filtering. */

--- a/dial9-viewer/ui/src/pages/viewer/issues-rail.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/issues-rail.test.ts
@@ -89,6 +89,23 @@ describe("issues-rail n/p stepping", () => {
     expect(store.getState().poi.index).toBe(0);
   });
 
+  it("opens the full backing poll when stepping to a sampled issue", () => {
+    const store = loadedStore();
+    store.update("poi", { filter: "cpu-sampled" });
+    const rail = createIssuesRail(store);
+
+    expect(binding(rail.keyBindings, "n").onKey(FAKE_KEY)).toBe(true);
+
+    const state = store.getState();
+    const poll = state.selection.pollDetail;
+    expect(poll).not.toBeNull();
+    expect(poll?.taskId).toBe(state.selection.selectedTaskId);
+    expect(poll).toHaveProperty("spawnLocId");
+    expect(
+      (poll?.cpuSamples?.length ?? 0) + (poll?.schedSamples?.length ?? 0),
+    ).toBeGreaterThan(0);
+  });
+
   it("declines (returns false) when no trace is loaded - the key falls through", () => {
     const store = createViewerStore({ scheduler: () => {} });
     const rail = createIssuesRail(store);

--- a/dial9-viewer/ui/src/pages/viewer/issues-rail.ts
+++ b/dial9-viewer/ui/src/pages/viewer/issues-rail.ts
@@ -16,6 +16,7 @@ import type { StoreState } from "../../types/state.js";
 import type { IssueColKey, PoiSortKey, RailTab, TaskSortKey } from "../../types/state.js";
 import type { PointOfInterestType } from "../../types/trace.js";
 import type { KeyBinding } from "../../lib/interact/keyboard.js";
+import { deriveLaneData } from "../../components/canvas/lanes/index.js";
 import {
   POI_FILTERS,
   derivePoiViewModel,
@@ -303,13 +304,22 @@ export function createIssuesRail(store: ViewerStore): IssuesRailController {
    *  Indexes `sorted`, not `rows`: `n`/`p` step the whole list while only a
    *  window around the cursor is ever formatted. */
   function jumpTo(index: number): void {
-    const vm = viewModel(store.getState());
+    const state = store.getState();
+    const vm = viewModel(state);
     const poi = vm.sorted[index];
     if (poi === undefined) return;
-    const jump = poiJump(poi, store.getState().viewport);
+    const jump = poiJump(poi, state.viewport);
+    const taskId = poi.span.taskId;
+    const pollDetail =
+      state.trace.trace !== null && taskId !== undefined
+        ? deriveLaneData(state.trace.trace).workerSpans[poi.worker]?.polls.find(
+            (poll) => poll.start === poi.span.start && poll.taskId === taskId,
+          ) ?? null
+        : null;
     store.update("viewport", { viewStart: jump.viewStart, viewEnd: jump.viewEnd });
     store.update("selection", {
       selectedTaskId: jump.selectedTaskId,
+      pollDetail,
       taskDump: null,
     });
     store.update("poi", { index });

--- a/dial9-viewer/ui/src/pages/viewer/poi.ts
+++ b/dial9-viewer/ui/src/pages/viewer/poi.ts
@@ -226,6 +226,52 @@ export function sortPois(
   return keyed.map((k) => k.poi);
 }
 
+/** Resolve a poll-backed issue after detector output or sort order changes. */
+export function poiIndexForPoll(
+  pois: readonly PointOfInterest[],
+  poll: Pick<PollSpan, "start" | "taskId">,
+): number {
+  return pois.findIndex(
+    (poi) =>
+      "taskId" in poi.span &&
+      poi.span.start === poll.start &&
+      poi.span.taskId === poll.taskId,
+  );
+}
+
+export interface PoiAnchor {
+  worker: number;
+  time: number;
+  spanStart: number;
+  taskId?: number;
+}
+
+/** Stable identity for one issue, independent of its current sorted index. */
+export function poiAnchor(poi: PointOfInterest): PoiAnchor {
+  return {
+    worker: poi.worker,
+    time: poi.time,
+    spanStart: poi.span.start,
+    ...("taskId" in poi.span ? { taskId: poi.span.taskId } : {}),
+  };
+}
+
+/** Resolve a stable issue identity against freshly computed detector output. */
+export function poiIndexForAnchor(
+  pois: readonly PointOfInterest[],
+  anchor: PoiAnchor,
+): number {
+  return pois.findIndex((poi) => {
+    const taskId = "taskId" in poi.span ? poi.span.taskId : undefined;
+    return (
+      poi.worker === anchor.worker &&
+      poi.time === anchor.time &&
+      poi.span.start === anchor.spanStart &&
+      taskId === anchor.taskId
+    );
+  });
+}
+
 function compareBy(
   a: PointOfInterest,
   b: PointOfInterest,

--- a/dial9-viewer/ui/src/pages/viewer/url-state.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/url-state.test.ts
@@ -376,6 +376,20 @@ describe("viewer URL state: complete durable view", () => {
 
 
 describe("viewer URL state: constructible and strict values", () => {
+  it("removes one-shot exemplar focus when canonicalizing viewer state", () => {
+    const params = new URLSearchParams(
+      "?trace=trace.bin&focus_start=100&focus_end=200" +
+        "&focus_worker=3&focus_task=42&focus_span_name=request",
+    );
+
+    mirrorViewerToQuery(params, projectViewerState(mkState({})));
+
+    expect(params.get("trace")).toBe("trace.bin");
+    expect(
+      [...params.keys()].filter((key) => key.startsWith("focus_")),
+    ).toEqual([]);
+  });
+
   it("reads a single-pass agent-authored list containing commas", () => {
     const out = readViewerUrlState("?span-names=v1%3Ahttp%2C+request%09poll");
     expect(out.spanNames).toEqual(["http, request", "poll"]);

--- a/dial9-viewer/ui/src/pages/viewer/url-state.ts
+++ b/dial9-viewer/ui/src/pages/viewer/url-state.ts
@@ -26,7 +26,12 @@ import {
   DEFAULT_LANES_HEIGHT,
   DEFAULT_RAIL_WIDTH,
 } from "./store.js";
-import { POI_FILTERS } from "./poi.js";
+import {
+  POI_FILTERS,
+  derivePoiViewModel,
+  poiAnchor,
+  type PoiAnchor,
+} from "./poi.js";
 import {
   FIELD_CHART_KINDS,
   FIELD_CHART_URL_SEPARATOR,
@@ -54,6 +59,7 @@ const P_SPAWNED = "spawned";
 const P_ISSUE = "issue";
 const P_ISSUE_SORT = "issue-sort";
 const P_ISSUE_INDEX = "issue-index";
+const P_ISSUE_ANCHOR = "issue-anchor";
 const P_SPAN_PCT = "span-pct";
 const P_SPAN_NAMES = "span-names";
 const P_EVENT_NAMES = "event-names";
@@ -87,11 +93,22 @@ const P_ANALYSIS_INSPECT = "analysis-inspect";
 const P_SPAN_INDEX = "span-index";
 const P_DATA_START = "data-start";
 const P_DATA_END = "data-end";
+const ONE_SHOT_FOCUS_PARAMS = [
+  "focus_start",
+  "focus_end",
+  "focus_span_name",
+  "focus_worker",
+  "focus_task",
+] as const;
 
 /** Valid rail sort keys (drop anything else on read). */
 const POI_SORT_KEYS: readonly PoiSortKey[] = ["worker", "kind", "time", "duration"];
 /** Valid span percentile-filter steps (0/All is the default, never emitted). */
 const SPAN_PCTS: readonly number[] = [50, 90, 95, 99];
+const projectedPoiAnchorCache = new WeakMap<
+  object,
+  { key: string; value: string | null }
+>();
 
 const TASK_SORT_KEYS: readonly TaskSortKey[] = ["id", "loc", "polls", "total", "longest", "lifetime"];
 /** Valid issue-cols keys: the severity-dot column plus the sortable four. */
@@ -144,7 +161,7 @@ export const VIEWER_STATE_OWNERSHIP = {
     filter: url(P_ISSUE),
     sortKey: url(P_ISSUE_SORT),
     sortDir: url(P_ISSUE_SORT),
-    index: url(P_ISSUE_INDEX),
+    index: url(P_ISSUE_INDEX, P_ISSUE_ANCHOR),
     railTab: url(P_RAIL_TAB),
     taskSort: url(P_TASK_SORT),
     taskSortDir: url(P_TASK_SORT),
@@ -222,6 +239,22 @@ export const VIEWER_VIEW_QUERY_PARAMS: readonly string[] = [
   ),
 ];
 
+function projectedPoiAnchor(
+  trace: NonNullable<StoreState["trace"]["trace"]>,
+  poi: Readonly<StoreState["poi"]>,
+  minTs: number,
+): string | null {
+  const key = `${poi.filter}|${poi.sortKey}|${poi.sortDir}|${poi.index}`;
+  const cached = projectedPoiAnchorCache.get(trace);
+  if (cached?.key === key) return cached.value;
+  const selected = derivePoiViewModel(trace, poi, minTs).sorted[poi.index];
+  const value = selected !== undefined
+    ? encodePoiAnchor(poiAnchor(selected))
+    : null;
+  projectedPoiAnchorCache.set(trace, { key, value });
+  return value;
+}
+
 /** Project the store into the shareable ViewState. */
 export function projectViewerState(state: ReadonlyState<StoreState>): ViewState {
   const vs: ViewState = {};
@@ -275,7 +308,14 @@ export function projectViewerState(state: ReadonlyState<StoreState>): ViewState 
   if (poi.sortKey !== "duration" || poi.sortDir !== "desc") {
     vs.poiSort = `${poi.sortKey},${poi.sortDir}`;
   }
-  if (poi.index >= 0) vs.poiIndex = poi.index;
+  if (poi.index >= 0) {
+    vs.poiIndex = poi.index;
+    const trace = state.trace.trace;
+    if (trace !== null) {
+      const anchor = projectedPoiAnchor(trace, poi, vp.minTs);
+      if (anchor !== null) vs.poiAnchor = anchor;
+    }
+  }
   if (state.uiPrefs.spanPctFilter !== 0) vs.spanPct = state.uiPrefs.spanPctFilter;
   if (state.uiPrefs.selectedSpanNames.size > 0) {
     vs.spanNames = [...state.uiPrefs.selectedSpanNames].sort();
@@ -377,6 +417,9 @@ export function mirrorViewerToQuery(
   params: URLSearchParams,
   vs: ViewState,
 ): void {
+  // focus_* bootstraps an exemplar once. The canonical viewport and selection
+  // below replace it so later navigation cannot leave two conflicting targets.
+  for (const param of ONE_SHOT_FOCUS_PARAMS) params.delete(param);
   set(params, P_START, vs.viewStart != null ? String(Math.round(vs.viewStart)) : null);
   set(params, P_END, vs.viewEnd != null ? String(Math.round(vs.viewEnd)) : null);
   set(params, P_TASK, vs.selectedTaskId != null ? `0x${vs.selectedTaskId.toString(16)}` : null);
@@ -398,6 +441,7 @@ export function mirrorViewerToQuery(
   set(params, P_ISSUE, vs.poiFilter ?? null);
   set(params, P_ISSUE_SORT, vs.poiSort ?? null);
   set(params, P_ISSUE_INDEX, vs.poiIndex != null ? String(Math.round(vs.poiIndex)) : null);
+  set(params, P_ISSUE_ANCHOR, vs.poiAnchor ?? null);
   set(params, P_SPAN_PCT, vs.spanPct != null ? String(vs.spanPct) : null);
   set(params, P_SPAN_NAMES, encodeList(vs.spanNames));
   set(params, P_EVENT_NAMES, encodeList(vs.eventNames));
@@ -479,6 +523,39 @@ function set(params: URLSearchParams, key: string, value: string | null): void {
   else params.set(key, value);
 }
 
+function encodePoiAnchor(anchor: PoiAnchor): string {
+  return [
+    Math.round(anchor.worker),
+    Math.round(anchor.time),
+    Math.round(anchor.spanStart),
+    anchor.taskId !== undefined ? Math.round(anchor.taskId) : "-",
+  ].join(":");
+}
+
+function decodePoiAnchor(value: string | null): PoiAnchor | null {
+  if (value === null) return null;
+  const parts = value.split(":");
+  if (parts.length !== 4) return null;
+  const worker = nonNegativeInt(parts[0]!);
+  const time = num(parts[1]!);
+  const spanStart = num(parts[2]!);
+  const taskId = parts[3] === "-" ? undefined : nonNegativeInt(parts[3]!);
+  if (
+    worker === null ||
+    time === null ||
+    spanStart === null ||
+    (parts[3] !== "-" && taskId === null)
+  ) {
+    return null;
+  }
+  return {
+    worker,
+    time,
+    spanStart,
+    ...(taskId !== undefined && taskId !== null ? { taskId } : {}),
+  };
+}
+
 /** The viewer state parsed from a URL query string. */
 export interface ViewerUrlState {
   /** Restore-on-load viewport window (ns), applied to the first loaded trace. */
@@ -501,6 +578,7 @@ export interface ViewerUrlState {
   poiFilter?: PointOfInterestType;
   poiSort?: { key: PoiSortKey; dir: "asc" | "desc" };
   poiIndex?: number;
+  poiAnchor?: PoiAnchor;
   spanPct?: number;
   spanNames?: string[];
   eventNames?: string[];
@@ -725,6 +803,8 @@ export function readViewerUrlState(search: string): ViewerUrlState {
   }
   const issueIndex = nonNegativeInt(p.get(P_ISSUE_INDEX));
   if (issueIndex != null) out.poiIndex = issueIndex;
+  const issueAnchor = decodePoiAnchor(p.get(P_ISSUE_ANCHOR));
+  if (issueAnchor !== null) out.poiAnchor = issueAnchor;
   const spanPct = num(p.get(P_SPAN_PCT));
   if (spanPct != null && SPAN_PCTS.includes(spanPct)) out.spanPct = spanPct;
   const spanNames = decodeList(p.get(P_SPAN_NAMES));

--- a/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.test.ts
@@ -18,6 +18,7 @@ import {
 import { resolveUrlSelection } from "./url-selection.js";
 import { createViewerReconstruction } from "./viewer-reconstruction.js";
 import { taskIndexFor } from "./tasks-model.js";
+import { derivePoiViewModel } from "./poi.js";
 
 let settledTrace: ParsedTrace;
 let reconstructedTrace: ParsedTrace;
@@ -152,6 +153,115 @@ describe("viewer deep-link reconstruction", () => {
       maxTs: 300,
       viewStart: 60,
       viewEnd: 290,
+    });
+  });
+
+  it("lets canonical viewer state override a stale exemplar focus", () => {
+    const polls = lanePolls(deriveLaneData(settledTrace))
+      .sort((a, b) => a.start - b.start);
+    const focusPoll = polls[0]!;
+    const canonicalPoll = polls.at(-1)!;
+    const offset = settledTrace.clockOffsetNs ?? 0;
+    const canonicalStart = Math.max(
+      settledTrace.recordMinTs!,
+      canonicalPoll.start - 1_000,
+    );
+    const canonicalEnd = Math.min(
+      settledTrace.recordMaxTs!,
+      canonicalPoll.end + 1_000,
+    );
+    const store = createViewerStore({ scheduler: () => {} });
+    const reconstruction = createViewerReconstruction(store, {
+      search:
+        `?focus_start=${focusPoll.start + offset}` +
+        `&focus_end=${focusPoll.end + offset}` +
+        `&focus_task=${focusPoll.taskId}` +
+        `&start=${canonicalStart}&end=${canonicalEnd}` +
+        `&task=0x${canonicalPoll.taskId.toString(16)}` +
+        `&poll=${canonicalPoll.start}:${canonicalPoll.taskId}`,
+      hash: "",
+    });
+
+    reconstruction.applyLoadedTrace(settledTrace, "source");
+
+    expect(store.getState().viewport).toMatchObject({
+      viewStart: canonicalStart,
+      viewEnd: canonicalEnd,
+    });
+    expect(store.getState().selection).toMatchObject({
+      selectedTaskId: canonicalPoll.taskId,
+      pollDetail: {
+        start: canonicalPoll.start,
+        taskId: canonicalPoll.taskId,
+      },
+    });
+  });
+
+  it("does not retain an exemplar task after restoring a canonical viewport", () => {
+    const task = taskIndexFor(settledTrace).rows.find((row) => row.pollCount > 0)!;
+    const offset = settledTrace.clockOffsetNs ?? 0;
+    const viewStart = settledTrace.recordMinTs! + 1_000;
+    const viewEnd = settledTrace.recordMaxTs! - 1_000;
+    const store = createViewerStore({ scheduler: () => {} });
+    const reconstruction = createViewerReconstruction(store, {
+      search:
+        `?focus_start=${task.firstPollStart + offset}` +
+        `&focus_end=${task.firstPollStart + offset + 1_000}` +
+        `&focus_task=${task.taskId}` +
+        `&start=${viewStart}&end=${viewEnd}`,
+      hash: "",
+    });
+
+    reconstruction.applyLoadedTrace(settledTrace, "source");
+
+    expect(store.getState().viewport).toMatchObject({ viewStart, viewEnd });
+    expect(store.getState().selection.selectedTaskId).toBeNull();
+  });
+
+  it("falls back to issue-index when a stable issue anchor no longer resolves", () => {
+    const store = createViewerStore({ scheduler: () => {} });
+    const reconstruction = createViewerReconstruction(store, {
+      search:
+        "?issue=wake-delay&issue-index=1" +
+        "&issue-anchor=999999:0:0:-",
+      hash: "",
+    });
+
+    reconstruction.applyLoadedTrace(settledTrace, "source");
+
+    expect(store.getState().poi.index).toBe(1);
+  });
+
+  it("resolves a legacy exemplar's stale issue index from its poll anchor", () => {
+    const poi = {
+      filter: "wake-delay" as const,
+      sortKey: "duration" as const,
+      sortDir: "desc" as const,
+      index: -1,
+      railTab: "issues" as const,
+      taskSort: "total" as const,
+      taskSortDir: "desc" as const,
+      taskIndex: -1,
+    };
+    const target = derivePoiViewModel(settledTrace, poi, settledTrace.minTs!)
+      .sorted[0]!;
+    expect("taskId" in target.span).toBe(true);
+    const taskId = (target.span as PollSpan).taskId;
+    const store = createViewerStore({ scheduler: () => {} });
+    const reconstruction = createViewerReconstruction(store, {
+      search:
+        "?issue=wake-delay&issue-index=1" +
+        `&focus_start=${target.time + (settledTrace.clockOffsetNs ?? 0)}` +
+        `&poll=${target.span.start}:${taskId}&task=0x${taskId.toString(16)}`,
+      hash: "",
+    });
+
+    reconstruction.applyLoadedTrace(settledTrace, "source");
+
+    expect(store.getState().poi.index).toBe(0);
+    expect(store.getState().selection.pollDetail).toMatchObject({
+      start: target.span.start,
+      taskId,
     });
   });
 

--- a/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.ts
+++ b/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.ts
@@ -18,6 +18,11 @@ import {
 } from "./url-state.js";
 import { taskIndexFor } from "./tasks-model.js";
 import { traceDisplayBounds, type TraceDisplayBounds } from "./trace-bounds.js";
+import {
+  derivePoiViewModel,
+  poiIndexForAnchor,
+  poiIndexForPoll,
+} from "./poi.js";
 
 export type LoadedTraceKind = "source" | "reparse";
 
@@ -74,6 +79,7 @@ export function createViewerReconstruction(
 
   function restoreInitialTrace(trace: ParsedTrace): void {
     const bounds = fitTrace(trace);
+    let restoredCanonicalViewport = false;
     if (
       bounds !== null &&
       urlState.viewStart !== undefined &&
@@ -83,17 +89,51 @@ export function createViewerReconstruction(
       const viewEnd = Math.min(bounds.maxTs, urlState.viewEnd);
       if (viewEnd > viewStart) {
         store.update("viewport", { viewStart, viewEnd });
+        restoredCanonicalViewport = true;
       }
     }
     const selection = resolveUrlSelection(trace, urlState);
+    if (
+      urlState.poiAnchor !== undefined ||
+      (
+        focusLink !== null &&
+        urlState.poiFilter !== undefined &&
+        urlState.poll !== undefined
+      )
+    ) {
+      const state = store.getState();
+      const sorted = derivePoiViewModel(
+        trace,
+        state.poi,
+        state.viewport.minTs,
+      ).sorted;
+      const index = urlState.poiAnchor
+        ? poiIndexForAnchor(sorted, urlState.poiAnchor)
+        : selection.pollDetail != null
+          ? poiIndexForPoll(sorted, selection.pollDetail)
+          : -1;
+      if (index >= 0) {
+        store.update("poi", { index });
+      }
+    }
+    const hasCanonicalSelection =
+      Object.keys(selection).length > 0 ||
+      taskExists(trace, urlState.selectedTaskId);
+    const activeFocusLink =
+      !restoredCanonicalViewport && !hasCanonicalSelection
+        ? focusLink
+        : null;
 
-    if (focusLink !== null) {
-      const focused = resolveFocusLink(trace, focusLink);
+    // focus_* is a one-shot bootstrap for aggregate exemplars. Once a URL has
+    // canonical viewport or selection anchors, those describe the current
+    // navigated state and must win over the original exemplar.
+    if (activeFocusLink !== null) {
+      const focused = resolveFocusLink(trace, activeFocusLink);
       if (focused !== null) {
         Object.assign(selection, focused.patch);
         store.update("viewport", focused.viewport);
       } else {
-        const window = focusWindow(focusLink, trace.clockOffsetNs);
+        const window = focusWindow(activeFocusLink, trace.clockOffsetNs);
         if (Number.isFinite(window.start)) {
           const pad = Math.max((window.end - window.start) * 2, 1e6);
           store.update("viewport", {
@@ -107,7 +147,7 @@ export function createViewerReconstruction(
     // An explicit shareable task selection wins, followed by the exemplar's
     // focus_task. Keep a task inferred from a matched span only when neither
     // URL task anchor resolves against this trace.
-    for (const taskId of [urlState.selectedTaskId, focusLink?.taskId]) {
+    for (const taskId of [urlState.selectedTaskId, activeFocusLink?.taskId]) {
       if (taskExists(trace, taskId)) {
         selection.selectedTaskId = taskId;
         break;


### PR DESCRIPTION
- canonicalize one-shot exemplar links after durable viewer state exists
- persist stable issue identities with numeric-index fallback
- resolve issue selections to complete poll details