### PR TITLE
perf(viewer): intern aggregate flamegraph frames

### DIFF
--- a/dial9-viewer/src/ingest/aggregate.rs
+++ b/dial9-viewer/src/ingest/aggregate.rs
@@ -24,6 +24,7 @@
 
 use crate::storage::{ObjectInfo, StorageBackend};
 use arrow::array::Array;
+use lasso::{Rodeo, Spur};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::Semaphore;
@@ -916,8 +917,8 @@ fn poll_hist_bars(hist: &PollHist) -> Vec<PollDurationBucket> {
 /// the large part), while `stack_counts` and `facets` are materialized because
 /// the caller iterates them to build the tree and toolbar.
 pub(crate) struct AggSnapshot<'a> {
-    pub stack_counts: Vec<(Vec<u8>, u64)>,
-    pub stacks_dict: &'a HashMap<Vec<u8>, Vec<String>>,
+    pub stack_counts: Vec<([u8; 16], u64)>,
+    pub stacks_dict: &'a StackDictionary,
     pub total_samples: usize,
     pub hosts: usize,
     pub min_ts: Option<i64>,
@@ -928,6 +929,57 @@ pub(crate) struct AggSnapshot<'a> {
     pub poll_duration_histogram: Vec<PollDurationBucket>,
 }
 
