### PR TITLE
perf(viewer): accelerate large heap flamegraphs

### DIFF
--- a/dial9-viewer/ui/flamegraph.js
+++ b/dial9-viewer/ui/flamegraph.js
@@ -339,9 +339,13 @@
   }
 
   function filterCpuSamples(cpuSamples, startNs, endNs) {
-    let out = cpuSamples.filter((s) => s.callchain.length > 0 && s.source !== 1);
-    if (startNs != null) out = out.filter((s) => s.timestamp >= startNs);
-    if (endNs != null) out = out.filter((s) => s.timestamp <= endNs);
+    const out = [];
+    for (const sample of cpuSamples) {
+      if (sample.callchain.length === 0 || sample.source === 1) continue;
+      if (startNs != null && sample.timestamp < startNs) continue;
+      if (endNs != null && sample.timestamp > endNs) continue;
+      out.push(sample);
+    }
     return out;
   }
 
@@ -368,6 +372,7 @@
     let repaintQueued = false;
     let allSamples = [];
     let currentSymbols = null;
+    let treeOptions = null;
     // True once setTreeDirect() has installed a pre-built (aggregated/API) tree.
     // In that mode there are no raw `allSamples`, so the spawn/runtime filters
     // (which rebuild the trees from samples) do not apply and must not run —
@@ -1481,25 +1486,23 @@
     function applyFilters() {
       const filterVal = spawnFilter.value;
       const runtimeVal = runtimeFilter.value;
-      let samples = allSamples;
-      if (filterVal) {
-        samples = samples.filter((s) => (s.spawnLoc || "(unknown)") === filterVal);
-      }
-      if (runtimeVal) {
+      const workerSamples = [];
+      const offworkerSamples = [];
+      for (const sample of allSamples) {
+        if (filterVal && (sample.spawnLoc || "(unknown)") !== filterVal) continue;
         // Off-worker samples (workerId 255) have no runtime; a runtime filter
         // excludes them. Worker samples are kept when their worker belongs to
         // the selected runtime.
-        samples = samples.filter((s) => workerRuntime.get(s.workerId) === runtimeVal);
+        if (runtimeVal && workerRuntime.get(sample.workerId) !== runtimeVal) continue;
+        if (sample.workerId === 255) offworkerSamples.push(sample);
+        else workerSamples.push(sample);
       }
 
-      const workerSamples = samples.filter((s) => s.workerId !== 255);
-      const offworkerSamples = samples.filter((s) => s.workerId === 255);
-
       workerTree = workerSamples.length > 0
-        ? buildFlamegraphTree(workerSamples, currentSymbols)
+        ? buildFlamegraphTree(workerSamples, currentSymbols, treeOptions)
         : null;
       offworkerTree = offworkerSamples.length > 0
-        ? buildFlamegraphTree(offworkerSamples, currentSymbols)
+        ? buildFlamegraphTree(offworkerSamples, currentSymbols, treeOptions)
         : null;
 
       workerZoomStack = [];
@@ -1507,6 +1510,7 @@
       // The focus node points into trees we just rebuilt; drop inspect state and
       // any stale search dropdown so nothing dangles onto the old trees.
       resetInspectState();
+      setInspectVisible(false);
       hideSearchResults();
 
       workerLabel.textContent =
@@ -1537,6 +1541,7 @@
       directMode = false;
       allSamples = samples;
       currentSymbols = callframeSymbols;
+      treeOptions = (opts && opts.treeOptions) || null;
       formatCount = (opts && opts.formatCount) || null;
       workerLabelPrefix = (opts && opts.workerLabel) || "Worker threads";
       offworkerLabelPrefix = (opts && opts.offworkerLabel) || "Off-worker (sampler thread)";

--- a/dial9-viewer/ui/src/lib/trace/analysis.ts
+++ b/dial9-viewer/ui/src/lib/trace/analysis.ts
@@ -60,6 +60,7 @@ export type {
   AllocationSite,
   FlamegraphNode,
   FlamegraphSampleInput,
+  FlamegraphTreeOptions,
   FlatFlamegraphNode,
   ParkSpan,
   PointOfInterest,

--- a/dial9-viewer/ui/src/lib/trace/index.ts
+++ b/dial9-viewer/ui/src/lib/trace/index.ts
@@ -208,6 +208,7 @@ export type {
   AllocationSite,
   FlamegraphNode,
   FlamegraphSampleInput,
+  FlamegraphTreeOptions,
   FlatFlamegraphNode,
   ParkSpan,
   PointOfInterest,

--- a/dial9-viewer/ui/src/pages/viewer/analysis-cache-signature.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/analysis-cache-signature.test.ts
@@ -81,4 +81,38 @@ describe("analysis cache signatures", () => {
       }),
     );
   });
+
+  it("reuses heap derivation while invalidating the widget weight variant", () => {
+    const trace = {};
+    const shared = {
+      trace,
+      mode: "heap" as const,
+      range: { startNs: 100, endNs: 200 },
+      groupBy: "leaf" as const,
+    };
+    const bytesComputed = regionComputedCacheSignature({
+      ...shared,
+      heapMode: "bytes",
+    });
+    const countComputed = regionComputedCacheSignature({
+      ...shared,
+      heapMode: "count",
+    });
+    expect(countComputed).toBe(bytesComputed);
+    expect(
+      regionWidgetCacheSignature({
+        trace,
+        computed: bytesComputed,
+        blockingFlame: false,
+        variant: "bytes",
+      }),
+    ).not.toBe(
+      regionWidgetCacheSignature({
+        trace,
+        computed: countComputed,
+        blockingFlame: false,
+        variant: "count",
+      }),
+    );
+  });
 });

