### PR TITLE
perf(viewer): bound flamegraph projections

### DIFF
--- a/dial9-viewer/src/server/flamegraph.rs
+++ b/dial9-viewer/src/server/flamegraph.rs
@@ -3,13 +3,14 @@
 //!
 //! One request holds the connection open: it [resolves](refine::resolve) the
 //! scope, streams already-folded parts in bounded cumulative snapshots, then
-//! folds missing capped-prefix files and pushes a fresh full-tree snapshot as
-//! each file lands, closing when the bounded work-list drains. Each SSE `data:`
+//! folds missing capped-prefix files and pushes a fresh bounded-tree snapshot
+//! as each file lands, closing when the bounded work-list drains. Each SSE `data:`
 //! frame is one
 //! [`FlamegraphResponse`] JSON object — the same shape the UI rendered per poll
 //! before — so the client just re-renders on every event.
 
-use std::collections::HashMap;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
 use std::convert::Infallible;
 
 use axum::Extension;
@@ -30,6 +31,8 @@ use crate::server::AppState;
 use crate::server::credentials::MaybeCreds;
 use crate::server::fold_stream;
 use crate::server::metrics::OperationMetrics;
+
+const DEFAULT_FLAMEGRAPH_NODE_BUDGET: usize = 50_000;
 
 #[derive(Deserialize)]
 pub struct FlamegraphParams {
@@ -89,6 +92,9 @@ pub struct FlamegraphParams {
     /// Response tree encoding. The canonical UI requests `flat-v1`; absent or
     /// unknown values retain the legacy nested-name response.
     pub format: Option<String>,
+    /// Frame identity currently focused by the aggregate inspect view. The
+    /// bounded projection retains one deterministic path to this frame.
+    pub inspect: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -146,6 +152,13 @@ pub struct FlatFlamegraphTree {
     /// row zero and names itself as its parent; every other parent precedes its
     /// children.
     pub nodes: Vec<FlatFlamegraphNode>,
+    /// Exact trie node count before projection.
+    pub total_nodes: usize,
+    /// Exact trie nodes represented only through synthetic `[other]` rows.
+    pub omitted_nodes: usize,
+    /// True when a requested inspect frame was found and its path retained.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inspect_retained: Option<bool>,
 }
 
 #[derive(Serialize)]
@@ -340,6 +353,7 @@ impl FlamegraphTrie {
         }
     }
 
+    #[cfg(test)]
     fn append_flat(
         &self,
         node_id: usize,
@@ -366,6 +380,7 @@ impl FlamegraphTrie {
         }
     }
 
+    #[cfg(test)]
     fn into_flat_tree(mut self, stacks_dict: &StackDictionary) -> FlatFlamegraphTree {
         self.edges = HashMap::new();
         let frames = WireFrames::new(&self.nodes, stacks_dict);
@@ -376,6 +391,219 @@ impl FlamegraphTrie {
             format: "flat-v1",
             frames: frames.names,
             nodes,
+            total_nodes: self.nodes.len(),
+            omitted_nodes: 0,
+            inspect_retained: None,
+        }
+    }
+
+    fn projection(
+        &self,
+        stacks_dict: &StackDictionary,
+        children: &OrderedChildren,
+        node_budget: usize,
+        inspect: Option<&str>,
+    ) -> Projection {
+        let mut preorder = Vec::with_capacity(self.nodes.len());
+        children.append_preorder(0, &mut preorder);
+        let mut rank = vec![0usize; self.nodes.len()];
+        for (index, node) in preorder.into_iter().enumerate() {
+            rank[node] = index;
+        }
+
+        let inspected = inspect.and_then(|name| {
+            (0..self.nodes.len())
+                .filter(|node| stacks_dict.resolve(self.nodes[*node].frame) == name)
+                .max_by_key(|node| (self.nodes[*node].count, Reverse(rank[*node])))
+        });
+
+        let mut selected = vec![false; self.nodes.len()];
+        selected[0] = true;
+        if let Some(mut node) = inspected {
+            loop {
+                selected[node] = true;
+                if node == 0 {
+                    break;
+                }
+                node = self.nodes[node].parent;
+            }
+        }
+
+        let mut omitted_children = vec![0usize; self.nodes.len()];
+        let mut selected_nodes = 0usize;
+        let mut collapsed_nodes = 0usize;
+        for parent in 0..self.nodes.len() {
+            if !selected[parent] {
+                continue;
+            }
+            selected_nodes += 1;
+            let omitted = children
+                .of(parent)
+                .iter()
+                .filter(|child| !selected[**child])
+                .count();
+            omitted_children[parent] = omitted;
+            collapsed_nodes += usize::from(omitted > 0);
+        }
+
+        // A path is normally only a few dozen frames. If a caller supplies an
+        // impossibly small test/config budget, prefer honoring the hard cap to
+        // claiming that the inspect path was retained.
+        let mut inspect_retained = inspected.is_some();
+        if selected_nodes + collapsed_nodes > node_budget {
+            selected.fill(false);
+            selected[0] = true;
+            omitted_children.fill(0);
+            omitted_children[0] = children.of(0).len();
+            selected_nodes = 1;
+            collapsed_nodes = usize::from(omitted_children[0] > 0);
+            inspect_retained = false;
+        }
+
+        let mut output_nodes = selected_nodes + collapsed_nodes;
+        let mut frontier = BinaryHeap::new();
+        let mut queued = vec![false; self.nodes.len()];
+        for parent in 0..self.nodes.len() {
+            if !selected[parent] {
+                continue;
+            }
+            for child in children.of(parent) {
+                if !selected[*child] && !queued[*child] {
+                    frontier.push((self.nodes[*child].count, Reverse(rank[*child]), *child));
+                    queued[*child] = true;
+                }
+            }
+        }
+
+        while let Some((_, _, node)) = frontier.pop() {
+            let parent = self.nodes[node].parent;
+            debug_assert!(selected[parent]);
+            let parent_still_collapsed = omitted_children[parent] > 1;
+            let child_collapsed = !children.of(node).is_empty();
+            // Selecting this node adds one real row, may remove its parent's
+            // `[other]`, and may add a new `[other]` beneath the selected node.
+            let delta = usize::from(parent_still_collapsed) + usize::from(child_collapsed);
+            if output_nodes + delta > node_budget {
+                continue;
+            }
+
+            selected[node] = true;
+            selected_nodes += 1;
+            output_nodes += delta;
+            omitted_children[parent] -= 1;
+            omitted_children[node] = children.of(node).len();
+            for child in children.of(node) {
+                frontier.push((self.nodes[*child].count, Reverse(rank[*child]), *child));
+            }
+        }
+
+        Projection {
+            selected,
+            output_nodes,
+            omitted_nodes: self.nodes.len() - selected_nodes,
+            inspect_retained: inspect.map(|_| inspect_retained),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn append_projected_flat(
+        &self,
+        node_id: usize,
+        parent_wire_id: u32,
+        stacks_dict: &StackDictionary,
+        frames: &WireFrames,
+        children: &OrderedChildren,
+        projection: &Projection,
+        rows: &mut Vec<FlatFlamegraphNode>,
+    ) {
+        let wire_id =
+            u32::try_from(rows.len()).expect("a flamegraph cannot contain more than u32 nodes");
+        let node = &self.nodes[node_id];
+        rows.push(FlatFlamegraphNode(
+            if node_id == 0 {
+                wire_id
+            } else {
+                parent_wire_id
+            },
+            frames.ids[&node.frame],
+            node.count,
+            node.self_count,
+        ));
+
+        let omitted_count: u64 = children
+            .of(node_id)
+            .iter()
+            .filter(|child| !projection.selected[**child])
+            .map(|child| self.nodes[*child].count)
+            .sum();
+        let mut emitted_other = omitted_count == 0;
+        for child in children
+            .of(node_id)
+            .iter()
+            .filter(|child| projection.selected[**child])
+        {
+            let child_node = &self.nodes[*child];
+            if !emitted_other
+                && (omitted_count > child_node.count
+                    || (omitted_count == child_node.count
+                        && "[other]" < stacks_dict.resolve(child_node.frame)))
+            {
+                rows.push(FlatFlamegraphNode(
+                    wire_id,
+                    frames.other.expect("projected trees intern [other]"),
+                    omitted_count,
+                    omitted_count,
+                ));
+                emitted_other = true;
+            }
+            self.append_projected_flat(
+                *child,
+                wire_id,
+                stacks_dict,
+                frames,
+                children,
+                projection,
+                rows,
+            );
+        }
+        if !emitted_other {
+            rows.push(FlatFlamegraphNode(
+                wire_id,
+                frames.other.expect("projected trees intern [other]"),
+                omitted_count,
+                omitted_count,
+            ));
+        }
+    }
+
+    fn into_projected_flat_tree(
+        mut self,
+        stacks_dict: &StackDictionary,
+        node_budget: usize,
+        inspect: Option<&str>,
+    ) -> FlatFlamegraphTree {
+        self.edges = HashMap::new();
+        let children = self.ordered_children(stacks_dict);
+        let projection = self.projection(stacks_dict, &children, node_budget, inspect);
+        let frames = WireFrames::new_selected(&self.nodes, stacks_dict, &projection.selected, true);
+        let mut nodes = Vec::with_capacity(projection.output_nodes);
+        self.append_projected_flat(
+            0,
+            0,
+            stacks_dict,
+            &frames,
+            &children,
+            &projection,
+            &mut nodes,
+        );
+        debug_assert_eq!(nodes.len(), projection.output_nodes);
+        FlatFlamegraphTree {
+            format: "flat-v1",
+            frames: frames.names,
+            nodes,
+            total_nodes: self.nodes.len(),
+            omitted_nodes: projection.omitted_nodes,
+            inspect_retained: projection.inspect_retained,
         }
     }
 }
@@ -389,16 +617,44 @@ impl OrderedChildren {
     fn of(&self, parent: usize) -> &[usize] {
         &self.nodes[self.starts[parent]..self.starts[parent + 1]]
     }
+
+    fn append_preorder(&self, parent: usize, output: &mut Vec<usize>) {
+        output.push(parent);
+        for child in self.of(parent) {
+            self.append_preorder(*child, output);
+        }
+    }
+}
+
+struct Projection {
+    selected: Vec<bool>,
+    output_nodes: usize,
+    omitted_nodes: usize,
+    inspect_retained: Option<bool>,
 }
 
 struct WireFrames {
     names: Vec<String>,
     ids: HashMap<FrameId, u32>,
+    other: Option<u32>,
 }
 
 impl WireFrames {
     fn new(nodes: &[TrieNode], stacks_dict: &StackDictionary) -> Self {
-        let mut frames: Vec<_> = nodes.iter().map(|node| node.frame).collect();
+        Self::new_selected(nodes, stacks_dict, &vec![true; nodes.len()], false)
+    }
+
+    fn new_selected(
+        nodes: &[TrieNode],
+        stacks_dict: &StackDictionary,
+        selected: &[bool],
+        include_other: bool,
+    ) -> Self {
+        let mut frames: Vec<_> = nodes
+            .iter()
+            .zip(selected)
+            .filter_map(|(node, selected)| selected.then_some(node.frame))
+            .collect();
         frames.sort_unstable_by(|a, b| stacks_dict.resolve(*a).cmp(stacks_dict.resolve(*b)));
         frames.dedup();
         let ids = frames
@@ -411,11 +667,21 @@ impl WireFrames {
                 )
             })
             .collect();
-        let names = frames
+        let mut names: Vec<String> = frames
             .iter()
             .map(|frame| stacks_dict.resolve(*frame).to_string())
             .collect();
-        Self { names, ids }
+        let other = include_other.then(|| {
+            if let Some(index) = names.iter().position(|name| name == "[other]") {
+                u32::try_from(index).expect("a flamegraph cannot contain more than u32 frames")
+            } else {
+                let index = u32::try_from(names.len())
+                    .expect("a flamegraph cannot contain more than u32 frames");
+                names.push("[other]".to_string());
+                index
+            }
+        });
+        Self { names, ids, other }
     }
 }
 