+pub(crate) type FrameId = Spur;
+
+/// Interned stack dictionary shared by every emitted flamegraph snapshot.
+///
+/// A production profile may contain millions of frame occurrences but only a
+/// few thousand distinct symbols. Keeping the strings in one interner makes
+/// each stack an array of fixed-width IDs instead of an array of owned strings.
+#[derive(Clone)]
+pub(crate) struct StackDictionary {
+    frames: Rodeo<FrameId>,
+    stacks: HashMap<[u8; 16], Vec<FrameId>>,
+}
+
+impl StackDictionary {
+    fn new() -> Self {
+        let mut frames = Rodeo::new();
+        frames.get_or_intern("(all)");
+        Self {
+            frames,
+            stacks: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn get(&self, stack_id: &[u8; 16]) -> Option<&[FrameId]> {
+        self.stacks.get(stack_id).map(Vec::as_slice)
+    }
+
+    pub(crate) fn resolve(&self, frame: FrameId) -> &str {
+        self.frames.resolve(&frame)
+    }
+
+    pub(crate) fn root(&self) -> FrameId {
+        self.frames
+            .get("(all)")
+            .expect("the root frame is interned when the dictionary is created")
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_stacks(stacks: HashMap<[u8; 16], Vec<String>>) -> Self {
+        let mut dict = Self::new();
+        for (stack_id, names) in stacks {
+            let frames = names
+                .iter()
+                .map(|name| dict.frames.get_or_intern(name))
+                .collect();
+            dict.stacks.insert(stack_id, frames);
+        }
+        dict
+    }
+}
+
 /// Incremental flamegraph accumulator: merge folded part-files one at a time
 /// under a fixed [`SampleFilter`], so a streaming query can emit a fresh
 /// [`snapshot`](Self::snapshot) after every file rather than re-reading the whole
@@ -936,7 +988,7 @@ pub(crate) struct AggSnapshot<'a> {
 pub(crate) struct FlamegraphAccum {
     filter: SampleFilter,
     counts: HashMap<[u8; 16], u64>,
-    dict: HashMap<Vec<u8>, Vec<String>>,
+    dict: StackDictionary,
     facets: FacetAccum,
     total_samples: usize,
     min_ts: Option<i64>,
@@ -951,7 +1003,7 @@ impl FlamegraphAccum {
         Self {
             filter,
             counts: HashMap::new(),
-            dict: HashMap::new(),
+            dict: StackDictionary::new(),
             facets: FacetAccum::new(),
             total_samples: 0,
             min_ts: None,
@@ -979,7 +1031,6 @@ impl FlamegraphAccum {
         self.read_samples_part_into(
             samples,
             &mut staged_counts,
-            &mut staged_dict,
             &mut staged_facets,
             &mut staged_total,
             &mut staged_min_ts,
@@ -1012,7 +1063,6 @@ impl FlamegraphAccum {
         &self,
         data: Vec<u8>,
         counts: &mut HashMap<[u8; 16], u64>,
-        _dict: &mut HashMap<Vec<u8>, Vec<String>>,
         facets: &mut FacetAccum,
         total_samples: &mut usize,
         min_ts: &mut Option<i64>,
@@ -1157,8 +1207,8 @@ impl FlamegraphAccum {
 
     /// A borrowed snapshot of the current totals for emitting one SSE event.
     pub(crate) fn snapshot(&self) -> AggSnapshot<'_> {
-        let stack_counts: Vec<(Vec<u8>, u64)> =
-            self.counts.iter().map(|(k, v)| (k.to_vec(), *v)).collect();
+        let stack_counts: Vec<([u8; 16], u64)> =
+            self.counts.iter().map(|(k, v)| (*k, *v)).collect();
         AggSnapshot {
             stack_counts,
             stacks_dict: &self.dict,
@@ -1392,7 +1442,7 @@ fn extract_facet_value(col: &ResolvedFacetCol, i: usize) -> Option<String> {
     }
 }
 
-fn read_dict_part(data: Vec<u8>, dict: &mut HashMap<Vec<u8>, Vec<String>>) -> anyhow::Result<()> {
+fn read_dict_part(data: Vec<u8>, dict: &mut StackDictionary) -> anyhow::Result<()> {
     // `Bytes::from(Vec<u8>)` reuses the allocation (no copy).
     let reader = ::parquet::arrow::arrow_reader::ParquetRecordBatchReader::try_new(
         bytes::Bytes::from(data),
@@ -1411,8 +1461,8 @@ fn read_dict_part(data: Vec<u8>, dict: &mut HashMap<Vec<u8>, Vec<String>>) -> an
             continue;
         };
         for i in 0..batch.num_rows() {
-            let id = stack_arr.value(i).to_vec();
-            if dict.contains_key(&id) {
+            let id: [u8; 16] = stack_arr.value(i).try_into()?;
+            if dict.stacks.contains_key(&id) {
                 continue;
             }
             let frame_list = frames_arr.value(i);
@@ -1420,10 +1470,10 @@ fn read_dict_part(data: Vec<u8>, dict: &mut HashMap<Vec<u8>, Vec<String>>) -> an
                 .as_any()
                 .downcast_ref::<arrow::array::StringArray>()
             {
-                let frames: Vec<String> = (0..str_arr.len())
-                    .map(|j| str_arr.value(j).to_string())
+                let frames: Vec<FrameId> = (0..str_arr.len())
+                    .map(|j| dict.frames.get_or_intern(str_arr.value(j)))
                     .collect();
-                dict.insert(id, frames);
+                dict.stacks.insert(id, frames);
             }
         }
     }
@@ -2311,7 +2361,7 @@ mod tests {
                     assert!(*count > 0, "a stack with zero count should not be present");
                     if let Some(fs) = snap.stacks_dict.get(stack_id) {
                         for f in fs {
-                            frames.insert(f.clone());
+                            frames.insert(snap.stacks_dict.resolve(*f).to_string());
                         }
                     }
                 }

--- a/dial9-viewer/src/server/flamegraph.rs
+++ b/dial9-viewer/src/server/flamegraph.rs
@@ -22,8 +22,8 @@ use hex;
 use serde::{Deserialize, Serialize};
 
 use crate::ingest::aggregate::{
-    self, AggContext, AggSnapshot, Coverage, FACETS, FacetResult, FlamegraphAccum,
-    PollDurationBucket, SampleFilter, Scope,
+    self, AggContext, AggSnapshot, Coverage, FACETS, FacetResult, FlamegraphAccum, FrameId,
+    PollDurationBucket, SampleFilter, Scope, StackDictionary,
 };
 use crate::ingest::refine::{self, FoldErrors, Folded, RefineOpts, Resolved};
 use crate::server::AppState;
@@ -86,16 +86,26 @@ pub struct FlamegraphParams {
     pub min_span_ns: Option<i64>,
     /// Maximum span elapsed_ns for the span filter (inclusive).
     pub max_span_ns: Option<i64>,
+    /// Response tree encoding. The canonical UI requests `interned-v1`; absent
+    /// or unknown values retain the legacy nested-name response.
+    pub format: Option<String>,
 }
 
 #[derive(Serialize)]
 pub struct FlamegraphResponse {
-    pub tree: FlamegraphNode,
+    pub tree: FlamegraphTree,
     pub total_samples: usize,
     /// Present in demand-driven mode: how much of the scope has been folded.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coverage: Option<Coverage>,
     pub metadata: FlamegraphMetadata,
+}
+
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum FlamegraphTree {
+    Legacy(FlamegraphNode),
+    Interned(InternedFlamegraphTree),
 }
 
 #[derive(Serialize, Clone)]
@@ -106,6 +116,24 @@ pub struct FlamegraphNode {
     pub self_count: u64,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub children: Vec<FlamegraphNode>,
+}
+
+#[derive(Serialize)]
+pub struct InternedFlamegraphTree {
+    pub format: &'static str,
+    /// Frame names indexed by every node's `frame` field.
+    pub frames: Vec<String>,
+    pub root: InternedFlamegraphNode,
+}
+
+#[derive(Serialize)]
+pub struct InternedFlamegraphNode {
+    pub frame: u32,
+    pub count: u64,
+    #[serde(rename = "self")]
+    pub self_count: u64,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<InternedFlamegraphNode>,
 }
 
 #[derive(Serialize)]
@@ -152,10 +180,10 @@ pub struct ScopeEcho {
 
 /// Build a flamegraph tree from (stack_id, count) pairs and a stacks dictionary.
 fn build_flamegraph_tree(
-    stack_counts: &[(Vec<u8>, u64)],
-    stacks_dict: &HashMap<Vec<u8>, Vec<String>>,
-) -> FlamegraphNode {
-    let mut root = TrieNode::new("(all)".to_string());
+    stack_counts: &[([u8; 16], u64)],
+    stacks_dict: &StackDictionary,
+) -> TrieNode {
+    let mut root = TrieNode::new(stacks_dict.root());
 
     for (stack_id, count) in stack_counts {
         let frames = match stacks_dict.get(stack_id) {
@@ -166,58 +194,113 @@ fn build_flamegraph_tree(
         root.count += count;
         let mut node = &mut root;
         for frame in frames.iter().rev() {
-            node = node.get_or_insert_child(frame.clone());
+            node = node.get_or_insert_child(*frame);
             node.count += count;
         }
         // Leaf gets self-time
         node.self_count += count;
     }
 
-    root.into_response()
+    root
 }
 
 struct TrieNode {
-    name: String,
+    frame: FrameId,
     count: u64,
     self_count: u64,
-    children: HashMap<String, TrieNode>,
+    children: HashMap<FrameId, TrieNode>,
 }
 
 impl TrieNode {
-    fn new(name: String) -> Self {
+    fn new(frame: FrameId) -> Self {
         Self {
-            name,
+            frame,
             count: 0,
             self_count: 0,
             children: HashMap::new(),
         }
     }
 
-    fn get_or_insert_child(&mut self, name: String) -> &mut TrieNode {
-        // `or_insert_with_key` clones the name only when a new node is inserted;
-        // on the hot path (child already present) it's just a move into the
-        // lookup with no allocation.
+    fn get_or_insert_child(&mut self, frame: FrameId) -> &mut TrieNode {
         self.children
-            .entry(name)
-            .or_insert_with_key(|name| TrieNode::new(name.clone()))
+            .entry(frame)
+            .or_insert_with_key(|frame| TrieNode::new(*frame))
     }
 
-    fn into_response(self) -> FlamegraphNode {
-        let mut children: Vec<_> = self
-            .children
-            .into_values()
-            .map(|c| c.into_response())
-            .collect();
-        // Sort children by count descending for consistent output
-        children.sort_by_key(|c| std::cmp::Reverse(c.count));
-
+    fn into_legacy(self, stacks_dict: &StackDictionary) -> FlamegraphNode {
+        let mut children: Vec<_> = self.children.into_values().collect();
+        sort_children(&mut children, stacks_dict);
         FlamegraphNode {
-            name: self.name,
+            name: stacks_dict.resolve(self.frame).to_string(),
             count: self.count,
             self_count: self.self_count,
-            children,
+            children: children
+                .into_iter()
+                .map(|child| child.into_legacy(stacks_dict))
+                .collect(),
         }
     }
+
+    fn collect_frames(&self, frames: &mut std::collections::HashSet<FrameId>) {
+        frames.insert(self.frame);
+        for child in self.children.values() {
+            child.collect_frames(frames);
+        }
+    }
+
+    fn into_interned(
+        self,
+        stacks_dict: &StackDictionary,
+        wire_ids: &HashMap<FrameId, u32>,
+    ) -> InternedFlamegraphNode {
+        let mut children: Vec<_> = self.children.into_values().collect();
+        sort_children(&mut children, stacks_dict);
+        InternedFlamegraphNode {
+            frame: wire_ids[&self.frame],
+            count: self.count,
+            self_count: self.self_count,
+            children: children
+                .into_iter()
+                .map(|child| child.into_interned(stacks_dict, wire_ids))
+                .collect(),
+        }
+    }
+
+    fn into_interned_tree(self, stacks_dict: &StackDictionary) -> InternedFlamegraphTree {
+        let mut used = std::collections::HashSet::new();
+        self.collect_frames(&mut used);
+        let mut frames: Vec<_> = used.into_iter().collect();
+        frames.sort_unstable_by(|a, b| stacks_dict.resolve(*a).cmp(stacks_dict.resolve(*b)));
+        let wire_ids: HashMap<_, _> = frames
+            .iter()
+            .enumerate()
+            .map(|(index, frame)| {
+                (
+                    *frame,
+                    u32::try_from(index).expect("a flamegraph cannot contain more than u32 frames"),
+                )
+            })
+            .collect();
+        let names = frames
+            .iter()
+            .map(|frame| stacks_dict.resolve(*frame).to_string())
+            .collect();
+        InternedFlamegraphTree {
+            format: "interned-v1",
+            frames: names,
+            root: self.into_interned(stacks_dict, &wire_ids),
+        }
+    }
+}
+
+fn sort_children(children: &mut [TrieNode], stacks_dict: &StackDictionary) {
+    children.sort_unstable_by(|a, b| {
+        b.count.cmp(&a.count).then_with(|| {
+            stacks_dict
+                .resolve(a.frame)
+                .cmp(stacks_dict.resolve(b.frame))
+        })
+    });
 }
 
 /// Handler for GET /api/flamegraph — a Server-Sent Events stream.
@@ -478,6 +561,13 @@ struct StreamCtx {
     end_ns: Option<i64>,
     min_poll_ns: Option<i64>,
     max_poll_ns: Option<i64>,
+    wire_format: WireFormat,
+}
+
+#[derive(Clone, Copy)]
+enum WireFormat {
+    Legacy,
+    InternedV1,
 }
 
 /// The flamegraph [`FoldSink`] adapter: owns the incremental [`FlamegraphAccum`]
@@ -622,6 +712,10 @@ fn flamegraph_stream(
         end_ns: params.end_ns,
         min_poll_ns: params.min_poll_ns,
         max_poll_ns: params.max_poll_ns,
+        wire_format: match params.format.as_deref() {
+            Some("interned-v1") => WireFormat::InternedV1,
+            _ => WireFormat::Legacy,
+        },
     };
     let accum = FlamegraphAccum::new(ctx.filter.clone());
     fold_stream::drive(agg, resolved, limits, FlamegraphSink { ctx, accum })
@@ -629,7 +723,13 @@ fn flamegraph_stream(
 
 /// Shape a [`FlamegraphResponse`] from an [`AggSnapshot`] + [`Coverage`].
 fn build_response(ctx: &StreamCtx, snap: &AggSnapshot, coverage: Coverage) -> FlamegraphResponse {
-    let tree = build_flamegraph_tree(&snap.stack_counts, snap.stacks_dict);
+    let trie = build_flamegraph_tree(&snap.stack_counts, snap.stacks_dict);
+    let tree = match ctx.wire_format {
+        WireFormat::Legacy => FlamegraphTree::Legacy(trie.into_legacy(snap.stacks_dict)),
+        WireFormat::InternedV1 => {
+            FlamegraphTree::Interned(trie.into_interned_tree(snap.stacks_dict))
+        }
+    };
 
     // Echo the active filter values back to the UI (facet name → selected value).
     let filters: HashMap<String, String> = ctx
@@ -673,23 +773,24 @@ mod tests {
 
     #[test]
     fn test_build_flamegraph_tree() {
-        let mut stacks_dict = HashMap::new();
+        let mut stacks = HashMap::new();
         // Stack A: main → foo → bar (leaf→root stored as bar, foo, main)
-        let stack_a = vec![0u8; 16];
-        stacks_dict.insert(
-            stack_a.clone(),
+        let stack_a = [0u8; 16];
+        stacks.insert(
+            stack_a,
             vec!["bar".to_string(), "foo".to_string(), "main".to_string()],
         );
         // Stack B: main → foo → baz
-        let mut stack_b = vec![0u8; 16];
+        let mut stack_b = [0u8; 16];
         stack_b[0] = 1;
-        stacks_dict.insert(
-            stack_b.clone(),
+        stacks.insert(
+            stack_b,
             vec!["baz".to_string(), "foo".to_string(), "main".to_string()],
         );
+        let stacks_dict = StackDictionary::from_stacks(stacks);
 
         let stack_counts = vec![(stack_a, 10), (stack_b, 5)];
-        let tree = build_flamegraph_tree(&stack_counts, &stacks_dict);
+        let tree = build_flamegraph_tree(&stack_counts, &stacks_dict).into_legacy(&stacks_dict);
 
         assert_eq!(tree.name, "(all)");
         assert_eq!(tree.count, 15);
@@ -701,5 +802,62 @@ mod tests {
         assert_eq!(foo_node.name, "foo");
         assert_eq!(foo_node.count, 15);
         assert_eq!(foo_node.children.len(), 2); // "bar" and "baz"
+    }
+
+    #[test]
+    fn interned_tree_serializes_each_frame_name_once() {
+        let repeated = "very_long_symbol_name_".repeat(64);
+        let mut stacks = HashMap::new();
+        for i in 0..8u8 {
+            let mut stack_id = [0u8; 16];
+            stack_id[0] = i;
+            stacks.insert(
+                stack_id,
+                vec![format!("leaf_{i}"), repeated.clone(), format!("root_{i}")],
+            );
+        }
+        let stacks_dict = StackDictionary::from_stacks(stacks);
+        let stack_counts: Vec<_> = (0..8u8)
+            .map(|i| {
+                let mut stack_id = [0u8; 16];
+                stack_id[0] = i;
+                (stack_id, 1)
+            })
+            .collect();
+
+        let tree =
+            build_flamegraph_tree(&stack_counts, &stacks_dict).into_interned_tree(&stacks_dict);
+        let json = serde_json::to_string(&tree).unwrap();
+
+        assert_eq!(
+            json.matches(&repeated).count(),
+            1,
+            "the frame table must own the repeated symbol once"
+        );
+        assert_eq!(tree.root.count, 8);
+        assert_eq!(
+            tree.frames.iter().filter(|name| *name == &repeated).count(),
+            1
+        );
+    }
+
+    #[test]
+    fn interned_tree_is_deterministic_across_input_order() {
+        let mut stacks = HashMap::new();
+        let a = [1u8; 16];
+        let b = [2u8; 16];
+        stacks.insert(a, vec!["z-leaf".to_string(), "shared".to_string()]);
+        stacks.insert(b, vec!["a-leaf".to_string(), "shared".to_string()]);
+        let stacks_dict = StackDictionary::from_stacks(stacks);
+
+        let first =
+            build_flamegraph_tree(&[(a, 5), (b, 5)], &stacks_dict).into_interned_tree(&stacks_dict);
+        let second =
+            build_flamegraph_tree(&[(b, 5), (a, 5)], &stacks_dict).into_interned_tree(&stacks_dict);
+
+        assert_eq!(
+            serde_json::to_string(&first).unwrap(),
+            serde_json::to_string(&second).unwrap()
+        );
     }
 }

--- a/dial9-viewer/ui/flamegraph_api.js
+++ b/dial9-viewer/ui/flamegraph_api.js
@@ -156,6 +156,44 @@ function shouldAdoptRefinementSnapshot(preserveExisting, baselineFilesFolded, in
   if (!preserveExisting) return true;
   return Number(incomingFilesFolded || 0) >= Number(baselineFilesFolded || 0);
 }
+
+// Resolve the negotiated aggregate flamegraph encoding into the legacy
+// nested-name tree consumed by the existing renderers. Older servers return
+// that tree directly; interned-v1 sends every frame name once and references
+// it by index from each node.
+function decodeFlamegraphTree(response) {
+  const tree = response && response.tree;
+  if (!tree || tree.format !== "interned-v1") return tree;
+  if (!Array.isArray(tree.frames)) {
+    throw new Error("interned-v1 flamegraph is missing its frame table");
+  }
+
+  function decodeNode(node) {
+    const frame = node && node.frame;
+    if (!Number.isInteger(frame) || frame < 0 || frame >= tree.frames.length) {
+      throw new Error(`interned-v1 flamegraph references invalid frame ${String(frame)}`);
+    }
+    const name = tree.frames[frame];
+    if (typeof name !== "string") {
+      throw new Error(`interned-v1 flamegraph frame ${frame} is not a string`);
+    }
+    const children = node.children;
+    if (children != null && !Array.isArray(children)) {
+      throw new Error("interned-v1 flamegraph node children must be an array");
+    }
+    const decoded = {
+      name,
+      count: node.count,
+      self: node.self,
+    };
+    if (children && children.length) {
+      decoded.children = children.map(decodeNode);
+    }
+    return decoded;
+  }
+
+  return decodeNode(tree.root);
+}
 // --- Data-driven toolbar facet options ---------------------------------------
 //
 // The `/api/flamegraph` response carries a `metadata` block describing which
@@ -214,6 +252,7 @@ const FlamegraphApi = {
   nextMaxFiles,
   refinementWorkDepth,
   shouldAdoptRefinementSnapshot,
+  decodeFlamegraphTree,
   nsToPickerUtc,
   pickerUtcToNs,
   msToNs,

--- a/dial9-viewer/ui/flamegraph_diff_view.js
+++ b/dial9-viewer/ui/flamegraph_diff_view.js
@@ -66,6 +66,7 @@
     }
     for (const h of scope.getAll("host")) u.searchParams.append("host", h);
     if (maxFiles != null) u.searchParams.set("max_files", String(maxFiles));
+    u.searchParams.set("format", "interned-v1");
     return u;
   }
 
@@ -625,8 +626,9 @@
           )) return;
 
           adoptedSnapshot = true;
-          if (side === "a") treeA = resp.tree; else treeB = resp.tree;
-          status.total = resp.total_samples || (resp.tree && resp.tree.count) || 0;
+          const tree = api.decodeFlamegraphTree(resp);
+          if (side === "a") treeA = tree; else treeB = tree;
+          status.total = resp.total_samples || (tree && tree.count) || 0;
           status.meta = resp.metadata || null;
           status.coverage = cov || null;
           if (cov != null) {

--- a/dial9-viewer/ui/src/lib/trace/aggregates.ts
+++ b/dial9-viewer/ui/src/lib/trace/aggregates.ts
@@ -114,6 +114,23 @@ export interface ApiFlamegraphNode {
   children?: ApiFlamegraphNode[];
 }
 
+/** One nested interned-v1 node; `frame` indexes the enclosing frame table. */
+export interface InternedApiFlamegraphNode {
+  frame: number;
+  count: number;
+  self: number;
+  children?: InternedApiFlamegraphNode[];
+}
+
+/** Negotiated compact response used by the canonical aggregate UI. */
+export interface InternedApiFlamegraphTree {
+  format: "interned-v1";
+  frames: string[];
+  root: InternedApiFlamegraphNode;
+}
+
+export type ApiFlamegraphTree = ApiFlamegraphNode | InternedApiFlamegraphTree;
+
 /** One facet's values. */
 export interface FacetResult {
   /** Query-param / filter key name (e.g. "source", "thread_class"). */
@@ -168,7 +185,7 @@ export interface FlamegraphMetadata {
 }
 
 export interface FlamegraphResponse {
-  tree: ApiFlamegraphNode;
+  tree: ApiFlamegraphTree;
   total_samples: number;
   /**
    * Absent only outside demand-driven mode (a single complete fetch);

--- a/dial9-viewer/ui/src/lib/trace/api_format.ts
+++ b/dial9-viewer/ui/src/lib/trace/api_format.ts
@@ -6,6 +6,7 @@
 
 export {
   coveragePercent,
+  decodeFlamegraphTree,
   foldErrorNotice,
   formatCoverageBadge,
   hostFacetOptions,
@@ -17,6 +18,10 @@ export {
   refinementWorkDepth,
   shouldAdoptRefinementSnapshot,
 } from "../../../flamegraph_api.js";
-export type { FacetOption, LegacyCoverage } from "../../../flamegraph_api.js";
+export type {
+  DecodedFlamegraphNode,
+  FacetOption,
+  LegacyCoverage,
+} from "../../../flamegraph_api.js";
 
 export { formatHumanDuration } from "../../../format.js";

--- a/dial9-viewer/ui/src/lib/trace/index.ts
+++ b/dial9-viewer/ui/src/lib/trace/index.ts
@@ -260,6 +260,7 @@ export type { Dial9SessionApi, SessionStorageLike } from "./session.js";
 // consumers share one implementation.
 export {
   coveragePercent,
+  decodeFlamegraphTree,
   foldErrorNotice,
   formatCoverageBadge,
   formatHumanDuration,
@@ -272,7 +273,11 @@ export {
   refinementWorkDepth,
   shouldAdoptRefinementSnapshot,
 } from "./api_format.js";
-export type { FacetOption, LegacyCoverage } from "./api_format.js";
+export type {
+  DecodedFlamegraphNode,
+  FacetOption,
+  LegacyCoverage,
+} from "./api_format.js";
 
 // sse.ts - the fetch-based Server-Sent Events client for the streamed
 // aggregation endpoints (the server owns the refine/stop loop).
@@ -350,6 +355,7 @@ export {
 export type {
   AggregateScope,
   ApiFlamegraphNode,
+  ApiFlamegraphTree,
   AttributeFacet,
   CompositionBucket,
   Coverage,
@@ -359,6 +365,8 @@ export type {
   FacetResult,
   FlamegraphMetadata,
   FlamegraphResponse,
+  InternedApiFlamegraphNode,
+  InternedApiFlamegraphTree,
   PollDurationBar,
   PollExemplar,
   SchedulingDelay,

--- a/dial9-viewer/ui/src/pages/flamegraph/api-mode.ts
+++ b/dial9-viewer/ui/src/pages/flamegraph/api-mode.ts
@@ -9,6 +9,7 @@ import {
   Dial9Creds,
   Dial9Session,
   applyToCreds,
+  decodeFlamegraphTree,
   formatCoverageBadge,
   formatHumanDuration,
   hostFacetOptions,
@@ -369,7 +370,8 @@ export function runApiMode(params: URLSearchParams, els: PageEls): void {
     // without it.
     loadingEl.classList.add("hidden");
     containerEl.style.display = "flex";
-    fg.setTreeDirect(toFgTree(resp.tree), resp.tree.count);
+    const tree = decodeFlamegraphTree(resp);
+    fg.setTreeDirect(toFgTree(tree), tree.count);
 
     const cov = resp.coverage;
     lastCoverage = cov ?? null;

--- a/dial9-viewer/ui/src/pages/flamegraph/query.test.ts
+++ b/dial9-viewer/ui/src/pages/flamegraph/query.test.ts
@@ -97,7 +97,7 @@ describe("seedFacetState", () => {
 describe("buildApiUrl", () => {
   it("SSE stream URL: scope + non-empty facets, no refine flag", () => {
     expect(buildApiUrl(state(), ORIGIN)).toBe(
-      `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&source=cpu`,
+      `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&source=cpu&format=interned-v1`,
     );
   });
   it("serializes repeated hosts, times and max_files in stable order", () => {
@@ -114,7 +114,7 @@ describe("buildApiUrl", () => {
     expect(u).toBe(
       `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&service=svc-a` +
         "&host=h1&host=h2&source=cpu&start_ns=1743000000000000000" +
-        "&end_ns=1743003600000000000&max_files=64",
+        "&end_ns=1743003600000000000&max_files=64&format=interned-v1",
     );
   });
   it("poll-duration band rides after the time window (min_poll_ns/max_poll_ns)", () => {
@@ -124,12 +124,14 @@ describe("buildApiUrl", () => {
     );
     expect(u).toBe(
       `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&source=cpu` +
-        "&start_ns=1&end_ns=2&min_poll_ns=500000&max_poll_ns=10000000",
+        "&start_ns=1&end_ns=2&min_poll_ns=500000&max_poll_ns=10000000" +
+        "&format=interned-v1",
     );
   });
   it("an open-ended band emits only the bound that is set", () => {
     expect(buildApiUrl(state({ minPollNs: "1000000" }), ORIGIN)).toBe(
-      `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&source=cpu&min_poll_ns=1000000`,
+      `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&source=cpu` +
+        "&min_poll_ns=1000000&format=interned-v1",
     );
     expect(buildBrowserQuery(state({ maxPollNs: "2000000" }))).toBe(
       "api=1&bucket=demo-traces&credential_mode=ambient&prefix=traces&source=cpu&max_poll_ns=2000000",
@@ -150,7 +152,8 @@ describe("buildApiUrl", () => {
       ORIGIN,
     );
     expect(u).toBe(
-      `${ORIGIN}/api/flamegraph?data_dir=%2Fvar%2Ftraces&source=cpu&host_group=blue`,
+      `${ORIGIN}/api/flamegraph?data_dir=%2Fvar%2Ftraces&source=cpu` +
+        "&host_group=blue&format=interned-v1",
     );
   });
 });

--- a/dial9-viewer/ui/src/pages/flamegraph/query.ts
+++ b/dial9-viewer/ui/src/pages/flamegraph/query.ts
@@ -126,6 +126,7 @@ export function buildApiUrl(state: ApiQueryState, origin: string): string {
   writeRequestParams(u.searchParams, state.source);
   appendScope(u.searchParams, state);
   if (state.maxFiles != null) u.searchParams.set("max_files", String(state.maxFiles));
+  u.searchParams.set("format", "interned-v1");
   return u.toString();
 }
 

--- a/dial9-viewer/ui/src/types/flamegraph_api.d.ts
+++ b/dial9-viewer/ui/src/types/flamegraph_api.d.ts
@@ -31,6 +31,13 @@ declare module "*/flamegraph_api.js" {
     label: string;
   }
 
+  export interface DecodedFlamegraphNode {
+    name: string;
+    count: number;
+    self: number;
+    children?: DecodedFlamegraphNode[];
+  }
+
   /**
    * "12 / 480 files (2.5%) [middot 8 / 40 hosts] middot 41,203 samples
    * [middot 4.1 MB]" - the stats-bar coverage badge. Host fraction omitted
@@ -100,6 +107,14 @@ declare module "*/flamegraph_api.js" {
     baselineFilesFolded: number,
     incomingFilesFolded: number
   ): boolean;
+
+  /**
+   * Decode the negotiated aggregate tree encoding. Legacy nested-name trees
+   * pass through; interned-v1 frame IDs are resolved through its frame table.
+   */
+  export function decodeFlamegraphTree(response: {
+    tree: unknown;
+  }): DecodedFlamegraphNode;
 
   /**
    * Epoch-ns -> `datetime-local` value ("YYYY-MM-DDTHH:MM:SS"), shown as

--- a/dial9-viewer/ui/tests/core/flamegraph_api.test.ts
+++ b/dial9-viewer/ui/tests/core/flamegraph_api.test.ts
@@ -46,6 +46,7 @@ const {
   nextMaxFiles,
   refinementWorkDepth,
   shouldAdoptRefinementSnapshot,
+  decodeFlamegraphTree,
   nsToPickerUtc,
   pickerUtcToNs,
   msToNs,
@@ -79,12 +80,80 @@ const {
     baselineFilesFolded: number,
     incomingFilesFolded: number,
   ) => boolean;
+  decodeFlamegraphTree: (response: { tree: unknown }) => unknown;
   nsToPickerUtc: (ns: string | null) => string;
   pickerUtcToNs: (picker: string) => string | null;
   sourceFacetOptions: (present?: string[]) => FacetOption[];
   threadFacetOptions: (present: string[]) => FacetOption[];
   hostFacetOptions: (hosts: string[]) => FacetOption[];
 };
+
+describe("decodeFlamegraphTree", () => {
+  it("resolves repeated interned frame IDs into the legacy nested tree", () => {
+    expect(
+      decodeFlamegraphTree({
+        tree: {
+          format: "interned-v1",
+          frames: ["(all)", "shared", "left", "right"],
+          root: {
+            frame: 0,
+            count: 7,
+            self: 0,
+            children: [
+              {
+                frame: 1,
+                count: 4,
+                self: 0,
+                children: [{ frame: 2, count: 4, self: 4 }],
+              },
+              {
+                frame: 1,
+                count: 3,
+                self: 0,
+                children: [{ frame: 3, count: 3, self: 3 }],
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual({
+      name: "(all)",
+      count: 7,
+      self: 0,
+      children: [
+        {
+          name: "shared",
+          count: 4,
+          self: 0,
+          children: [{ name: "left", count: 4, self: 4 }],
+        },
+        {
+          name: "shared",
+          count: 3,
+          self: 0,
+          children: [{ name: "right", count: 3, self: 3 }],
+        },
+      ],
+    });
+  });
+
+  it("passes a legacy tree through unchanged", () => {
+    const tree = { name: "(all)", count: 1, self: 1 };
+    expect(decodeFlamegraphTree({ tree })).toBe(tree);
+  });
+
+  it("rejects an invalid frame reference", () => {
+    expect(() =>
+      decodeFlamegraphTree({
+        tree: {
+          format: "interned-v1",
+          frames: ["(all)"],
+          root: { frame: 2, count: 1, self: 1 },
+        },
+      }),
+    ).toThrow(/invalid frame 2/);
+  });
+});
 
 describe("formatCoverageBadge", () => {
   it("spec example", () => {

--- a/dial9-viewer/ui/tests/core/flamegraph_diff_view_state.test.js
+++ b/dial9-viewer/ui/tests/core/flamegraph_diff_view_state.test.js
@@ -151,6 +151,7 @@ test("apiUrlFor forwards server scope and strips client-only flags", () => {
   assert.strictEqual(url.searchParams.get("aws_region"), "us-west-2");
   assert.deepStrictEqual(url.searchParams.getAll("host"), ["h1", "h2"]);
   assert.strictEqual(url.searchParams.get("max_files"), "8");
+  assert.strictEqual(url.searchParams.get("format"), "interned-v1");
   assert.strictEqual(url.searchParams.get("api"), null);
 });
 


### PR DESCRIPTION
## Summary

- Add the negotiated `interned-v1` aggregate flamegraph response format.
- Serialize frame names once and reference them by integer ID from tree nodes.
- Decode the compact response at the UI API boundary while preserving the existing internal tree shape.
- Keep absent or unknown formats on the legacy response path for compatibility.

## Why

A production request with 471,751 CPU samples and 218,590 distinct stacks produced a 619 MB SSE JSON event. Repeated long Rust symbols accounted for most of the payload because every trie node serialized its full frame name. Interning removes that repeated text from the wire format.

## Stack

1. **#846 Frame interning (this PR)**
2. #847 Flat parent-indexed tree rows
3. #848 Deterministic node budget
4. #849 Coverage-only progress events
5. #850 Transactional in-place part merges

## Validation

I manually verified this worked as expected on the previously unusable trace