### PR TITLE
fix(viewer): consume legacy wake evidence once

### DIFF
--- a/dial9-tokio-telemetry/src/telemetry/analysis.rs
+++ b/dial9-tokio-telemetry/src/telemetry/analysis.rs
@@ -338,28 +338,36 @@ pub fn analyze_trace(events: &[Dial9Event]) -> TraceAnalysis {
 }
 
 /// Compute wake→poll scheduling delays from wake events and poll starts.
-/// Returns a sorted vec of delay durations in nanoseconds.
+/// Each poll consumes callbacks through its start; for older traces that
+/// include stale callback attempts, the latest callback is a conservative
+/// lower-bound estimate. Returns sorted delay durations in nanoseconds.
 pub fn compute_wake_to_poll_delays(events: &[Dial9Event]) -> Vec<u64> {
     let mut wakes_by_task: HashMap<u64, Vec<u64>> = HashMap::new();
+    let mut poll_starts = Vec::new();
     for e in events {
-        if let Dial9Event::WakeEvent(w) = e {
-            wakes_by_task
-                .entry(w.woken_task_id)
-                .or_default()
-                .push(w.timestamp_ns);
+        match e {
+            Dial9Event::WakeEvent(w) => {
+                wakes_by_task
+                    .entry(w.woken_task_id)
+                    .or_default()
+                    .push(w.timestamp_ns);
+            }
+            Dial9Event::PollStartEvent(p) => poll_starts.push(p),
+            _ => {}
         }
     }
     for v in wakes_by_task.values_mut() {
         v.sort_unstable();
     }
+    poll_starts.sort_by_key(|p| p.timestamp_ns);
 
     let mut delays = Vec::new();
-    for e in events {
-        if let Dial9Event::PollStartEvent(p) = e
-            && let Some(wakes) = wakes_by_task.get(&p.task_id)
-        {
+    let mut last_poll_start_by_task = HashMap::new();
+    for p in poll_starts {
+        if let Some(wakes) = wakes_by_task.get(&p.task_id) {
+            let previous_poll_start = last_poll_start_by_task.insert(p.task_id, p.timestamp_ns);
             let idx = wakes.partition_point(|&t| t <= p.timestamp_ns);
-            if idx > 0 {
+            if idx > 0 && previous_poll_start.is_none_or(|start| wakes[idx - 1] > start) {
                 let delay = p.timestamp_ns - wakes[idx - 1];
                 if delay > 0 && delay < 1_000_000_000 {
                     delays.push(delay);
@@ -616,29 +624,39 @@ pub struct WakeDelay {
 }
 
 /// Detect wake-to-poll delays exceeding `threshold_ns`.
+///
+/// Each callback is consumed by the first subsequent poll. When an older trace
+/// contains multiple callback attempts before that poll, the latest one is the
+/// conservative lower-bound evidence.
 pub fn detect_wake_delays(events: &[Dial9Event], threshold_ns: u64) -> Vec<WakeDelay> {
     const MAX_REASONABLE_DELAY_NS: u64 = 1_000_000_000;
 
     let mut wakes_by_task: HashMap<u64, Vec<u64>> = HashMap::new();
+    let mut poll_starts = Vec::new();
     for event in events {
-        if let Dial9Event::WakeEvent(w) = event {
-            wakes_by_task
-                .entry(w.woken_task_id)
-                .or_default()
-                .push(w.timestamp_ns);
+        match event {
+            Dial9Event::WakeEvent(w) => {
+                wakes_by_task
+                    .entry(w.woken_task_id)
+                    .or_default()
+                    .push(w.timestamp_ns);
+            }
+            Dial9Event::PollStartEvent(p) => poll_starts.push(p),
+            _ => {}
         }
     }
     for v in wakes_by_task.values_mut() {
         v.sort_unstable();
     }
+    poll_starts.sort_by_key(|p| p.timestamp_ns);
 
     let mut delays = Vec::new();
-    for event in events {
-        if let Dial9Event::PollStartEvent(p) = event
-            && let Some(wakes) = wakes_by_task.get(&p.task_id)
-        {
+    let mut last_poll_start_by_task = HashMap::new();
+    for p in poll_starts {
+        if let Some(wakes) = wakes_by_task.get(&p.task_id) {
+            let previous_poll_start = last_poll_start_by_task.insert(p.task_id, p.timestamp_ns);
             let idx = wakes.partition_point(|&t| t <= p.timestamp_ns);
-            if idx > 0 {
+            if idx > 0 && previous_poll_start.is_none_or(|start| wakes[idx - 1] > start) {
                 let delay = p.timestamp_ns.saturating_sub(wakes[idx - 1]);
                 if delay >= threshold_ns && delay < MAX_REASONABLE_DELAY_NS {
                     delays.push(WakeDelay {
@@ -1254,6 +1272,77 @@ mod tests {
         ];
         let delays = detect_wake_delays(&events, 100_000);
         assert!(delays.is_empty());
+    }
+
+    #[test]
+    fn wake_callback_is_consumed_by_the_first_poll() {
+        let events = vec![
+            Dial9Event::WakeEvent(WakeEvent {
+                timestamp_ns: 1_000_000,
+                waker_task_id: 0,
+                woken_task_id: 1,
+                target_worker: 0,
+            }),
+            Dial9Event::PollStartEvent(PollStartEvent {
+                timestamp_ns: 1_500_000,
+                worker_id: WorkerId(0),
+                local_queue: 0,
+                task_id: 1,
+                spawn_loc: String::new(),
+            }),
+            Dial9Event::PollEndEvent(PollEndEvent {
+                timestamp_ns: 1_600_000,
+                worker_id: WorkerId(0),
+            }),
+            Dial9Event::PollStartEvent(PollStartEvent {
+                timestamp_ns: 1_800_000,
+                worker_id: WorkerId(0),
+                local_queue: 0,
+                task_id: 1,
+                spawn_loc: String::new(),
+            }),
+            Dial9Event::PollEndEvent(PollEndEvent {
+                timestamp_ns: 1_900_000,
+                worker_id: WorkerId(0),
+            }),
+        ];
+
+        assert_eq!(compute_wake_to_poll_delays(&events), vec![500_000]);
+        let delays = detect_wake_delays(&events, 100_000);
+        assert_eq!(delays.len(), 1);
+        assert_eq!(delays[0].poll_ns, 1_500_000);
+    }
+
+    #[test]
+    fn wake_callback_is_consumed_by_the_first_poll_in_timestamp_order() {
+        let events = vec![
+            Dial9Event::WakeEvent(WakeEvent {
+                timestamp_ns: 1_000_000,
+                waker_task_id: 0,
+                woken_task_id: 1,
+                target_worker: 0,
+            }),
+            Dial9Event::PollStartEvent(PollStartEvent {
+                timestamp_ns: 1_800_000,
+                worker_id: WorkerId(1),
+                local_queue: 0,
+                task_id: 1,
+                spawn_loc: String::new(),
+            }),
+            Dial9Event::PollStartEvent(PollStartEvent {
+                timestamp_ns: 1_500_000,
+                worker_id: WorkerId(0),
+                local_queue: 0,
+                task_id: 1,
+                spawn_loc: String::new(),
+            }),
+        ];
+
+        assert_eq!(compute_wake_to_poll_delays(&events), vec![500_000]);
+        let delays = detect_wake_delays(&events, 100_000);
+        assert_eq!(delays.len(), 1);
+        assert_eq!(delays[0].poll_ns, 1_500_000);
+        assert_eq!(delays[0].worker_id, WorkerId(0));
     }
 
     #[test]

--- a/dial9-viewer/src/ingest/decode/polls.rs
+++ b/dial9-viewer/src/ingest/decode/polls.rs
@@ -114,12 +114,13 @@ impl Reconstructor {
             if let Some(worker_id) = self.open_worker_by_task.get(&event.woken_task_id)
                 && let Some(open) = self.open_by_worker.get_mut(worker_id)
             {
-                // Wakes coalesce while a task is already scheduled. Keep the
-                // first one until the readiness transition is consumed.
-                open.wake_during_poll.get_or_insert(evidence);
+                // Older producers recorded callback attempts after the live
+                // executor waker had already been consumed. The latest
+                // callback is the conservative lower-bound evidence.
+                open.wake_during_poll = Some(evidence);
             }
         } else {
-            state.ready.get_or_insert(evidence);
+            state.ready = Some(evidence);
         }
     }
 
@@ -496,7 +497,7 @@ mod tests {
     }
 
     #[test]
-    fn idle_wake_measures_next_poll_and_coalesces_to_earliest_wake() {
+    fn idle_wake_uses_latest_callback_as_conservative_ready_time() {
         let mut reconstructor = Reconstructor::default();
         reconstructor.wake(&WakeEvent {
             timestamp_ns: 200,
@@ -512,9 +513,9 @@ mod tests {
         reconstructor.poll_end(&end(320));
 
         let ready = reconstructor.records[0].readiness.unwrap();
-        assert_eq!(ready.timestamp, MonoNs(200));
+        assert_eq!(ready.timestamp, MonoNs(250));
         assert_eq!(ready.kind, SchedulingDelayKind::Wake);
-        assert_eq!(ready.waker_task_id, Some(11));
+        assert_eq!(ready.waker_task_id, Some(12));
     }
 
     #[test]
@@ -526,6 +527,11 @@ mod tests {
             waker_task_id: 11,
             woken_task_id: 7,
         });
+        reconstructor.wake(&WakeEvent {
+            timestamp_ns: 170,
+            waker_task_id: 12,
+            woken_task_id: 7,
+        });
         reconstructor.poll_end(&end(200));
         reconstructor.poll_start(&start(500, 7));
         reconstructor.poll_end(&end(520));
@@ -533,7 +539,7 @@ mod tests {
         let ready = reconstructor.records[1].readiness.unwrap();
         assert_eq!(ready.timestamp, MonoNs(200));
         assert_eq!(ready.kind, SchedulingDelayKind::WakeDuringPoll);
-        assert_eq!(ready.waker_task_id, Some(11));
+        assert_eq!(ready.waker_task_id, Some(12));
     }
 
     #[test]

--- a/dial9-viewer/ui/src/lib/trace/columnar-worker-spans.test.ts
+++ b/dial9-viewer/ui/src/lib/trace/columnar-worker-spans.test.ts
@@ -336,4 +336,85 @@ describe("ColumnarWorkerSpans.schedulingDelays matches frozen computeSchedulingD
     });
     expect(col.map(norm)).toEqual(fat.map(norm));
   });
+
+  it("uses the latest unconsumed wake as a conservative lower bound", () => {
+    const synthetic = {
+      0: {
+        polls: [
+          { taskId: 1, start: 100, end: 200 },
+          { taskId: 1, start: 500, end: 600 },
+          { taskId: 1, start: 900, end: 1_000 },
+        ],
+        parks: [],
+        actives: [],
+        cpuSampleTimes: [],
+      },
+    };
+    const wakes = {
+      1: [
+        { timestamp: 150, wakerTaskId: 7 },
+        { timestamp: 490, wakerTaskId: 8 },
+      ],
+    };
+    const store = ColumnarWorkerSpans.fromWorkerSpans(synthetic as never);
+
+    expect(
+      store.schedulingDelays([0], wakes).map((delay) => ({
+        wakeTime: delay.wakeTime,
+        pollTime: delay.pollTime,
+        delay: delay.delay,
+        wakerTaskId: delay.wakerTaskId,
+      })),
+    ).toEqual([
+      {
+        wakeTime: 490,
+        pollTime: 500,
+        delay: 10,
+        wakerTaskId: 8,
+      },
+    ]);
+  });
+
+  it("preserves poll identity across an equal-start zero-width chain", async () => {
+    const { computeSchedulingDelays } = await import("./index.js");
+    const synthetic = {
+      0: {
+        polls: [
+          { taskId: 1, start: 0, end: 5 },
+          { taskId: 1, start: 10, end: 10 },
+          { taskId: 1, start: 10, end: 20 },
+        ],
+        parks: [],
+        actives: [],
+        cpuSampleTimes: [],
+      },
+    };
+    const wakes = {
+      1: [{ timestamp: 9, wakerTaskId: 7 }],
+    };
+    const store = ColumnarWorkerSpans.fromWorkerSpans(synthetic as never);
+    const norm = (delay: {
+      wakeTime: number;
+      pollTime: number;
+      delay: number;
+      poll: { end: number };
+    }) => ({
+      wakeTime: delay.wakeTime,
+      pollTime: delay.pollTime,
+      delay: delay.delay,
+      pollEnd: delay.poll.end,
+    });
+
+    const fat = computeSchedulingDelays(
+      synthetic as never,
+      [0],
+      wakes as never,
+    ).map(norm);
+    const columnar = store.schedulingDelays([0], wakes).map(norm);
+
+    expect(fat).toEqual([
+      { wakeTime: 9, pollTime: 10, delay: 1, pollEnd: 10 },
+    ]);
+    expect(columnar).toEqual(fat);
+  });
 });

--- a/dial9-viewer/ui/src/lib/trace/columnar-worker-spans.ts
+++ b/dial9-viewer/ui/src/lib/trace/columnar-worker-spans.ts
@@ -96,14 +96,16 @@ interface WakeRec {
 
 /** Per-task poll index as a typed-array CSR (replaces the fat Map<taskId,
  * {start,end,workerId}[]>). Task `slot` owns [off[slot], off[slot+1]) in the
- * flat start/end/worker arrays, sorted ascending by start. Built once, cached,
- * shared by schedulingDelays + buildSpanDataColumnar's reconstructSpanSegments. */
+ * flat arrays, sorted ascending by start. `sourceIndex` identifies the poll
+ * within its worker's columns. Built once, cached, shared by schedulingDelays +
+ * buildSpanDataColumnar's reconstructSpanSegments. */
 export interface PollsByTaskCSR {
   slotOf: Map<number, number>;
   off: Int32Array;
   start: Float64Array;
   end: Float64Array;
   worker: Float64Array;
+  sourceIndex: Int32Array;
 }
 
 /** Per-task poll aggregate for the Tasks tab index. Scalars only - reduced from
@@ -304,7 +306,7 @@ export class ColumnarWorkerSpans {
   /** Set by attachCpuSamples; pollAt reads it to hand back real sample refs. */
   private cpuSamplesArr: readonly CpuSample[] | null = null;
   /** Lazily-built, cached per-task poll CSR (shared by schedulingDelays +
-   * buildSpanDataColumnar). ~127 MB typed vs 5.3M {start,end,workerId} objects. */
+   * buildSpanDataColumnar). ~148 MB typed vs 5.3M {start,end,workerId} objects. */
   private _pollsByTaskCSR: PollsByTaskCSR | null = null;
 
   private intern(s: string | null): number {
@@ -641,6 +643,7 @@ export class ColumnarWorkerSpans {
     const start = new Float64Array(off[T]!);
     const end = new Float64Array(off[T]!);
     const worker = new Float64Array(off[T]!);
+    const sourceIndex = new Int32Array(off[T]!);
     const cur = off.slice(0, T);
     // Pass 2: fill.
     for (const [w, c] of this.byWorker) {
@@ -648,12 +651,31 @@ export class ColumnarWorkerSpans {
         const t = c.taskId[i];
         if (!t) continue;
         const p = cur[slotOf.get(t)!]!++;
-        start[p] = c.start[i]!; end[p] = c.end[i]!; worker[p] = w;
+        start[p] = c.start[i]!;
+        end[p] = c.end[i]!;
+        worker[p] = w;
+        sourceIndex[p] = i;
       }
     }
     // Sort each task slice by start (stable - matches the fat arr.sort tie-break).
-    for (let s = 0; s < T; s++) sortTriByStart(start, end, worker, off[s]!, off[s + 1]!);
-    return (this._pollsByTaskCSR = { slotOf, off, start, end, worker });
+    for (let s = 0; s < T; s++) {
+      sortPollsByStart(
+        start,
+        end,
+        worker,
+        sourceIndex,
+        off[s]!,
+        off[s + 1]!,
+      );
+    }
+    return (this._pollsByTaskCSR = {
+      slotOf,
+      off,
+      start,
+      end,
+      worker,
+      sourceIndex,
+    });
   }
 
   /**
@@ -911,20 +933,28 @@ export class ColumnarWorkerSpans {
   }
 
   /**
-   * Columnar port of the frozen computeSchedulingDelays. For each poll of a
-   * task, find the latest wake before its start; if that wake landed mid an
-   * earlier poll of the same task, measure from that poll's end. Emits a
-   * schedDelay per poll with delay in (0, 1e9), sorted by wakeTime - identical
-   * to the fat pass. `pollsByTask` (5.3M poll refs in the fat pass) becomes a
-   * per-task CSR over Float64 start/end columns (~85 MB, not 1.9 GB of objects),
-   * transient to this call.
+   * Columnar port of computeSchedulingDelays. For each poll of a task, find the
+   * latest wake callback not consumed by the previous poll; if that wake landed
+   * during the previous poll, measure from that poll's end. For older traces
+   * that include stale callback attempts, this is a conservative lower bound.
+   * Emits a schedDelay per poll with delay in (0, 1e9), sorted by wakeTime -
+   * identical to the fat pass.
+   * `pollsByTask` (5.3M poll refs in the fat pass) becomes a per-task CSR over
+   * compact typed columns (~148 MB, not 1.9 GB of objects).
    */
   schedulingDelays(
     workerIds: number[],
     wakesByTask: Record<number, WakeRec[]>
   ): SchedDelayView[] {
     // Shared per-task poll CSR (cached; also used by buildSpanDataColumnar).
-    const { slotOf: slot, off, start: pStart, end: pEnd } = this.pollsByTaskCSR();
+    const {
+      slotOf: slot,
+      off,
+      start: pStart,
+      end: pEnd,
+      worker: pWorker,
+      sourceIndex: pSourceIndex,
+    } = this.pollsByTaskCSR();
     const out: SchedDelayView[] = [];
     for (const w of workerIds) {
       const c = this.byWorker.get(w);
@@ -935,26 +965,46 @@ export class ColumnarWorkerSpans {
         const wakes = wakesByTask[taskId];
         if (!wakes || !wakes.length) continue;
         const sStart = c.start[i]!;
-        // latest wake with timestamp <= sStart
+        const taskSlot = slot.get(taskId);
+        if (taskSlot === undefined) continue;
+        const pollLo = off[taskSlot]!;
+        const pollHi = off[taskSlot + 1]!;
+        let plo = pollLo, phi = pollHi - 1, pollIndex = pollHi;
+        while (plo <= phi) {
+          const mid = (plo + phi) >> 1;
+          if (pStart[mid]! < sStart) {
+            plo = mid + 1;
+          } else {
+            pollIndex = mid;
+            phi = mid - 1;
+          }
+        }
+        while (
+          pollIndex < pollHi &&
+          (pStart[pollIndex] !== sStart ||
+            pWorker[pollIndex] !== w ||
+            pSourceIndex[pollIndex] !== i)
+        ) {
+          pollIndex++;
+        }
+        if (pollIndex >= pollHi) continue;
+
+        const previousIndex = pollIndex > pollLo ? pollIndex - 1 : -1;
+        const consumedThrough =
+          previousIndex >= 0 ? pStart[previousIndex]! : -Infinity;
         let lo = 0, hi = wakes.length - 1, best = -1;
         while (lo <= hi) {
           const mid = (lo + hi) >> 1;
-          if (wakes[mid]!.timestamp <= sStart) { best = mid; lo = mid + 1; } else hi = mid - 1;
+          if (wakes[mid]!.timestamp <= sStart) {
+            best = mid;
+            lo = mid + 1;
+          } else hi = mid - 1;
         }
-        if (best < 0) continue;
+        if (best < 0 || wakes[best]!.timestamp <= consumedThrough) continue;
         const wake = wakes[best]!;
         let effectiveWake = wake.timestamp;
-        const s = slot.get(taskId);
-        if (s !== undefined) {
-          // rightmost poll of the task with start <= wake.timestamp
-          let plo = off[s]!, phi = off[s + 1]! - 1, pbest = -1;
-          while (plo <= phi) {
-            const pmid = (plo + phi) >> 1;
-            if (pStart[pmid]! <= wake.timestamp) { pbest = pmid; plo = pmid + 1; } else phi = pmid - 1;
-          }
-          if (pbest >= 0 && pStart[pbest]! < sStart && wake.timestamp <= pEnd[pbest]!) {
-            effectiveWake = pEnd[pbest]!;
-          }
+        if (previousIndex >= 0 && wake.timestamp <= pEnd[previousIndex]!) {
+          effectiveWake = pEnd[previousIndex]!;
         }
         const delay = sStart - effectiveWake;
         if (delay > 0 && delay < 1e9) {
@@ -1026,11 +1076,16 @@ export class ColumnarWorkerSpansBuilder {
   }
 }
 
-/** Stable sort of the parallel (start,end,worker) slice [lo,hi) by start
+/** Stable sort of the parallel poll columns in [lo,hi) by start
  * ascending; ties keep insertion order (== the fat arr.sort tie-break, so the
  * mid-poll binary search + segment reconstruction pick the same poll). */
-function sortTriByStart(
-  pStart: Float64Array, pEnd: Float64Array, pWorker: Float64Array, lo: number, hi: number
+function sortPollsByStart(
+  pStart: Float64Array,
+  pEnd: Float64Array,
+  pWorker: Float64Array,
+  pSourceIndex: Int32Array,
+  lo: number,
+  hi: number,
 ): void {
   const n = hi - lo;
   if (n < 2) return;
@@ -1038,9 +1093,18 @@ function sortTriByStart(
   // across engines regardless.
   const arr = Array.from({ length: n }, (_, k) => lo + k);
   arr.sort((x, y) => pStart[x]! - pStart[y]! || x - y);
-  const ts = new Float64Array(n), te = new Float64Array(n), tw = new Float64Array(n);
-  for (let k = 0; k < n; k++) { ts[k] = pStart[arr[k]!]!; te[k] = pEnd[arr[k]!]!; tw[k] = pWorker[arr[k]!]!; }
+  const ts = new Float64Array(n);
+  const te = new Float64Array(n);
+  const tw = new Float64Array(n);
+  const ti = new Int32Array(n);
+  for (let k = 0; k < n; k++) {
+    ts[k] = pStart[arr[k]!]!;
+    te[k] = pEnd[arr[k]!]!;
+    tw[k] = pWorker[arr[k]!]!;
+    ti[k] = pSourceIndex[arr[k]!]!;
+  }
   pStart.set(ts, lo);
   pEnd.set(te, lo);
   pWorker.set(tw, lo);
+  pSourceIndex.set(ti, lo);
 }

--- a/dial9-viewer/ui/src/types/trace_analysis.d.ts
+++ b/dial9-viewer/ui/src/types/trace_analysis.d.ts
@@ -200,9 +200,10 @@ declare module "*/trace_analysis.js" {
   ): SchedDelay[];
 
   /**
-   * For each poll of one task, the most recent wake at/before its start and
-   * the effective wake time (bumped past an earlier poll containing the
-   * wake). Result is parallel to `polls`; null where no wake applies.
+   * For each poll of one task, the latest wake callback not consumed by the
+   * previous poll and its effective wake time. This is a conservative lower
+   * bound for old traces that recorded stale callbacks. Result is parallel to
+   * `polls`; null where no wake applies.
    */
   export function computePollWakes(
     polls: readonly { start: number; end: number }[],

--- a/dial9-viewer/ui/tests/core/trace_analysis.test.ts
+++ b/dial9-viewer/ui/tests/core/trace_analysis.test.ts
@@ -596,6 +596,42 @@ describe("computeSchedulingDelays", () => {
       `gap wake wrongly adjusted: wakeTime=${r[0].wakeTime} delay=${r[0].delay} (expected 300/200)`,
     ).toBe(true);
   });
+
+  it("uses the latest unconsumed wake as a conservative lower bound", () => {
+    const ws = {
+      0: {
+        polls: [
+          { taskId: 1, start: 100, end: 200 },
+          { taskId: 1, start: 500, end: 600 },
+          { taskId: 1, start: 900, end: 1_000 },
+        ],
+      },
+    };
+    const wakes = {
+      1: [
+        { timestamp: 150, wakerTaskId: 7 },
+        { timestamp: 490, wakerTaskId: 8 },
+      ],
+    };
+
+    const r = computeSchedulingDelays(ws, [0], wakes);
+
+    expect(
+      r.map((delay: any) => ({
+        wakeTime: delay.wakeTime,
+        pollTime: delay.pollTime,
+        delay: delay.delay,
+        wakerTaskId: delay.wakerTaskId,
+      })),
+    ).toEqual([
+      {
+        wakeTime: 490,
+        pollTime: 500,
+        delay: 10,
+        wakerTaskId: 8,
+      },
+    ]);
+  });
 });
 
 // ── filterPointsOfInterest ──
@@ -1854,8 +1890,7 @@ describe("block-in-place active-span suppression", () => {
 
 // ── computePollWakes ──
 
-// Reference O(P^2) implementation — the original viewer loop, kept here to
-// prove the binary-search version produces identical results.
+// Deliberately simple O(P*W) reference for the production linear merge.
 function pollWakesBruteForce(
   polls: { start: number; end: number }[],
   wakes: { timestamp: number; wakerTaskId: number }[],
@@ -1864,29 +1899,26 @@ function pollWakesBruteForce(
   for (let pi = 0; pi < polls.length; pi++) {
     const s = polls[pi]!;
     let best: { wake: { wakerTaskId: number }; effectiveWake: number } | null = null;
-    if (wakes.length) {
-      let lo = 0,
-        hi = wakes.length - 1,
-        bi = -1;
-      while (lo <= hi) {
-        const mid = (lo + hi) >> 1;
-        if (wakes[mid]!.timestamp <= s.start) {
-          bi = mid;
-          lo = mid + 1;
-        } else hi = mid - 1;
+    const previousPoll = pi > 0 ? polls[pi - 1]! : null;
+    const consumedThrough = previousPoll?.start ?? -Infinity;
+    let wake: { timestamp: number; wakerTaskId: number } | null = null;
+    for (let wi = wakes.length - 1; wi >= 0; wi--) {
+      const candidate = wakes[wi]!;
+      if (
+        candidate.timestamp > consumedThrough &&
+        candidate.timestamp <= s.start
+      ) {
+        wake = candidate;
+        break;
       }
-      if (bi >= 0) {
-        const w = wakes[bi]!;
-        let effectiveWake = w.timestamp;
-        for (let j = 0; j < pi; j++) {
-          if (w.timestamp >= polls[j]!.start && w.timestamp <= polls[j]!.end) {
-            effectiveWake = polls[j]!.end;
-            break;
-          }
-        }
-        const delay = s.start - effectiveWake;
-        if (delay >= 0 && delay < 1e9) best = { wake: w, effectiveWake };
-      }
+    }
+    if (wake) {
+      const effectiveWake =
+        previousPoll && wake.timestamp <= previousPoll.end
+          ? previousPoll.end
+          : wake.timestamp;
+      const delay = s.start - effectiveWake;
+      if (delay >= 0 && delay < 1e9) best = { wake, effectiveWake };
     }
     out.push(best);
   }
@@ -1894,7 +1926,7 @@ function pollWakesBruteForce(
 }
 
 describe("computePollWakes", () => {
-  it("binary-search computePollWakes matches O(P^2) reference (400 polls, 600 wakes)", () => {
+  it("linear merge matches a simple reference (400 polls, 600 wakes)", () => {
     // Deterministic pseudo-random non-overlapping polls + scattered wakes.
     const polls: { start: number; end: number }[] = [];
     let t = 0;
@@ -1911,11 +1943,8 @@ describe("computePollWakes", () => {
     for (let i = 0; i < 600; i++) {
       wakes.push({ timestamp: Math.floor(rnd() * t), wakerTaskId: i });
     }
-    // Deliberately seed wakes EXACTLY on poll boundaries (poll.start, which for
-    // a zero-gap poll equals the previous poll's end). This is the case where a
-    // wake is contained by two adjacent polls and where the binary-search and
-    // O(P^2) versions can disagree on which poll "owns" it — so the comparison
-    // below actually exercises the first-match tie-break, not just interiors.
+    // Deliberately seed wakes exactly on poll boundaries. This checks that a
+    // boundary wake is consumed once by the poll starting at that timestamp.
     for (let i = 0; i < polls.length; i += 7) {
       wakes.push({ timestamp: polls[i]!.start, wakerTaskId: 1000 + i });
       wakes.push({ timestamp: polls[i]!.end, wakerTaskId: 2000 + i });
@@ -1974,13 +2003,27 @@ describe("computePollWakes", () => {
     ).toBeTruthy();
   });
 
-  it("wake on a shared poll boundary matches first-match (lowest-index) semantics", () => {
-    // A wake landing on a shared poll boundary (poll0.end == poll1.start == t)
-    // is contained by BOTH adjacent polls. The original O(P^2) loop took the
-    // FIRST (lowest-index) match, so effectiveWake = poll0.end == t (no bump).
-    // The binary search finds the rightmost poll with start <= t (poll1), so it
-    // must walk left to poll0 to stay faithful. Without that walk it would
-    // wrongly report poll1.end.
+  it("uses the latest idle wake once and consumes it", () => {
+    const polls = [
+      { start: 100, end: 200 },
+      { start: 500, end: 600 },
+      { start: 900, end: 1_000 },
+    ];
+    const wakes = [
+      { timestamp: 250, wakerTaskId: 7 },
+      { timestamp: 490, wakerTaskId: 8 },
+    ];
+
+    const out = computePollWakes(polls, wakes);
+
+    expect(out).toEqual([
+      null,
+      { wake: wakes[1], effectiveWake: 490 },
+      null,
+    ]);
+  });
+
+  it("consumes a wake on a shared poll boundary at that poll", () => {
     const polls = [
       { start: 0, end: 10 },
       { start: 10, end: 20 },
@@ -1988,12 +2031,13 @@ describe("computePollWakes", () => {
     ];
     const wakes = [{ timestamp: 10, wakerTaskId: 7 }];
     const out = computePollWakes(polls, wakes);
+    expect(out[1]?.effectiveWake).toBe(10);
     expect(
-      out[2] && out[2].effectiveWake === 10,
-      `pollWakes: shared-boundary effectiveWake should be 10 (first match), got ${out[2] && out[2].effectiveWake}`,
-    ).toBeTruthy();
+      out[2],
+      "pollWakes: a boundary wake must not be reused by a later poll",
+    ).toBeNull();
 
-    // Zero-width poll chain all touching t=10: lowest-index match is poll0.
+    // A zero-width chain still consumes the wake only once.
     const chain = [
       { start: 0, end: 10 },
       { start: 10, end: 10 },
@@ -2002,9 +2046,9 @@ describe("computePollWakes", () => {
     ];
     const cout = computePollWakes(chain, wakes);
     expect(
-      cout[3] && cout[3].effectiveWake === 10,
-      `pollWakes: boundary-chain effectiveWake should be 10, got ${cout[3] && cout[3].effectiveWake}`,
-    ).toBeTruthy();
+      cout[3],
+      "pollWakes: a boundary wake must not survive a zero-width poll chain",
+    ).toBeNull();
   });
 });
 

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -755,7 +755,9 @@
   }
 
   /**
-   * Compute scheduling delays: for each poll, find the most recent wake before it.
+   * Compute scheduling delays: for each poll, use the latest wake callback not
+   * consumed by the previous poll. Older producers recorded stale callback
+   * attempts, so the latest callback is a conservative lower-bound estimate.
    * Adjusts for mid-poll wake arrivals.
    * @param {Object} workerSpans - as returned by buildWorkerSpans
    * @param {number[]} workerIds
@@ -779,6 +781,35 @@
         if (!s.taskId) continue;
         const wakes = wakesByTask[s.taskId];
         if (!wakes || !wakes.length) continue;
+        const taskPolls = pollsByTask[s.taskId];
+        if (!taskPolls) continue;
+        let plo = 0,
+          phi = taskPolls.length - 1,
+          pollIndex = -1;
+        while (plo <= phi) {
+          const mid = (plo + phi) >> 1;
+          if (taskPolls[mid].start < s.start) {
+            plo = mid + 1;
+          } else {
+            if (taskPolls[mid] === s) pollIndex = mid;
+            phi = mid - 1;
+          }
+        }
+        if (pollIndex < 0) {
+          pollIndex = plo;
+          while (
+            pollIndex < taskPolls.length &&
+            taskPolls[pollIndex].start === s.start &&
+            taskPolls[pollIndex] !== s
+          ) {
+            pollIndex++;
+          }
+          if (taskPolls[pollIndex] !== s) continue;
+        }
+
+        const previousPoll =
+          pollIndex > 0 ? taskPolls[pollIndex - 1] : null;
+        const consumedThrough = previousPoll?.start ?? -Infinity;
         let lo = 0,
           hi = wakes.length - 1,
           best = -1;
@@ -789,37 +820,11 @@
             lo = mid + 1;
           } else hi = mid - 1;
         }
-        if (best >= 0) {
+        if (best >= 0 && wakes[best].timestamp > consumedThrough) {
           const wake = wakes[best];
           let effectiveWake = wake.timestamp;
-          const taskPolls = pollsByTask[s.taskId];
-          if (taskPolls) {
-            // If the wake landed mid-poll (the task was already being polled
-            // when it was woken), measure the delay from the end of that poll
-            // rather than the wake itself. taskPolls is sorted by start and a
-            // single task's polls never overlap, so at most one poll's
-            // [start, end] can contain wake.timestamp. Binary search for the
-            // rightmost poll with start <= wake.timestamp instead of linearly
-            // scanning every poll of the task (which is O(P^2) for a
-            // long-lived task with millions of polls).
-            let plo = 0,
-              phi = taskPolls.length - 1,
-              pbest = -1;
-            while (plo <= phi) {
-              const pmid = (plo + phi) >> 1;
-              if (taskPolls[pmid].start <= wake.timestamp) {
-                pbest = pmid;
-                plo = pmid + 1;
-              } else phi = pmid - 1;
-            }
-            if (pbest >= 0) {
-              const p = taskPolls[pbest];
-              // Preserve original semantics: only an earlier poll counts, and
-              // the wake must fall within it (start <= wake is guaranteed by
-              // the search above).
-              if (p.start < s.start && wake.timestamp <= p.end)
-                effectiveWake = p.end;
-            }
+          if (previousPoll && wake.timestamp <= previousPoll.end) {
+            effectiveWake = previousPoll.end;
           }
           const delay = s.start - effectiveWake;
           if (delay > 0 && delay < 1e9) {
@@ -841,21 +846,19 @@
   }
 
   /**
-   * For each poll of a selected task, find the most recent wake at or before
-   * the poll's start, plus the "effective wake" time used to measure the
-   * wake→poll scheduling delay.
+   * For each poll of a selected task, find the latest wake callback not
+   * consumed by the previous poll, plus the "effective wake" time used to
+   * estimate the wake→poll scheduling delay. Older producers recorded stale
+   * callback attempts, so this is a conservative lower bound.
    *
    * If that wake actually arrived while an EARLIER poll of the same task was
    * still running (the task was woken again mid-poll), the wait doesn't begin
    * until that earlier poll ends — so `effectiveWake` is bumped to that poll's
    * `end`.
    *
-   * `polls` MUST be the task's polls sorted ascending by `start`; a single
-   * task is polled on one worker at a time, so they are non-overlapping.
-   * `wakes` MUST be sorted ascending by `timestamp`. Both lookups are binary
-   * searches, so the whole pass is O(P·logP + P·logW) — NOT the O(P²) that a
-   * per-poll linear scan over earlier polls costs for a task polled millions
-   * of times. (This mirrors the binary-search fix in computeSchedulingDelays.)
+   * `polls` MUST be the task's polls sorted ascending by `start`; a single task
+   * is polled on one worker at a time, so they are non-overlapping. `wakes`
+   * MUST be sorted ascending by `timestamp`. The pass is O(P + W).
    *
    * @param {Array<{start:number,end:number}>} polls  task polls, sorted by start
    * @param {Array<{timestamp:number}>} wakes          task wakes, sorted by timestamp
@@ -864,39 +867,22 @@
   function computePollWakes(polls, wakes) {
     const result = new Array(polls.length).fill(null);
     if (!wakes || wakes.length === 0) return result;
+    let wakeIndex = 0;
     for (let pi = 0; pi < polls.length; pi++) {
       const s = polls[pi];
-      // Rightmost wake at or before this poll's start.
-      let lo = 0, hi = wakes.length - 1, bi = -1;
-      while (lo <= hi) {
-        const mid = (lo + hi) >> 1;
-        if (wakes[mid].timestamp <= s.start) { bi = mid; lo = mid + 1; }
-        else hi = mid - 1;
+      const previousPoll = pi > 0 ? polls[pi - 1] : null;
+      let wake = null;
+      while (
+        wakeIndex < wakes.length &&
+        wakes[wakeIndex].timestamp <= s.start
+      ) {
+        wake = wakes[wakeIndex];
+        wakeIndex++;
       }
-      if (bi < 0) continue;
-      const wake = wakes[bi];
+      if (wake === null) continue;
       let effectiveWake = wake.timestamp;
-      // Did that wake land inside an EARLIER poll (index < pi)? The original
-      // O(P^2) loop scanned earlier polls and took the FIRST (lowest-index) one
-      // containing the wake. Binary search the rightmost poll whose
-      // start <= wake.timestamp — the only candidates that can contain it are
-      // that poll and its immediate predecessors (polls are non-overlapping and
-      // sorted, so their `end`s are non-decreasing; an earlier poll contains the
-      // wake only at an exact shared boundary, end == wake == next.start). Walk
-      // left across that contiguous boundary run to the lowest-index member so
-      // the result matches the original "first match wins" semantics exactly
-      // (which, at such a boundary, yields effectiveWake == wake.timestamp — no
-      // bump — rather than the later poll's end). The walk spans only a tiny
-      // boundary chain, so the pass stays O(P·logP + P·logW) overall.
-      let plo = 0, phi = pi - 1, pbest = -1;
-      while (plo <= phi) {
-        const pmid = (plo + phi) >> 1;
-        if (polls[pmid].start <= wake.timestamp) { pbest = pmid; plo = pmid + 1; }
-        else phi = pmid - 1;
-      }
-      if (pbest >= 0 && wake.timestamp <= polls[pbest].end) {
-        while (pbest > 0 && polls[pbest - 1].end >= wake.timestamp) pbest--;
-        effectiveWake = polls[pbest].end;
+      if (previousPoll && wake.timestamp <= previousPoll.end) {
+        effectiveWake = previousPoll.end;
       }
       const delay = s.start - effectiveWake;
       if (delay >= 0 && delay < 1e9) result[pi] = { wake, effectiveWake };


### PR DESCRIPTION
## Summary
- consume legacy wake callback evidence once per poll while retaining the latest callback as a conservative lower bound
- process Rust poll starts in timestamp order for traces whose thread-local buffers flush out of order
- preserve source poll identity in the columnar scheduling-delay path, including equal-start zero-width chains

## Testing
- `mise x node@22.22.1 -- npm run test` (2,183 passed, 11 skipped)
- `mise x node@22.22.1 -- npx tsc --noEmit`
- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `cargo nextest run` (1,430 passed)
- `cargo nextest run --stress-duration 20s` (1 full iteration, 1,430 passed)
- `cargo build -p dial9-viewer`

## Stack
Depends on #837.