@@ -424,7 +690,7 @@ impl WireFrames {
 /// [Resolves](refine::resolve) the scope, primes an incremental
 /// [`FlamegraphAccum`] over the already-folded set, and emits an initial
 /// snapshot. Then it folds the not-yet-folded capped files in [order key] order
-/// (up to the [sampling cap](refine)), pushing a fresh full-tree SSE event as
+/// (up to the [sampling cap](refine)), pushing a fresh bounded-tree SSE event as
 /// each file lands, and closes when the work-list drains. The client re-renders
 /// on every event; there is no re-polling.
 ///
@@ -678,6 +944,7 @@ struct StreamCtx {
     min_poll_ns: Option<i64>,
     max_poll_ns: Option<i64>,
     wire_format: WireFormat,
+    inspect: Option<String>,
 }
 
 #[derive(Clone, Copy)]
@@ -834,6 +1101,7 @@ fn flamegraph_stream(
             Some("flat-v1") => WireFormat::FlatV1,
             _ => WireFormat::Legacy,
         },
+        inspect: params.inspect.clone(),
     };
     let accum = FlamegraphAccum::new(ctx.filter.clone());
     fold_stream::drive(agg, resolved, limits, FlamegraphSink { ctx, accum })
@@ -847,7 +1115,11 @@ fn build_response(ctx: &StreamCtx, snap: &AggSnapshot, coverage: Coverage) -> Fl
         WireFormat::InternedV1 => {
             FlamegraphTree::Interned(trie.into_interned_tree(snap.stacks_dict))
         }