--- a/dial9-viewer/ui/src/pages/viewer/analysis-cache-signature.ts
+++ b/dial9-viewer/ui/src/pages/viewer/analysis-cache-signature.ts
@@ -31,7 +31,7 @@ export function regionComputedCacheSignature(args: {
 }): string {
   const range = `${args.range.startNs}-${args.range.endNs}`;
   if (args.mode === "heap") {
-    return `${traceIdentity(args.trace)}:heap:${range}:${args.heapMode}`;
+    return `${traceIdentity(args.trace)}:heap:${range}`;
   }
   if (args.mode === "blocking") {
     return `${traceIdentity(args.trace)}:blocking:${range}:${args.groupBy}`;
@@ -43,6 +43,9 @@ export function regionWidgetCacheSignature(args: {
   trace: object;
   computed: string;
   blockingFlame: boolean;
+  /** Rendering variant over the same derived data, such as heap Bytes/Count. */
+  variant?: string;
 }): string {
-  return `${traceIdentity(args.trace)}:${args.computed}${args.blockingFlame ? ":flame" : ""}`;
+  const variant = args.variant === undefined ? "" : `:${args.variant}`;
+  return `${traceIdentity(args.trace)}:${args.computed}${variant}${args.blockingFlame ? ":flame" : ""}`;
 }

--- a/dial9-viewer/ui/src/pages/viewer/region-analysis-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/region-analysis-model.test.ts
@@ -170,8 +170,10 @@ describe("heapRegionView", () => {
     });
     const view = heapRegionView(t, { startNs: 0, endNs: 100 }, {});
     expect(view.sampleCount).toBe(2);
-    // first sample: hook stripped -> ["site"], worker 0
-    expect(view.baseSamples[0]?.callchain).toEqual(["site"]);
+    // The hot path retains the original chain and skips its hook by offset.
+    expect(view.baseSamples[0]?.callchain).toEqual(["hook", "site"]);
+    expect(view.baseSamples[0]?.callchainStart).toBe(1);
+    expect(heapSamplesForMode(view.baseSamples, "bytes")[0]?.callchain).toEqual(["site"]);
     expect(view.baseSamples[0]?.workerId).toBe(0);
     expect(view.baseSamples[1]?.workerId).toBe(OFF);
     // size == R -> invP = 1/(1-e^-1) ~= 1.582; bytes ~= 524288 * that
@@ -281,6 +283,26 @@ describe("displayNamePath / frameSampleTimeExtent (frame->time)", () => {
       frameSampleTimeExtent(samples, { worker: [], offworker: ["root_fn"] }, cs),
     ).toEqual({ startNs: 42, endNs: 42 });
     expect(frameSampleTimeExtent(samples, { worker: [], offworker: [] }, cs)).toBeNull();
+  });
+
+  it("formats each repeated address once while matching a zoom prefix", () => {
+    const callframeSymbols = symbols({ leaf: "leaf_fn", root: "root_fn" });
+    const mapGet = callframeSymbols.get.bind(callframeSymbols);
+    let lookups = 0;
+    callframeSymbols.get = (key) => {
+      lookups += 1;
+      return mapGet(key);
+    };
+    const samples = Array.from({ length: 100 }, (_, timestamp) => ({
+      callchain: ["leaf", "root"],
+      workerId: 0,
+      timestamp,
+    }));
+
+    expect(
+      frameSampleTimeExtent(samples, { worker: ["root_fn"], offworker: [] }, callframeSymbols),
+    ).toEqual({ startNs: 0, endNs: 99 });
+    expect(lookups).toBe(1);
   });
 });
 

--- a/dial9-viewer/ui/src/pages/viewer/region-analysis-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/region-analysis-model.ts
@@ -99,6 +99,44 @@ export function collectSchedSamplesInRange(
   return out;
 }
 
+/** Whether an in-poll scheduling sample exists in `range`, without materializing entries. */
+function hasSchedSampleInRange(
+  workerSpans: WorkerSpans,
+  workerIds: readonly number[],
+  range: TimeRange | null,
+): boolean {
+  for (const w of workerIds) {
+    const lane = workerSpans[w];
+    if (!lane) continue;
+    for (const poll of lane.polls) {
+      if (!poll.schedSamples) continue;
+      if (range && (poll.end < range.startNs || poll.start > range.endNs)) continue;
+      for (const sample of poll.schedSamples) {
+        if (range && (sample.timestamp < range.startNs || sample.timestamp > range.endNs)) {
+          continue;
+        }
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** Whether a foldable on-CPU sample exists in `range`, without allocating a filtered array. */
+function hasCpuInRange(cpuSamples: readonly CpuSample[], range: TimeRange | null): boolean {
+  for (const sample of cpuSamples) {
+    if (!isFoldableCpuSample(sample)) continue;
+    if (
+      range &&
+      (sample.timestamp < range.startNs || sample.timestamp > range.endNs)
+    ) {
+      continue;
+    }
+    return true;
+  }
+  return false;
+}
+
 /** Whether alloc events with stacks exist in `range`. */
 export function hasHeapInRange(
   allocEvents: readonly AllocEvent[],
@@ -122,10 +160,8 @@ export function regionModesPresent(
   workerIds: readonly number[],
   range: TimeRange | null,
 ): RegionModesPresent {
-  const cpu =
-    filterRegionCpuSamples(trace.cpuSamples, range?.startNs ?? null, range?.endNs ?? null)
-      .length > 0;
-  const blocking = collectSchedSamplesInRange(workerSpans, workerIds, range).length > 0;
+  const cpu = hasCpuInRange(trace.cpuSamples, range);
+  const blocking = hasSchedSampleInRange(workerSpans, workerIds, range);
   const heap = hasHeapInRange(trace.allocEvents, range);
   return { cpu, blocking, heap };
 }
@@ -182,13 +218,19 @@ export function cpuRegionView(
   trace: ParsedTrace,
   range: TimeRange | null,
 ): CpuRegionView {
-  const samples = filterRegionCpuSamples(
-    trace.cpuSamples,
-    range?.startNs ?? null,
-    range?.endNs ?? null,
-  );
+  const samples: CpuSample[] = [];
+  let totalRecords = 0;
+  for (const sample of trace.cpuSamples) {
+    if (
+      range &&
+      (sample.timestamp < range.startNs || sample.timestamp > range.endNs)
+    ) {
+      continue;
+    }
+    totalRecords += 1;
+    if (isFoldableCpuSample(sample)) samples.push(sample);
+  }
   const foldableCount = samples.length;
-  const totalRecords = countCpuRecords(trace.cpuSamples, range);
   return {
     samples,
     foldableCount,
@@ -218,9 +260,12 @@ const HOOK_PATTERNS: readonly string[] = [
   "__rustc::__rust_realloc",
 ];
 
-/** A heap sample carrying BOTH weight axes; mapped to widget samples per mode. */
+/** A heap sample carrying both weight axes; the widget selects fields per mode. */
 export interface HeapBaseSample {
-  callchain: string[];
+  /** Original allocation callchain; allocator hooks are skipped via callchainStart. */
+  callchain: readonly string[];
+  /** First non-allocator frame in callchain. */
+  callchainStart: number;
   workerId: number;
   spawnLoc: string | null;
   /** size * 1/P(sample) - unbiased bytes (Horvitz-Thompson). */
@@ -239,25 +284,32 @@ export interface HeapRegionView {
   estimatedAllocs: number;
 }
 
-/** Strip leading allocator-hook frames. */
-function stripHookFrames(
+/** First frame after the leading allocator hooks. */
+function hookFrameStart(
   chain: readonly string[],
   callframeSymbols: CallframeSymbols,
-): string[] {
+  hookFrames: Map<string, boolean>,
+): number {
   let start = 0;
   while (start < chain.length) {
     const key = chain[start];
     if (key === undefined) break;
-    const entry = callframeSymbols.get(key);
-    const frames = Array.isArray(entry) ? entry : [entry];
-    const name = frames.map((f) => (f ? f.symbol : "")).join(" ");
-    if (HOOK_PATTERNS.some((p) => name.includes(p))) {
+    let isHook = hookFrames.get(key);
+    if (isHook === undefined) {
+      const entry = callframeSymbols.get(key);
+      const frames = Array.isArray(entry) ? entry : [entry];
+      isHook = frames.some(
+        (frame) => frame != null && HOOK_PATTERNS.some((pattern) => frame.symbol.includes(pattern)),
+      );
+      hookFrames.set(key, isHook);
+    }
+    if (isHook) {
       start += 1;
       continue;
     }
     break;
   }
-  return start > 0 ? chain.slice(start) : chain.slice();
+  return start;
 }
 
 /** Spawn location of the poll `timestamp` fell in for tid->worker `wId` (binary
@@ -288,12 +340,13 @@ export function heapRegionView(
   workerSpans: WorkerSpans,
 ): HeapRegionView {
   const baseSamples: HeapBaseSample[] = [];
+  const hookFrames = new Map<string, boolean>();
   let estimatedBytes = 0;
   let estimatedAllocs = 0;
   for (const a of trace.allocEvents) {
     if (range && (a.timestamp < range.startNs || a.timestamp > range.endNs)) continue;
-    const chain = stripHookFrames(a.callchain, trace.callframeSymbols);
-    if (chain.length === 0) continue;
+    const callchainStart = hookFrameStart(a.callchain, trace.callframeSymbols, hookFrames);
+    if (callchainStart === a.callchain.length) continue;
     const wId = trace.tidToWorker.get(a.tid);
     const size = a.size;
     const ratio = size / HEAP_R;
@@ -301,7 +354,8 @@ export function heapRegionView(
     const byteWeight = size * invP;
     const countWeight = invP;
     baseSamples.push({
-      callchain: chain,
+      callchain: a.callchain,
+      callchainStart,
       workerId: wId != null ? 0 : OFF_WORKER_WORKER_ID,
       spawnLoc: spawnLocAt(workerSpans, wId, a.timestamp),
       byteWeight,
@@ -318,14 +372,14 @@ export function heapRegionView(
   };
 }
 
-/** Map heap base samples to widget samples for the Bytes/Count toggle:
+/** Compatibility mapper for callers that need ordinary weighted widget samples:
  *  bytes -> weight=bytes/allocWeight=count; count -> swapped. */
 export function heapSamplesForMode(
   base: readonly HeapBaseSample[],
   mode: "bytes" | "count",
 ): FlamegraphDataSample[] {
   return base.map((s) => ({
-    callchain: s.callchain,
+    callchain: s.callchain.slice(s.callchainStart),
     workerId: s.workerId,
     spawnLoc: s.spawnLoc,
     weight: mode === "bytes" ? s.byteWeight : s.countWeight,
@@ -515,8 +569,9 @@ export function displayNamePath(
   callframeSymbols: CallframeSymbols,
 ): string[] {
   const names: string[] = [];
-  const chain = callchain.slice().reverse();
-  for (const addr of chain) {
+  for (let ci = callchain.length - 1; ci >= 0; ci--) {
+    const addr = callchain[ci];
+    if (addr === undefined) continue;
     const entry = callframeSymbols.get(addr);
     const frames = Array.isArray(entry) ? entry : [entry];
     for (let fi = 0; fi < frames.length; fi++) {
@@ -529,17 +584,9 @@ export function displayNamePath(
   return names;
 }
 
-function pathStartsWith(path: readonly string[], prefix: readonly string[]): boolean {
-  if (prefix.length === 0 || prefix.length > path.length) return false;
-  for (let i = 0; i < prefix.length; i++) {
-    if (path[i] !== prefix[i]) return false;
-  }
-  return true;
-}
-
 /** A sample the extent walk reads: a stack + panel routing + a timestamp. */
 export interface ExtentSample {
-  callchain: string[];
+  callchain: readonly string[];
   workerId: number;
   timestamp: number;
 }
@@ -562,13 +609,43 @@ export function frameSampleTimeExtent(
   if (!onWorker && !onOff) return null;
   const names = onWorker ? zoomPath.worker : zoomPath.offworker;
   const wantOff = !onWorker && onOff;
+  const namesByAddr = new Map<string, readonly string[]>();
   let min = Infinity;
   let max = -Infinity;
   for (const s of samples) {
     const isOff = s.workerId === OFF_WORKER_WORKER_ID;
     if (isOff !== wantOff) continue;
-    const path = displayNamePath(s.callchain, callframeSymbols);
-    if (!pathStartsWith(path, names)) continue;
+    let nameIndex = 0;
+    let matches = true;
+    for (let ci = s.callchain.length - 1; ci >= 0 && nameIndex < names.length; ci--) {
+      const addr = s.callchain[ci];
+      if (addr === undefined) continue;
+      let frameNames = namesByAddr.get(addr);
+      if (frameNames === undefined) {
+        const entry = callframeSymbols.get(addr);
+        const frames = Array.isArray(entry) ? entry : [entry];
+        const formatted: string[] = [];
+        for (let fi = 0; fi < frames.length; fi++) {
+          const resolved = frames[fi];
+          if (fi > 0 && !resolved) continue;
+          formatted.push(
+            resolved ? formatFrame(resolved).text : formatFrame(addr, callframeSymbols).text,
+          );
+        }
+        frameNames = formatted;
+        namesByAddr.set(addr, frameNames);
+      }
+      for (const frameName of frameNames) {
+        if (frameName !== names[nameIndex]) {
+          matches = false;
+          break;
+        }
+        nameIndex += 1;
+        if (nameIndex === names.length) break;
+      }
+      if (!matches) break;
+    }
+    if (!matches || nameIndex !== names.length) continue;
     if (s.timestamp < min) min = s.timestamp;
     if (s.timestamp > max) max = s.timestamp;
   }

--- a/dial9-viewer/ui/src/pages/viewer/region-analysis.ts
+++ b/dial9-viewer/ui/src/pages/viewer/region-analysis.ts
@@ -39,13 +39,13 @@ import {
   formatHeapBytes,
   frameSampleTimeExtent,
   heapRegionView,
-  heapSamplesForMode,
   regionCoverage,
   regionModesPresent,
   regionTitle,
   type BlockingGroup,
   type BlockingView,
   type CpuRegionView,
+  type HeapBaseSample,
   type HeapRegionView,
   type RegionCoverage,
   type RegionMode,
@@ -200,7 +200,10 @@ export function createRegionAnalysis(
 
   // ── heap widget options (tooltip / export labels) ───────────────────────
 
-  function heapFgOpts(view: HeapRegionView, range: TimeRange): FlamegraphSetDataOptions {
+  function heapFgOpts(
+    view: HeapRegionView,
+    range: TimeRange,
+  ): FlamegraphSetDataOptions<HeapBaseSample> {
     const m = heapMode;
     const durStr = ` · ${((range.endNs - range.startNs) / 1e6).toFixed(1)}ms`;
     return {
@@ -213,6 +216,11 @@ export function createRegionAnalysis(
         m === "bytes"
           ? (count: number) => `~${formatHeapBytes(count)}`
           : (count: number) => `~${Math.round(count).toLocaleString()} allocs`,
+      treeOptions: {
+        weightKey: m === "bytes" ? "byteWeight" : "countWeight",
+        allocWeightKey: m === "bytes" ? "countWeight" : "byteWeight",
+        callchainStartKey: "callchainStart",
+      },
       formatCount(count: number, total: number, _self: number, treeNode: FlamegraphNode | null | undefined) {
         const pct = ((count / total) * 100).toFixed(1);
         if (m === "bytes") {
@@ -299,6 +307,7 @@ export function createRegionAnalysis(
         trace,
         computed: sig,
         blockingFlame,
+        ...(mode === "heap" ? { variant: heapMode } : {}),
       });
       fg.sync({
         hostEl: fgHost,
@@ -322,7 +331,7 @@ export function createRegionAnalysis(
     } else if (computedView.kind === "heap") {
       cpuSamplesForExtent = [];
       instance.setData(
-        heapSamplesForMode(computedView.heap.baseSamples, heapMode),
+        computedView.heap.baseSamples,
         trace.callframeSymbols,
         heapFgOpts(computedView.heap, range),
       );

--- a/dial9-viewer/ui/src/types/flamegraph.d.ts
+++ b/dial9-viewer/ui/src/types/flamegraph.d.ts
@@ -4,7 +4,7 @@
 
 declare module "*/flamegraph.js" {
   import type { CallframeSymbols, CpuSample } from "*/trace_parser.js";
-  import type { FlamegraphNode } from "*/trace_analysis.js";
+  import type { FlamegraphNode, FlamegraphTreeOptions } from "*/trace_analysis.js";
 
   /**
    * Input sample for setData. CpuSample satisfies this; the heap views pass
@@ -13,14 +13,16 @@ declare module "*/flamegraph.js" {
    * `spawnLoc` feeds the spawn-location filter dropdown.
    */
   export interface FlamegraphDataSample {
-    callchain: string[];
+    callchain: readonly string[];
     workerId: number;
     spawnLoc?: string | null;
     weight?: number;
     allocWeight?: number;
   }
 
-  export interface FlamegraphSetDataOptions {
+  export interface FlamegraphSetDataOptions<
+    S extends FlamegraphDataSample = FlamegraphDataSample
+  > {
     /**
      * Tooltip weight formatter. `treeNode` is the hovered tree node (for
      * heap views to read allocCount); null-ish for synthetic rows.
@@ -41,6 +43,8 @@ declare module "*/flamegraph.js" {
     exportFormatValue?: (count: number) => string;
     /** runtime name -> worker ids, enables the runtime filter dropdown. */
     runtimeWorkers?: Map<string, number[]> | null;
+    /** Alternate sample fields used by weighted profiles such as heap views. */
+    treeOptions?: FlamegraphTreeOptions<S>;
   }
 
   /**
@@ -61,10 +65,10 @@ declare module "*/flamegraph.js" {
 
   export interface FlamegraphInstance {
     /** Build worker/off-worker trees from samples and render. */
-    setData(
-      samples: readonly FlamegraphDataSample[],
+    setData<S extends FlamegraphDataSample>(
+      samples: readonly S[],
       callframeSymbols: CallframeSymbols,
-      opts?: FlamegraphSetDataOptions
+      opts?: FlamegraphSetDataOptions<S>
     ): void;
     /**
      * API mode: render a pre-built tree directly (no worker/off-worker

--- a/dial9-viewer/ui/src/types/probe.ts
+++ b/dial9-viewer/ui/src/types/probe.ts
@@ -512,6 +512,19 @@ export function probeFlamegraph(container: HTMLElement, trace: ParsedTrace): voi
   void keyedTree.count;
   fg.setData(keyedHeapSamples, trace.callframeSymbols, { treeOptions });
 
+  type KeyProbeSample = (typeof keyedHeapSamples)[number] & {
+    optionalWeight?: number;
+  };
+  const invalidTreeOptions: FlamegraphTreeOptions<KeyProbeSample> = {
+    // @ts-expect-error weight fields must be required numeric properties.
+    weightKey: "callchain",
+    // @ts-expect-error optional numeric properties are not safe tree weights.
+    allocWeightKey: "optionalWeight",
+    // @ts-expect-error callchain offsets must be required numeric properties.
+    callchainStartKey: "callchain",
+  };
+  void invalidTreeOptions;
+
   // API mode: minimal toFgTree node into setTreeDirect.
   function toFgTree(node: { name: string; count: number; self: number; children?: { name: string; count: number; self: number }[] }): FlamegraphNode {
     const m = new Map<string, FlamegraphNode>();

--- a/dial9-viewer/ui/src/types/probe.ts
+++ b/dial9-viewer/ui/src/types/probe.ts
@@ -60,6 +60,7 @@ import type {
   WorkerLane,
   TracingSpan,
   FlamegraphNode,
+  FlamegraphTreeOptions,
 } from "../../trace_analysis.js";
 import {
   formatHumanDuration,
@@ -490,6 +491,26 @@ export function probeFlamegraph(container: HTMLElement, trace: ParsedTrace): voi
       return `~${count} (${pct}%) ${self} self${allocs !== null ? ` ${allocs} allocs` : ""}`;
     },
   });
+
+  // Keyed weighted columns avoid remapping large heap profiles.
+  const keyedHeapSamples = samples.map((s) => ({
+    ...s,
+    callchainStart: 0,
+    byteWeight: 8,
+    allocationWeight: 1,
+  }));
+  const treeOptions: FlamegraphTreeOptions<(typeof keyedHeapSamples)[number]> = {
+    weightKey: "byteWeight",
+    allocWeightKey: "allocationWeight",
+    callchainStartKey: "callchainStart",
+  };
+  const keyedTree: FlamegraphNode = buildFlamegraphTree(
+    keyedHeapSamples,
+    trace.callframeSymbols,
+    treeOptions,
+  );
+  void keyedTree.count;
+  fg.setData(keyedHeapSamples, trace.callframeSymbols, { treeOptions });
 
   // API mode: minimal toFgTree node into setTreeDirect.
   function toFgTree(node: { name: string; count: number; self: number; children?: { name: string; count: number; self: number }[] }): FlamegraphNode {

--- a/dial9-viewer/ui/src/types/trace_analysis.d.ts
+++ b/dial9-viewer/ui/src/types/trace_analysis.d.ts
@@ -311,16 +311,24 @@ declare module "*/trace_analysis.js" {
     allocWeight?: number;
   }
 
+  type RequiredNumericKey<S> = {
+    [K in keyof S]-?: undefined extends S[K]
+      ? never
+      : S[K] extends number
+        ? K
+        : never;
+  }[keyof S] & string;
+
   export interface FlamegraphTreeOptions<S extends FlamegraphSampleInput> {
     /** Sample property used as the primary weight instead of `weight`. */
-    weightKey?: keyof S & string;
+    weightKey?: RequiredNumericKey<S>;
     /**
      * Sample property used as the secondary weight. Supplying this selects the
      * optimized path for profiles where every sample has both weight axes.
      */
-    allocWeightKey?: keyof S & string;
+    allocWeightKey?: RequiredNumericKey<S>;
     /** Sample property containing the first callchain index to include. */
-    callchainStartKey?: keyof S & string;
+    callchainStartKey?: RequiredNumericKey<S>;
   }
 
   export interface FlamegraphNode {

--- a/dial9-viewer/ui/src/types/trace_analysis.d.ts
+++ b/dial9-viewer/ui/src/types/trace_analysis.d.ts
@@ -304,11 +304,23 @@ declare module "*/trace_analysis.js" {
    * views pass pseudo-samples with explicit weights.
    */
   export interface FlamegraphSampleInput {
-    callchain: string[];
+    callchain: readonly string[];
     /** Per-sample weight; defaults to 1 (CPU sample counting). */
     weight?: number;
     /** Secondary weight (heap views: bytes or alloc count). */
     allocWeight?: number;
+  }
+
+  export interface FlamegraphTreeOptions<S extends FlamegraphSampleInput> {
+    /** Sample property used as the primary weight instead of `weight`. */
+    weightKey?: keyof S & string;
+    /**
+     * Sample property used as the secondary weight. Supplying this selects the
+     * optimized path for profiles where every sample has both weight axes.
+     */
+    allocWeightKey?: keyof S & string;
+    /** Sample property containing the first callchain index to include. */
+    callchainStartKey?: keyof S & string;
   }
 
   export interface FlamegraphNode {
@@ -325,9 +337,10 @@ declare module "*/trace_analysis.js" {
     selfAllocCount?: number;
   }
 
-  export function buildFlamegraphTree(
-    samples: readonly FlamegraphSampleInput[],
-    callframeSymbols: CallframeSymbols
+  export function buildFlamegraphTree<S extends FlamegraphSampleInput>(
+    samples: readonly S[],
+    callframeSymbols: CallframeSymbols,
+    opts?: FlamegraphTreeOptions<S>
   ): FlamegraphNode;
 
   export interface FlatFlamegraphNode {

--- a/dial9-viewer/ui/tests/core/flamegraph_inspect_dom.test.js
+++ b/dial9-viewer/ui/tests/core/flamegraph_inspect_dom.test.js
@@ -144,6 +144,17 @@ function sampleTree() {
   return tree("", 15, 0, [a, b]);
 }
 
+function exactSamples(frame) {
+  const symbols = new Map([
+    [1, { symbol: "root", location: null }],
+    [2, { symbol: frame, location: null }],
+  ]);
+  const samples = [
+    { callchain: [2, 1], workerId: 0, spawnLoc: null, weight: 1 },
+  ];
+  return { samples, symbols };
+}
+
 // Dispatch a mouse-ish event to an element's handlers.
 function fire(el, type, props) {
   const ev = Object.assign({
@@ -192,6 +203,29 @@ test("right-click → Inspect enters butterfly; Esc exits (#652)", () => {
     const consumed = fg.handleEscape();
     assert.strictEqual(consumed, true, "Esc consumed by inspect exit");
     assert.strictEqual(inspectView.style.display, "none", "inspect view hidden after Esc");
+  } finally {
+    dom.restore();
+  }
+});
+
+test("replacing exact-trace data exits inspect and hides its DOM", () => {
+  const dom = makeDom();
+  try {
+    const { createFlamegraph } = require("../../flamegraph.js");
+    const fg = createFlamegraph(dom.makeEl());
+    const cpu = exactSamples("cpu_frame");
+    fg.setData(cpu.samples, cpu.symbols);
+
+    assert.strictEqual(fg.focusInspectByKey("cpu_frame"), true);
+    const inspectView = dom.byClass["fg-inspect"][0];
+    assert.strictEqual(inspectView.style.display, "", "inspect view is visible");
+
+    const heap = exactSamples("heap_frame");
+    fg.setData(heap.samples, heap.symbols);
+
+    assert.strictEqual(fg.getInspectFocus(), null, "inspect focus is cleared");
+    assert.strictEqual(inspectView.style.display, "none", "inspect view is hidden");
+    assert.strictEqual(fg.handleEscape(), false, "no stale inspect state remains");
   } finally {
     dom.restore();
   }

--- a/dial9-viewer/ui/tests/core/trace_analysis.test.ts
+++ b/dial9-viewer/ui/tests/core/trace_analysis.test.ts
@@ -834,6 +834,57 @@ describe("flamegraph", () => {
       "node.allocCount should be undefined for unweighted samples",
     ).toBe(true);
   });
+
+  it("resolves each repeated address once per tree build", () => {
+    const callframeSymbols = new Map([
+      ["0xD", [{ symbol: "leaf_fn", location: "leaf.rs:1" }]],
+      ["0xE", [{ symbol: "caller_fn", location: "caller.rs:1" }]],
+    ]);
+    const mapGet = callframeSymbols.get.bind(callframeSymbols);
+    let lookups = 0;
+    callframeSymbols.get = (key) => {
+      lookups += 1;
+      return mapGet(key);
+    };
+    const samples = Array.from({ length: 100 }, () => ({
+      callchain: ["0xD", "0xE"],
+    }));
+
+    const tree = buildFlamegraphTree(samples, callframeSymbols);
+
+    expect(tree.count).toBe(100);
+    expect(lookups).toBe(2);
+  });
+
+  it("reads weighted profile fields and a callchain start offset without remapping", () => {
+    const callframeSymbols = new Map([
+      ["hook", { symbol: "allocator_hook", location: null }],
+      ["leaf", { symbol: "leaf_fn", location: null }],
+      ["root", { symbol: "root_fn", location: null }],
+    ]);
+    const samples = [
+      {
+        callchain: ["hook", "leaf", "root"],
+        callchainStart: 1,
+        bytes: 128,
+        allocations: 4,
+      },
+    ];
+
+    const tree = buildFlamegraphTree(samples, callframeSymbols, {
+      weightKey: "bytes",
+      allocWeightKey: "allocations",
+      callchainStartKey: "callchainStart",
+    });
+
+    expect(tree.count).toBe(128);
+    expect(tree.allocCount).toBe(4);
+    const root = tree.children.get("root_fn");
+    const leaf = root?.children.get("leaf_fn");
+    expect(leaf?.count).toBe(128);
+    expect(leaf?.allocCount).toBe(4);
+    expect(leaf?.children.has("allocator_hook")).toBe(false);
+  });
 });
 
 // ── TaskDumpEvent parsing (verified against the demo trace) ──

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -1031,44 +1031,159 @@
    * Build a flamegraph tree from CPU samples with reversed callchains.
    * @param {import('./trace_parser.js').CpuSample[]} samples
    * @param {Map} callframeSymbols
+   * @param {{weightKey?: string, allocWeightKey?: string, callchainStartKey?: string}} [opts]
    * @returns {{ name: string, children: Map, count: number, self: number }}
    */
-  function buildFlamegraphTree(samples, callframeSymbols) {
-    const root = { name: "(all)", children: new Map(), count: 0, self: 0 };
+  function buildFlamegraphTree(samples, callframeSymbols, opts) {
+    const weightKey = opts && opts.weightKey;
+    const allocWeightKey = opts && opts.allocWeightKey;
+    const callchainStartKey = opts && opts.callchainStartKey;
+    const weighted = allocWeightKey != null;
+    const root = {
+      name: "(all)",
+      children: new Map(),
+      count: 0,
+      self: 0,
+    };
+    if (weighted && samples.length > 0) {
+      root.allocCount = 0;
+    }
+    // Symbol expansion and frame formatting depend only on the raw address.
+    // Large heap profiles revisit a small symbol table millions of times, so
+    // resolve each address once per build instead of once per sample.
+    const framesByAddr = new Map();
+
+    function resolveFrames(addr) {
+      const entry = callframeSymbols.get(addr);
+      if (!Array.isArray(entry)) {
+        const formatted = entry
+          ? formatFrame(entry)
+          : formatFrame(addr, callframeSymbols);
+        return {
+          key: entry ? entry.symbol : addr || "??",
+          text: formatted.text,
+          location: entry ? entry.location : null,
+          docsUrl: formatted.docsUrl,
+        };
+      }
+
+      // Expand inlined frames. Per blazesym, an array entry is ordered
+      // [outermost, ..., innermost]: entry[0] is the real function at this
+      // address, and entry[i>0] are inlined callees (entry[0] calls entry[1]
+      // calls entry[2], etc.). To walk the call graph caller→callee while
+      // descending the flamegraph tree, iterate 0 → N. Skip nullish slots
+      // that can appear in sparse arrays (rare, but can happen if inline
+      // SymbolTableEntry events arrive before their depth=0 sibling).
+      const frames = [];
+      for (let fi = 0; fi < entry.length; fi++) {
+        const resolved = entry[fi];
+        if (fi > 0 && !resolved) continue;
+        const formatted = resolved
+          ? formatFrame(resolved)
+          : formatFrame(addr, callframeSymbols);
+        frames.push({
+          key: resolved ? resolved.symbol : addr || "??",
+          text: formatted.text,
+          location: resolved ? resolved.location : null,
+          docsUrl: formatted.docsUrl,
+        });
+      }
+      return frames;
+    }
+
+    function newNode(frame) {
+      const node = {
+        name: frame.text,
+        fullName: frame.key,
+        location: frame.location,
+        docsUrl: frame.docsUrl,
+        children: new Map(),
+        count: 0,
+        self: 0,
+      };
+      if (weighted) {
+        node.allocCount = 0;
+      }
+      return node;
+    }
+
+    // Heap profiles always carry both weight axes. Keeping this path separate
+    // removes two optional-value branches from every visited stack frame.
+    if (weighted) {
+      for (const s of samples) {
+        const w = weightKey != null ? s[weightKey] : s.weight != null ? s.weight : 1;
+        const aw = s[allocWeightKey];
+        const start = callchainStartKey != null ? s[callchainStartKey] : 0;
+        let node = root;
+        node.count += w;
+        node.allocCount += aw;
+        for (let ci = s.callchain.length - 1; ci >= start; ci--) {
+          const addr = s.callchain[ci];
+          let frames = framesByAddr.get(addr);
+          if (frames === undefined) {
+            frames = resolveFrames(addr);
+            framesByAddr.set(addr, frames);
+          }
+          if (Array.isArray(frames)) {
+            for (const frame of frames) {
+              let child = node.children.get(frame.key);
+              if (child === undefined) {
+                child = newNode(frame);
+                node.children.set(frame.key, child);
+              }
+              node = child;
+              node.count += w;
+              node.allocCount += aw;
+            }
+          } else {
+            let child = node.children.get(frames.key);
+            if (child === undefined) {
+              child = newNode(frames);
+              node.children.set(frames.key, child);
+            }
+            node = child;
+            node.count += w;
+            node.allocCount += aw;
+          }
+        }
+        node.self += w;
+        node.selfAllocCount = (node.selfAllocCount || 0) + aw;
+      }
+      return root;
+    }
+
     for (const s of samples) {
-      const w = s.weight != null ? s.weight : 1;
+      const w = weightKey != null ? s[weightKey] : s.weight != null ? s.weight : 1;
       const aw = s.allocWeight;
-      const chain = s.callchain.slice().reverse();
+      const start = callchainStartKey != null ? s[callchainStartKey] : 0;
       let node = root;
       node.count += w;
       if (aw != null) node.allocCount = (node.allocCount || 0) + aw;
-      for (const addr of chain) {
-        const entry = callframeSymbols.get(addr);
-        // Expand inlined frames. Per blazesym, an array entry is ordered
-        // [outermost, ..., innermost]: entry[0] is the real function at this
-        // address, and entry[i>0] are inlined callees (entry[0] calls entry[1]
-        // calls entry[2], etc.). To walk the call graph caller→callee while
-        // descending the flamegraph tree, iterate 0 → N. Skip nullish slots
-        // that can appear in sparse arrays (rare, but can happen if inline
-        // SymbolTableEntry events arrive before their depth=0 sibling).
-        const frames = Array.isArray(entry) ? entry : [entry];
-        for (let fi = 0; fi < frames.length; fi++) {
-          const resolved = frames[fi];
-          if (fi > 0 && !resolved) continue;
-          const key = resolved ? resolved.symbol : addr || "??";
-          const formatted = resolved ? formatFrame(resolved) : formatFrame(addr, callframeSymbols);
-          if (!node.children.has(key)) {
-            node.children.set(key, {
-              name: formatted.text,
-              fullName: key,
-              location: resolved ? resolved.location : null,
-              docsUrl: formatted.docsUrl,
-              children: new Map(),
-              count: 0,
-              self: 0,
-            });
+      for (let ci = s.callchain.length - 1; ci >= start; ci--) {
+        const addr = s.callchain[ci];
+        let frames = framesByAddr.get(addr);
+        if (frames === undefined) {
+          frames = resolveFrames(addr);
+          framesByAddr.set(addr, frames);
+        }
+        if (Array.isArray(frames)) {
+          for (const frame of frames) {
+            let child = node.children.get(frame.key);
+            if (child === undefined) {
+              child = newNode(frame);
+              node.children.set(frame.key, child);
+            }
+            node = child;
+            node.count += w;
+            if (aw != null) node.allocCount = (node.allocCount || 0) + aw;
           }
-          node = node.children.get(key);
+        } else {
+          let child = node.children.get(frames.key);
+          if (child === undefined) {
+            child = newNode(frames);
+            node.children.set(frames.key, child);
+          }
+          node = child;
           node.count += w;
           if (aw != null) node.allocCount = (node.allocCount || 0) + aw;
         }


### PR DESCRIPTION
## Summary

- avoid per-allocation sample and callchain copies by letting the flamegraph tree read keyed weight fields and callchain offsets directly
- cache symbol expansion/formatting per address and reuse the heap derivation across Bytes/Count modes
- restrict keyed tree options to required numeric sample fields, with negative type probes
- clear stale inspect DOM when replacing profile data, fixing CPU inspect -> Heap leaving an undismissable butterfly view

## Performance

Measured on the supplied trace with 752,542 allocation events:

- initial heap render: 1.89-1.92s
- Bytes/Count rebuild: 1.31-1.41s

## Testing

- `mise x node@22.22.1 -- npm run test` (2,180 passed, 11 skipped)
- `mise x node@22.22.1 -- npm run check:types`
- `mise x node@22.22.1 -- npm run build`
- `cargo build -p dial9-viewer`
- manually verified CPU inspect -> Heap against the supplied trace