-        WireFormat::FlatV1 => FlamegraphTree::Flat(trie.into_flat_tree(snap.stacks_dict)),
+        WireFormat::FlatV1 => FlamegraphTree::Flat(trie.into_projected_flat_tree(
+            snap.stacks_dict,
+            DEFAULT_FLAMEGRAPH_NODE_BUDGET,
+            ctx.inspect.as_deref(),
+        )),
     };
 
     // Echo the active filter values back to the UI (facet name → selected value).
@@ -1027,6 +1299,89 @@ mod tests {
             build_flamegraph_tree(&[(a, 5), (b, 5)], &stacks_dict).into_flat_tree(&stacks_dict);
         let second =
             build_flamegraph_tree(&[(b, 5), (a, 5)], &stacks_dict).into_flat_tree(&stacks_dict);
+
+        assert_eq!(
+            serde_json::to_string(&first).unwrap(),
+            serde_json::to_string(&second).unwrap()
+        );
+    }
+
+    #[test]
+    fn projected_tree_respects_budget_and_conserves_collapsed_counts() {
+        let mut stacks = HashMap::new();
+        let mut stack_counts = Vec::new();
+        for i in 0..20u8 {
+            let mut stack_id = [0u8; 16];
+            stack_id[0] = i;
+            stacks.insert(stack_id, vec![format!("leaf-{i}"), format!("branch-{i}")]);
+            stack_counts.push((stack_id, u64::from(i) + 1));
+        }
+        let stacks_dict = StackDictionary::from_stacks(stacks);
+        let tree = build_flamegraph_tree(&stack_counts, &stacks_dict).into_projected_flat_tree(
+            &stacks_dict,
+            10,
+            None,
+        );
+
+        assert!(tree.nodes.len() <= 10);
+        assert_eq!(tree.total_nodes, 41);
+        assert!(tree.omitted_nodes > 0);
+        assert!(tree.frames.iter().any(|name| name == "[other]"));
+
+        let mut child_totals = vec![0u64; tree.nodes.len()];
+        for (index, node) in tree.nodes.iter().enumerate().skip(1) {
+            child_totals[usize::try_from(node.0).unwrap()] += node.2;
+            assert!(usize::try_from(node.0).unwrap() < index);
+        }
+        for (index, node) in tree.nodes.iter().enumerate() {
+            assert_eq!(
+                node.2,
+                node.3 + child_totals[index],
+                "projected node {index} must conserve its inclusive count"
+            );
+        }
+    }
+
+    #[test]
+    fn projected_tree_retains_inspected_path() {
+        let hot = [1u8; 16];
+        let cold = [2u8; 16];
+        let mut stacks = HashMap::new();
+        stacks.insert(hot, vec!["hot-leaf".to_string(), "hot-root".to_string()]);
+        stacks.insert(
+            cold,
+            vec!["focus-frame".to_string(), "cold-root".to_string()],
+        );
+        let stacks_dict = StackDictionary::from_stacks(stacks);
+        let tree = build_flamegraph_tree(&[(hot, 1_000), (cold, 1)], &stacks_dict)
+            .into_projected_flat_tree(&stacks_dict, 4, Some("focus-frame"));
+
+        let emitted_names: Vec<_> = tree
+            .nodes
+            .iter()
+            .map(|node| tree.frames[usize::try_from(node.1).unwrap()].as_str())
+            .collect();
+        assert_eq!(tree.inspect_retained, Some(true));
+        assert!(emitted_names.contains(&"cold-root"));
+        assert!(emitted_names.contains(&"focus-frame"));
+        assert!(tree.nodes.len() <= 4);
+    }
+
+    #[test]
+    fn projected_tree_is_deterministic_across_input_order() {
+        let mut stacks = HashMap::new();
+        let a = [1u8; 16];
+        let b = [2u8; 16];
+        let c = [3u8; 16];
+        stacks.insert(a, vec!["z-leaf".to_string(), "shared".to_string()]);
+        stacks.insert(b, vec!["a-leaf".to_string(), "shared".to_string()]);
+        stacks.insert(c, vec!["focus".to_string(), "cold".to_string()]);
+        let stacks_dict = StackDictionary::from_stacks(stacks);
+
+        let first = build_flamegraph_tree(&[(a, 5), (b, 5), (c, 1)], &stacks_dict)
+            .into_projected_flat_tree(&stacks_dict, 6, Some("focus"));
+        let second = build_flamegraph_tree(&[(c, 1), (b, 5), (a, 5)], &stacks_dict)
+            .into_projected_flat_tree(&stacks_dict, 6, Some("focus"));
 
         assert_eq!(
             serde_json::to_string(&first).unwrap(),

--- a/dial9-viewer/src/server/flamegraph.rs
+++ b/dial9-viewer/src/server/flamegraph.rs
@@ -86,8 +86,8 @@ pub struct FlamegraphParams {
     pub min_span_ns: Option<i64>,
     /// Maximum span elapsed_ns for the span filter (inclusive).
     pub max_span_ns: Option<i64>,
-    /// Response tree encoding. The canonical UI requests `interned-v1`; absent
-    /// or unknown values retain the legacy nested-name response.
+    /// Response tree encoding. The canonical UI requests `flat-v1`; absent or
+    /// unknown values retain the legacy nested-name response.
     pub format: Option<String>,
 }
 
@@ -106,6 +106,7 @@ pub struct FlamegraphResponse {
 pub enum FlamegraphTree {
     Legacy(FlamegraphNode),
     Interned(InternedFlamegraphTree),
+    Flat(FlatFlamegraphTree),
 }
 
 #[derive(Serialize, Clone)]
@@ -135,6 +136,20 @@ pub struct InternedFlamegraphNode {
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub children: Vec<InternedFlamegraphNode>,
 }
+
+#[derive(Serialize)]
+pub struct FlatFlamegraphTree {
+    pub format: &'static str,
+    /// Frame names indexed by each node row's frame field.
+    pub frames: Vec<String>,
+    /// Preorder rows: `[parent_node, frame, count, self_count]`. The root is
+    /// row zero and names itself as its parent; every other parent precedes its
+    /// children.
+    pub nodes: Vec<FlatFlamegraphNode>,
+}
+
+#[derive(Serialize)]
+pub struct FlatFlamegraphNode(u32, u32, u64, u64);
 
 #[derive(Serialize)]
 pub struct FlamegraphMetadata {
@@ -182,8 +197,8 @@ pub struct ScopeEcho {
 fn build_flamegraph_tree(
     stack_counts: &[([u8; 16], u64)],
     stacks_dict: &StackDictionary,
-) -> TrieNode {
-    let mut root = TrieNode::new(stacks_dict.root());
+) -> FlamegraphTrie {
+    let mut trie = FlamegraphTrie::new(stacks_dict.root());
 
     for (stack_id, count) in stack_counts {
         let frames = match stacks_dict.get(stack_id) {
@@ -191,87 +206,202 @@ fn build_flamegraph_tree(
             None => continue,
         };
         // Frames are stored leaf→root; flamegraph trie inserts root→leaf
-        root.count += count;
-        let mut node = &mut root;
+        trie.nodes[0].count += count;
+        let mut node = 0;
         for frame in frames.iter().rev() {
-            node = node.get_or_insert_child(*frame);
-            node.count += count;
+            node = trie.get_or_insert_child(node, *frame);
+            trie.nodes[node].count += count;
         }
         // Leaf gets self-time
-        node.self_count += count;
+        trie.nodes[node].self_count += count;
     }
 
-    root
+    trie
 }
 
 struct TrieNode {
     frame: FrameId,
+    parent: usize,
     count: u64,
     self_count: u64,
-    children: HashMap<FrameId, TrieNode>,
 }
 
-impl TrieNode {
-    fn new(frame: FrameId) -> Self {
+struct FlamegraphTrie {
+    nodes: Vec<TrieNode>,
+    edges: HashMap<(usize, FrameId), usize>,
+}
+
+impl FlamegraphTrie {
+    fn new(root_frame: FrameId) -> Self {
         Self {
+            nodes: vec![TrieNode {
+                frame: root_frame,
+                parent: 0,
+                count: 0,
+                self_count: 0,
+            }],
+            edges: HashMap::new(),
+        }
+    }
+
+    fn get_or_insert_child(&mut self, parent: usize, frame: FrameId) -> usize {
+        let key = (parent, frame);
+        if let Some(child) = self.edges.get(&key) {
+            return *child;
+        }
+        let child = self.nodes.len();
+        self.nodes.push(TrieNode {
             frame,
+            parent,
             count: 0,
             self_count: 0,
-            children: HashMap::new(),
+        });
+        self.edges.insert(key, child);
+        child
+    }
+
+    fn ordered_children(&self, stacks_dict: &StackDictionary) -> OrderedChildren {
+        let mut nodes: Vec<_> = (1..self.nodes.len()).collect();
+        nodes.sort_unstable_by(|a, b| {
+            let a = &self.nodes[*a];
+            let b = &self.nodes[*b];
+            a.parent.cmp(&b.parent).then_with(|| {
+                b.count.cmp(&a.count).then_with(|| {
+                    stacks_dict
+                        .resolve(a.frame)
+                        .cmp(stacks_dict.resolve(b.frame))
+                })
+            })
+        });
+
+        let mut starts = vec![0usize; self.nodes.len() + 1];
+        for node in self.nodes.iter().skip(1) {
+            starts[node.parent + 1] += 1;
         }
-    }
-
-    fn get_or_insert_child(&mut self, frame: FrameId) -> &mut TrieNode {
-        self.children
-            .entry(frame)
-            .or_insert_with_key(|frame| TrieNode::new(*frame))
-    }
-
-    fn into_legacy(self, stacks_dict: &StackDictionary) -> FlamegraphNode {
-        let mut children: Vec<_> = self.children.into_values().collect();
-        sort_children(&mut children, stacks_dict);
-        FlamegraphNode {
-            name: stacks_dict.resolve(self.frame).to_string(),
-            count: self.count,
-            self_count: self.self_count,
-            children: children
-                .into_iter()
-                .map(|child| child.into_legacy(stacks_dict))
-                .collect(),
+        for i in 1..starts.len() {
+            starts[i] += starts[i - 1];
         }
+        OrderedChildren { nodes, starts }
     }
 
-    fn collect_frames(&self, frames: &mut std::collections::HashSet<FrameId>) {
-        frames.insert(self.frame);
-        for child in self.children.values() {
-            child.collect_frames(frames);
-        }
-    }
-
-    fn into_interned(
-        self,
+    fn legacy_node(
+        &self,
+        node_id: usize,
         stacks_dict: &StackDictionary,
-        wire_ids: &HashMap<FrameId, u32>,
-    ) -> InternedFlamegraphNode {
-        let mut children: Vec<_> = self.children.into_values().collect();
-        sort_children(&mut children, stacks_dict);
-        InternedFlamegraphNode {
-            frame: wire_ids[&self.frame],
-            count: self.count,
-            self_count: self.self_count,
+        children: &OrderedChildren,
+    ) -> FlamegraphNode {
+        let node = &self.nodes[node_id];
+        FlamegraphNode {
+            name: stacks_dict.resolve(node.frame).to_string(),
+            count: node.count,
+            self_count: node.self_count,
             children: children
-                .into_iter()
-                .map(|child| child.into_interned(stacks_dict, wire_ids))
+                .of(node_id)
+                .iter()
+                .map(|child| self.legacy_node(*child, stacks_dict, children))
                 .collect(),
         }
     }
 
-    fn into_interned_tree(self, stacks_dict: &StackDictionary) -> InternedFlamegraphTree {
-        let mut used = std::collections::HashSet::new();
-        self.collect_frames(&mut used);
-        let mut frames: Vec<_> = used.into_iter().collect();
+    fn into_legacy(mut self, stacks_dict: &StackDictionary) -> FlamegraphNode {
+        self.edges = HashMap::new();
+        let children = self.ordered_children(stacks_dict);
+        self.legacy_node(0, stacks_dict, &children)
+    }
+
+    fn interned_node(
+        &self,
+        node_id: usize,
+        frames: &WireFrames,
+        children: &OrderedChildren,
+    ) -> InternedFlamegraphNode {
+        let node = &self.nodes[node_id];
+        InternedFlamegraphNode {
+            frame: frames.ids[&node.frame],
+            count: node.count,
+            self_count: node.self_count,
+            children: children
+                .of(node_id)
+                .iter()
+                .map(|child| self.interned_node(*child, frames, children))
+                .collect(),
+        }
+    }
+
+    fn into_interned_tree(mut self, stacks_dict: &StackDictionary) -> InternedFlamegraphTree {
+        self.edges = HashMap::new();
+        let frames = WireFrames::new(&self.nodes, stacks_dict);
+        let children = self.ordered_children(stacks_dict);
+        let root = self.interned_node(0, &frames, &children);
+        InternedFlamegraphTree {
+            format: "interned-v1",
+            frames: frames.names,
+            root,
+        }
+    }
+
+    fn append_flat(
+        &self,
+        node_id: usize,
+        parent_wire_id: u32,
+        frames: &WireFrames,
+        children: &OrderedChildren,
+        rows: &mut Vec<FlatFlamegraphNode>,
+    ) {
+        let wire_id =
+            u32::try_from(rows.len()).expect("a flamegraph cannot contain more than u32 nodes");
+        let node = &self.nodes[node_id];
+        rows.push(FlatFlamegraphNode(
+            if node_id == 0 {
+                wire_id
+            } else {
+                parent_wire_id
+            },
+            frames.ids[&node.frame],
+            node.count,
+            node.self_count,
+        ));
+        for child in children.of(node_id) {
+            self.append_flat(*child, wire_id, frames, children, rows);
+        }
+    }
+
+    fn into_flat_tree(mut self, stacks_dict: &StackDictionary) -> FlatFlamegraphTree {
+        self.edges = HashMap::new();
+        let frames = WireFrames::new(&self.nodes, stacks_dict);
+        let children = self.ordered_children(stacks_dict);
+        let mut nodes = Vec::with_capacity(self.nodes.len());
+        self.append_flat(0, 0, &frames, &children, &mut nodes);
+        FlatFlamegraphTree {
+            format: "flat-v1",
+            frames: frames.names,
+            nodes,
+        }
+    }
+}
+
+struct OrderedChildren {
+    nodes: Vec<usize>,
+    starts: Vec<usize>,
+}
+
+impl OrderedChildren {
+    fn of(&self, parent: usize) -> &[usize] {
+        &self.nodes[self.starts[parent]..self.starts[parent + 1]]
+    }
+}
+
+struct WireFrames {
+    names: Vec<String>,
+    ids: HashMap<FrameId, u32>,
+}
+
+impl WireFrames {
+    fn new(nodes: &[TrieNode], stacks_dict: &StackDictionary) -> Self {
+        let mut frames: Vec<_> = nodes.iter().map(|node| node.frame).collect();
         frames.sort_unstable_by(|a, b| stacks_dict.resolve(*a).cmp(stacks_dict.resolve(*b)));
-        let wire_ids: HashMap<_, _> = frames
+        frames.dedup();
+        let ids = frames
             .iter()
             .enumerate()
             .map(|(index, frame)| {
@@ -285,22 +415,8 @@ impl TrieNode {
             .iter()
             .map(|frame| stacks_dict.resolve(*frame).to_string())
             .collect();
-        InternedFlamegraphTree {
-            format: "interned-v1",
-            frames: names,
-            root: self.into_interned(stacks_dict, &wire_ids),
-        }
+        Self { names, ids }
     }
-}
-
-fn sort_children(children: &mut [TrieNode], stacks_dict: &StackDictionary) {
-    children.sort_unstable_by(|a, b| {
-        b.count.cmp(&a.count).then_with(|| {
-            stacks_dict
-                .resolve(a.frame)
-                .cmp(stacks_dict.resolve(b.frame))
-        })
-    });
 }
 
 /// Handler for GET /api/flamegraph — a Server-Sent Events stream.
@@ -568,6 +684,7 @@ struct StreamCtx {
 enum WireFormat {
     Legacy,
     InternedV1,
+    FlatV1,
 }
 
 /// The flamegraph [`FoldSink`] adapter: owns the incremental [`FlamegraphAccum`]
@@ -714,6 +831,7 @@ fn flamegraph_stream(
         max_poll_ns: params.max_poll_ns,
         wire_format: match params.format.as_deref() {
             Some("interned-v1") => WireFormat::InternedV1,
+            Some("flat-v1") => WireFormat::FlatV1,
             _ => WireFormat::Legacy,
         },
     };
@@ -729,6 +847,7 @@ fn build_response(ctx: &StreamCtx, snap: &AggSnapshot, coverage: Coverage) -> Fl
         WireFormat::InternedV1 => {
             FlamegraphTree::Interned(trie.into_interned_tree(snap.stacks_dict))
         }
+        WireFormat::FlatV1 => FlamegraphTree::Flat(trie.into_flat_tree(snap.stacks_dict)),
     };
 
     // Echo the active filter values back to the UI (facet name → selected value).
@@ -854,6 +973,60 @@ mod tests {
             build_flamegraph_tree(&[(a, 5), (b, 5)], &stacks_dict).into_interned_tree(&stacks_dict);
         let second =
             build_flamegraph_tree(&[(b, 5), (a, 5)], &stacks_dict).into_interned_tree(&stacks_dict);
+
+        assert_eq!(
+            serde_json::to_string(&first).unwrap(),
+            serde_json::to_string(&second).unwrap()
+        );
+    }
+
+    #[test]
+    fn flat_tree_preserves_counts_and_parent_order() {
+        let mut stacks = HashMap::new();
+        let a = [1u8; 16];
+        let b = [2u8; 16];
+        stacks.insert(
+            a,
+            vec!["left".to_string(), "main".to_string(), "root".to_string()],
+        );
+        stacks.insert(
+            b,
+            vec!["right".to_string(), "main".to_string(), "root".to_string()],
+        );
+        let stacks_dict = StackDictionary::from_stacks(stacks);
+        let tree =
+            build_flamegraph_tree(&[(a, 4), (b, 3)], &stacks_dict).into_flat_tree(&stacks_dict);
+
+        assert_eq!(tree.format, "flat-v1");
+        assert_eq!(tree.nodes.len(), 5);
+        assert_eq!(
+            (tree.nodes[0].0, tree.nodes[0].2, tree.nodes[0].3),
+            (0, 7, 0)
+        );
+        for (index, node) in tree.nodes.iter().enumerate().skip(1) {
+            assert!(
+                usize::try_from(node.0).unwrap() < index,
+                "node {index} must follow parent {}",
+                node.0
+            );
+        }
+        let self_total: u64 = tree.nodes.iter().map(|node| node.3).sum();
+        assert_eq!(self_total, 7);
+    }
+
+    #[test]
+    fn flat_tree_is_deterministic_across_input_order() {
+        let mut stacks = HashMap::new();
+        let a = [1u8; 16];
+        let b = [2u8; 16];
+        stacks.insert(a, vec!["z-leaf".to_string(), "shared".to_string()]);
+        stacks.insert(b, vec!["a-leaf".to_string(), "shared".to_string()]);
+        let stacks_dict = StackDictionary::from_stacks(stacks);
+
+        let first =
+            build_flamegraph_tree(&[(a, 5), (b, 5)], &stacks_dict).into_flat_tree(&stacks_dict);
+        let second =
+            build_flamegraph_tree(&[(b, 5), (a, 5)], &stacks_dict).into_flat_tree(&stacks_dict);
 
         assert_eq!(
             serde_json::to_string(&first).unwrap(),

--- a/dial9-viewer/ui/flamegraph_api.js
+++ b/dial9-viewer/ui/flamegraph_api.js
@@ -159,30 +159,62 @@ function shouldAdoptRefinementSnapshot(preserveExisting, baselineFilesFolded, in
 
 // Resolve the negotiated aggregate flamegraph encoding into the legacy
 // nested-name tree consumed by the existing renderers. Older servers return
-// that tree directly; interned-v1 sends every frame name once and references
-// it by index from each node.
+// that tree directly; interned-v1 and flat-v1 send every frame name once and
+// reference it by index from each node.
 function decodeFlamegraphTree(response) {
   const tree = response && response.tree;
-  if (!tree || tree.format !== "interned-v1") return tree;
+  if (!tree || (tree.format !== "interned-v1" && tree.format !== "flat-v1")) return tree;
   if (!Array.isArray(tree.frames)) {
-    throw new Error("interned-v1 flamegraph is missing its frame table");
+    throw new Error(`${tree.format} flamegraph is missing its frame table`);
+  }
+
+  function frameName(frame) {
+    if (!Number.isInteger(frame) || frame < 0 || frame >= tree.frames.length) {
+      throw new Error(`${tree.format} flamegraph references invalid frame ${String(frame)}`);
+    }
+    const name = tree.frames[frame];
+    if (typeof name !== "string") {
+      throw new Error(`${tree.format} flamegraph frame ${frame} is not a string`);
+    }
+    return name;
+  }
+
+  if (tree.format === "flat-v1") {
+    if (!Array.isArray(tree.nodes) || tree.nodes.length === 0) {
+      throw new Error("flat-v1 flamegraph must contain a root node");
+    }
+    const decoded = [];
+    for (let i = 0; i < tree.nodes.length; i++) {
+      const row = tree.nodes[i];
+      if (!Array.isArray(row) || row.length !== 4) {
+        throw new Error(`flat-v1 flamegraph node ${i} is not a four-field row`);
+      }
+      const parent = row[0];
+      if (!Number.isInteger(parent) || (i === 0 ? parent !== 0 : parent < 0 || parent >= i)) {
+        throw new Error(`flat-v1 flamegraph node ${i} has invalid parent ${String(parent)}`);
+      }
+      const node = {
+        name: frameName(row[1]),
+        count: row[2],
+        self: row[3],
+      };
+      decoded.push(node);
+      if (i > 0) {
+        const parentNode = decoded[parent];
+        (parentNode.children || (parentNode.children = [])).push(node);
+      }
+    }
+    return decoded[0];
   }
 
   function decodeNode(node) {
     const frame = node && node.frame;
-    if (!Number.isInteger(frame) || frame < 0 || frame >= tree.frames.length) {
-      throw new Error(`interned-v1 flamegraph references invalid frame ${String(frame)}`);
-    }
-    const name = tree.frames[frame];
-    if (typeof name !== "string") {
-      throw new Error(`interned-v1 flamegraph frame ${frame} is not a string`);
-    }
     const children = node.children;
     if (children != null && !Array.isArray(children)) {
       throw new Error("interned-v1 flamegraph node children must be an array");
     }
     const decoded = {
-      name,
+      name: frameName(frame),
       count: node.count,
       self: node.self,
     };

--- a/dial9-viewer/ui/flamegraph_diff_view.js
+++ b/dial9-viewer/ui/flamegraph_diff_view.js
@@ -593,7 +593,7 @@
 
     // ── Per-side SSE stream ──
     // One stream per side: the server emits cumulative snapshots after bounded
-    // cached batches, then a fresh full snapshot per newly-folded capped-prefix
+    // cached batches, then a fresh bounded snapshot per newly-folded capped-prefix
     // file, and closes when that work-list drains (the server owns the stop
     // condition — no client polling or plateau detection). A new tree on either
     // side triggers a re-merge + re-render. The cap is the

--- a/dial9-viewer/ui/flamegraph_diff_view.js
+++ b/dial9-viewer/ui/flamegraph_diff_view.js
@@ -66,7 +66,7 @@
     }
     for (const h of scope.getAll("host")) u.searchParams.append("host", h);
     if (maxFiles != null) u.searchParams.set("max_files", String(maxFiles));
-    u.searchParams.set("format", "interned-v1");
+    u.searchParams.set("format", "flat-v1");
     return u;
   }
 

--- a/dial9-viewer/ui/src/lib/trace/aggregates.ts
+++ b/dial9-viewer/ui/src/lib/trace/aggregates.ts
@@ -141,6 +141,9 @@ export interface FlatApiFlamegraphTree {
   format: "flat-v1";
   frames: string[];
   nodes: FlatApiFlamegraphNode[];
+  total_nodes: number;
+  omitted_nodes: number;
+  inspect_retained?: boolean;
 }
 
 export type ApiFlamegraphTree =

--- a/dial9-viewer/ui/src/lib/trace/aggregates.ts
+++ b/dial9-viewer/ui/src/lib/trace/aggregates.ts
@@ -129,7 +129,24 @@ export interface InternedApiFlamegraphTree {
   root: InternedApiFlamegraphNode;
 }
 
-export type ApiFlamegraphTree = ApiFlamegraphNode | InternedApiFlamegraphTree;
+/** Preorder `[parent_node, frame, count, self_count]` row. */
+export type FlatApiFlamegraphNode = [
+  parent: number,
+  frame: number,
+  count: number,
+  selfCount: number,
+];
+
+export interface FlatApiFlamegraphTree {
+  format: "flat-v1";
+  frames: string[];
+  nodes: FlatApiFlamegraphNode[];
+}
+
+export type ApiFlamegraphTree =
+  | ApiFlamegraphNode
+  | InternedApiFlamegraphTree
+  | FlatApiFlamegraphTree;
 
 /** One facet's values. */
 export interface FacetResult {

--- a/dial9-viewer/ui/src/lib/trace/index.ts
+++ b/dial9-viewer/ui/src/lib/trace/index.ts
@@ -364,6 +364,8 @@ export type {
   Exemplar,
   ExemplarAttribute,
   FacetResult,
+  FlatApiFlamegraphNode,
+  FlatApiFlamegraphTree,
   FlamegraphMetadata,
   FlamegraphResponse,
   InternedApiFlamegraphNode,

--- a/dial9-viewer/ui/src/pages/flamegraph/api-mode.ts
+++ b/dial9-viewer/ui/src/pages/flamegraph/api-mode.ts
@@ -131,6 +131,7 @@ export function runApiMode(params: URLSearchParams, els: PageEls): void {
 
   function queryState(): ApiQueryState {
     const band = minimap?.band() ?? { minPollNs: null, maxPollNs: null };
+    const currentParams = new URLSearchParams(window.location.search);
     return {
       dataDir,
       source: { ...source, bucket: scopeBucket || source.bucket },
@@ -146,6 +147,7 @@ export function runApiMode(params: URLSearchParams, els: PageEls): void {
       spanTypeUid: scopeSpanTypeUid,
       minSpanNs: scopeMinSpanNs,
       maxSpanNs: scopeMaxSpanNs,
+      inspect: currentParams.get("inspect_full") || currentParams.get("inspect"),
     };
   }
 
@@ -301,6 +303,16 @@ export function runApiMode(params: URLSearchParams, els: PageEls): void {
   function baseStats(resp: FlamegraphResponse): string {
     const meta = resp.metadata;
     const bits = [`${resp.total_samples.toLocaleString()} samples`];
+    if (
+      "format" in resp.tree &&
+      resp.tree.format === "flat-v1" &&
+      resp.tree.omitted_nodes > 0
+    ) {
+      bits.push(
+        `${resp.tree.nodes.length.toLocaleString()} / ` +
+          `${resp.tree.total_nodes.toLocaleString()} nodes shown`,
+      );
+    }
     if (meta.hosts > 1) bits.push(`${meta.hosts} hosts`);
     if (meta.min_timestamp_ns && meta.max_timestamp_ns) {
       const from = new Date(meta.min_timestamp_ns / 1e6);

--- a/dial9-viewer/ui/src/pages/flamegraph/query.test.ts
+++ b/dial9-viewer/ui/src/pages/flamegraph/query.test.ts
@@ -33,6 +33,7 @@ function state(over: Partial<ApiQueryState> = {}): ApiQueryState {
     spanTypeUid: null,
     minSpanNs: null,
     maxSpanNs: null,
+    inspect: null,
     ...over,
   };
 }
@@ -154,6 +155,12 @@ describe("buildApiUrl", () => {
     expect(u).toBe(
       `${ORIGIN}/api/flamegraph?data_dir=%2Fvar%2Ftraces&source=cpu` +
         "&host_group=blue&format=flat-v1",
+    );
+  });
+  it("forwards the current inspect frame for projection retention", () => {
+    expect(buildApiUrl(state({ inspect: "core::task::poll" }), ORIGIN)).toBe(
+      `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&source=cpu` +
+        "&inspect=core%3A%3Atask%3A%3Apoll&format=flat-v1",
     );
   });
 });

--- a/dial9-viewer/ui/src/pages/flamegraph/query.test.ts
+++ b/dial9-viewer/ui/src/pages/flamegraph/query.test.ts
@@ -97,7 +97,7 @@ describe("seedFacetState", () => {
 describe("buildApiUrl", () => {
   it("SSE stream URL: scope + non-empty facets, no refine flag", () => {
     expect(buildApiUrl(state(), ORIGIN)).toBe(
-      `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&source=cpu&format=interned-v1`,
+      `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&source=cpu&format=flat-v1`,
     );
   });
   it("serializes repeated hosts, times and max_files in stable order", () => {
@@ -114,7 +114,7 @@ describe("buildApiUrl", () => {
     expect(u).toBe(
       `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&service=svc-a` +
         "&host=h1&host=h2&source=cpu&start_ns=1743000000000000000" +
-        "&end_ns=1743003600000000000&max_files=64&format=interned-v1",
+        "&end_ns=1743003600000000000&max_files=64&format=flat-v1",
     );
   });
   it("poll-duration band rides after the time window (min_poll_ns/max_poll_ns)", () => {
@@ -125,13 +125,13 @@ describe("buildApiUrl", () => {
     expect(u).toBe(
       `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&source=cpu` +
         "&start_ns=1&end_ns=2&min_poll_ns=500000&max_poll_ns=10000000" +
-        "&format=interned-v1",
+        "&format=flat-v1",
     );
   });
   it("an open-ended band emits only the bound that is set", () => {
     expect(buildApiUrl(state({ minPollNs: "1000000" }), ORIGIN)).toBe(
       `${ORIGIN}/api/flamegraph?bucket=demo-traces&prefix=traces&source=cpu` +
-        "&min_poll_ns=1000000&format=interned-v1",
+        "&min_poll_ns=1000000&format=flat-v1",
     );
     expect(buildBrowserQuery(state({ maxPollNs: "2000000" }))).toBe(
       "api=1&bucket=demo-traces&credential_mode=ambient&prefix=traces&source=cpu&max_poll_ns=2000000",
@@ -153,7 +153,7 @@ describe("buildApiUrl", () => {
     );
     expect(u).toBe(
       `${ORIGIN}/api/flamegraph?data_dir=%2Fvar%2Ftraces&source=cpu` +
-        "&host_group=blue&format=interned-v1",
+        "&host_group=blue&format=flat-v1",
     );
   });
 });

--- a/dial9-viewer/ui/src/pages/flamegraph/query.ts
+++ b/dial9-viewer/ui/src/pages/flamegraph/query.ts
@@ -126,7 +126,7 @@ export function buildApiUrl(state: ApiQueryState, origin: string): string {
   writeRequestParams(u.searchParams, state.source);
   appendScope(u.searchParams, state);
   if (state.maxFiles != null) u.searchParams.set("max_files", String(state.maxFiles));
-  u.searchParams.set("format", "interned-v1");
+  u.searchParams.set("format", "flat-v1");
   return u.toString();
 }
 

--- a/dial9-viewer/ui/src/pages/flamegraph/query.ts
+++ b/dial9-viewer/ui/src/pages/flamegraph/query.ts
@@ -77,6 +77,8 @@ export interface ApiQueryState {
   spanTypeUid: string | null;
   minSpanNs: string | null;
   maxSpanNs: string | null;
+  /** Current aggregate inspect frame, retained by bounded server projections. */
+  inspect: string | null;
 }
 
 /** Seed the non-host facet filters from the page URL. */
@@ -110,6 +112,7 @@ function appendScope(p: URLSearchParams, state: ApiQueryState): void {
   if (state.spanTypeUid) p.set("span_type_uid", state.spanTypeUid);
   if (state.minSpanNs) p.set("min_span_ns", state.minSpanNs);
   if (state.maxSpanNs) p.set("max_span_ns", state.maxSpanNs);
+  if (state.inspect) p.set("inspect", state.inspect);
 }
 
 /**

--- a/dial9-viewer/ui/src/types/flamegraph_api.d.ts
+++ b/dial9-viewer/ui/src/types/flamegraph_api.d.ts
@@ -110,7 +110,8 @@ declare module "*/flamegraph_api.js" {
 
   /**
    * Decode the negotiated aggregate tree encoding. Legacy nested-name trees
-   * pass through; interned-v1 frame IDs are resolved through its frame table.
+   * pass through; interned-v1 and flat-v1 frame IDs are resolved through their
+   * frame tables.
    */
   export function decodeFlamegraphTree(response: {
     tree: unknown;

--- a/dial9-viewer/ui/tests/core/flamegraph_api.test.ts
+++ b/dial9-viewer/ui/tests/core/flamegraph_api.test.ts
@@ -89,6 +89,38 @@ const {
 };
 
 describe("decodeFlamegraphTree", () => {
+  it("materializes parent-first flat rows", () => {
+    expect(
+      decodeFlamegraphTree({
+        tree: {
+          format: "flat-v1",
+          frames: ["(all)", "main", "left", "right"],
+          nodes: [
+            [0, 0, 7, 0],
+            [0, 1, 7, 0],
+            [1, 2, 4, 4],
+            [1, 3, 3, 3],
+          ],
+        },
+      }),
+    ).toEqual({
+      name: "(all)",
+      count: 7,
+      self: 0,
+      children: [
+        {
+          name: "main",
+          count: 7,
+          self: 0,
+          children: [
+            { name: "left", count: 4, self: 4 },
+            { name: "right", count: 3, self: 3 },
+          ],
+        },
+      ],
+    });
+  });
+
   it("resolves repeated interned frame IDs into the legacy nested tree", () => {
     expect(
       decodeFlamegraphTree({
@@ -152,6 +184,21 @@ describe("decodeFlamegraphTree", () => {
         },
       }),
     ).toThrow(/invalid frame 2/);
+  });
+
+  it("rejects a flat node whose parent does not precede it", () => {
+    expect(() =>
+      decodeFlamegraphTree({
+        tree: {
+          format: "flat-v1",
+          frames: ["(all)", "child"],
+          nodes: [
+            [0, 0, 1, 0],
+            [2, 1, 1, 1],
+          ],
+        },
+      }),
+    ).toThrow(/node 1 has invalid parent 2/);
   });
 });
 

--- a/dial9-viewer/ui/tests/core/flamegraph_diff_view_state.test.js
+++ b/dial9-viewer/ui/tests/core/flamegraph_diff_view_state.test.js
@@ -151,7 +151,7 @@ test("apiUrlFor forwards server scope and strips client-only flags", () => {
   assert.strictEqual(url.searchParams.get("aws_region"), "us-west-2");
   assert.deepStrictEqual(url.searchParams.getAll("host"), ["h1", "h2"]);
   assert.strictEqual(url.searchParams.get("max_files"), "8");
-  assert.strictEqual(url.searchParams.get("format"), "interned-v1");
+  assert.strictEqual(url.searchParams.get("format"), "flat-v1");
   assert.strictEqual(url.searchParams.get("api"), null);
 });
 


### PR DESCRIPTION
## Summary

- Cap `flat-v1` flamegraph projections at 50,000 rows.
- Select retained nodes deterministically and aggregate omitted subtrees into synthetic `[other]` rows.
- Preserve total and self counts across the bounded projection.
- Retain one deterministic path to the requested inspect frame when it exists.
- Report exact and omitted node counts to the UI.

## Why

Compact encodings reduce bytes per node but do not bound pathological cardinality. The production trace built a 1.65 million-node trie; this projection budget places a hard ceiling on the browser-facing response while retaining the highest-value paths and count conservation.

## Dependency

Depends on #847.

## Stack

1. #846 Frame interning
2. #847 Flat parent-indexed tree rows
3. **#848 Deterministic node budget (this PR)**
4. #849 Coverage-only progress events
5. #850 Transactional in-place part merges

## Validation

Validated on the complete stack:

- `cargo fmt --check`
- `cargo clippy --all-targets --all-features`
- `cargo nextest run` (1,444 passed)
- `cargo nextest run --stress-duration 20s` (1 full iteration, 1,444 passed)
- UI typecheck, import-boundary check, Vitest (2,181 passed), and Vite production build