### PR TITLE
test(dial9-core): add shuttle coverage for SharedState concurrency

### DIFF
--- a/dial9-core/src/pipeline_shuttle_tests.rs
+++ b/dial9-core/src/pipeline_shuttle_tests.rs
@@ -450,10 +450,14 @@ fn run_erroring_pipeline(fault: fs::FaultPolicy) -> u64 {
     warn_count.load(StdOrdering::Relaxed)
 }
 
-// The fault is armed on the test thread but read on the flush thread,
-// this proves it crosses that boundary. No `pct`: the spawning thread
-// parks on `.join()` immediately with no other work in between, so the
-// two threads are never simultaneously runnable.
+// Pins the choice of using a real `std::thread_local!` on `primitives::fs::FAULT`
+// so a fault armed on this thread is visible to a spawned thread too.
+//
+// If a future upgrade caused shuttle to lose visibility of that thread,
+// this is what would catch it.
+//
+// No `pct`: the spawning thread parks on `.join()` immediately with no
+// other work in between, so there's no interleaving choice to explore.
 crate::shuttle_test! {
     default, determinism_only;
     fn fs_fault_visible_across_threads() {

--- a/dial9-core/src/pipeline_shuttle_tests.rs
+++ b/dial9-core/src/pipeline_shuttle_tests.rs
@@ -450,14 +450,9 @@ fn run_erroring_pipeline(fault: fs::FaultPolicy) -> u64 {
     warn_count.load(StdOrdering::Relaxed)
 }
 
-// Pins the choice of using a real `std::thread_local!` on `primitives::fs::FAULT`
-// so a fault armed on this thread is visible to a spawned thread too.
-//
-// If a future upgrade caused shuttle to lose visibility of that thread,
-// this is what would catch it.
-//
-// No `pct`: the spawning thread parks on `.join()` immediately with no
-// other work in between, so there's no interleaving choice to explore.
+// Pins `primitives::fs::FAULT`'s real `std::thread_local!`: a fault armed
+// on this thread must stay visible to a spawned thread too. No `pct`: the
+// spawning thread parks on `.join()` immediately, no interleaving to explore.
 crate::shuttle_test! {
     default, determinism_only;
     fn fs_fault_visible_across_threads() {

--- a/dial9-core/src/primitives.rs
+++ b/dial9-core/src/primitives.rs
@@ -274,12 +274,10 @@ macro_rules! shuttle_test {
     // using this -- don't use it defensively. Still runnable manually with
     // `--ignored`.
     //
-    // If also using `replay = $schedule`, capture that schedule from `pct`'s
-    // failure output, never from `determinism`'s: `replay` does a single run,
-    // same as `pct` -- safe. `determinism`'s schedules come from its
-    // record-twice mechanism, the same one that SIGABRTs, so replaying one
-    // of those could reproduce the abort deterministically instead of the
-    // catchable panic.
+    // If also using `replay = $schedule`: capture it from `pct`'s failure
+    // output, not `determinism`'s. `determinism`'s schedules come from
+    // the same record-twice mechanism that SIGABRTs, so replaying one
+    // could reproduce the abort instead of a catchable panic.
     (num_iters = $num_iters:expr, depth = $depth:expr, should_panic, flaky_sigabrt_determinism_only $(, expect_panic = $msg:expr)? $(, replay = $schedule:expr)?; $(#[$attr:meta])* fn $name:ident() $body:block) => {
         mod $name {
             use super::*;
@@ -422,15 +420,10 @@ pub mod fs {
         FailProb(f64),
     }
 
-    // Deliberately the real `std::thread_local!`, not this module's shuttle-
-    // swapped one. Shuttle's threads are coroutines cooperatively scheduled
-    // on a single real OS thread, so a real thread-local is effectively
-    // global for the whole test -- a fault armed on the test's own thread
-    // stays visible to every thread it spawns. The shuttle-aware thread_local
-    // would isolate storage per logical thread instead, so this deliberately
-    // opts out of that: switching it would silently stop fault injection
-    // from reaching any spawned thread, which is most real usage (e.g. the
-    // flush thread). Pinned by `fs_fault_visible_across_threads`.
+    // Shuttle's threads are coroutines on one real OS thread, so this
+    // stays visible to every spawned thread instead of being isolated per
+    // logical thread. Swapping to `shuttle::thread` would silently stop fault injection
+    // from reaching spawned threads. Pinned by `fs_fault_visible_across_threads`.
     std::thread_local! {
         static FAULT: Cell<FaultPolicy> = const { Cell::new(FaultPolicy::None) };
     }

--- a/dial9-core/src/primitives.rs
+++ b/dial9-core/src/primitives.rs
@@ -273,6 +273,13 @@ macro_rules! shuttle_test {
     // Confirm the crash first (run `determinism` alone, repeatedly) before
     // using this -- don't use it defensively. Still runnable manually with
     // `--ignored`.
+    //
+    // If also using `replay = $schedule`, capture that schedule from `pct`'s
+    // failure output, never from `determinism`'s: `replay` does a single run,
+    // same as `pct` -- safe. `determinism`'s schedules come from its
+    // record-twice mechanism, the same one that SIGABRTs, so replaying one
+    // of those could reproduce the abort deterministically instead of the
+    // catchable panic.
     (num_iters = $num_iters:expr, depth = $depth:expr, should_panic, flaky_sigabrt_determinism_only $(, expect_panic = $msg:expr)? $(, replay = $schedule:expr)?; $(#[$attr:meta])* fn $name:ident() $body:block) => {
         mod $name {
             use super::*;
@@ -415,6 +422,15 @@ pub mod fs {
         FailProb(f64),
     }
 
+    // Deliberately the real `std::thread_local!`, not this module's shuttle-
+    // swapped one. Shuttle's threads are coroutines cooperatively scheduled
+    // on a single real OS thread, so a real thread-local is effectively
+    // global for the whole test -- a fault armed on the test's own thread
+    // stays visible to every thread it spawns. The shuttle-aware thread_local
+    // would isolate storage per logical thread instead, so this deliberately
+    // opts out of that: switching it would silently stop fault injection
+    // from reaching any spawned thread, which is most real usage (e.g. the
+    // flush thread). Pinned by `fs_fault_visible_across_threads`.
     std::thread_local! {
         static FAULT: Cell<FaultPolicy> = const { Cell::new(FaultPolicy::None) };
     }

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -313,23 +313,25 @@ impl EventBuffer<'_> {
 }
 
 #[cfg(test)]
+fn sample_event() -> crate::format::ClockSyncEvent {
+    crate::format::ClockSyncEvent {
+        timestamp_ns: 1000,
+        realtime_ns: 2000,
+    }
+}
+
+/// Helper: create a SharedState with recording enabled.
+#[cfg(test)]
+fn enabled_shared_state() -> SharedState {
+    let ss = SharedState::new(0);
+    ss.enable();
+    ss
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::primitives::sync::atomic::AtomicBool;
-
-    fn sample_event() -> crate::format::ClockSyncEvent {
-        crate::format::ClockSyncEvent {
-            timestamp_ns: 1000,
-            realtime_ns: 2000,
-        }
-    }
-
-    /// Helper: create a SharedState with recording enabled.
-    fn enabled_shared_state() -> SharedState {
-        let ss = SharedState::new(0);
-        ss.enable();
-        ss
-    }
 
     #[test]
     fn record_event_registers_tl_buffer_handle() {
@@ -535,6 +537,13 @@ mod tests {
     }
 }
 
+// Every scenario below that touches `drain_epoch`/`flush_epoch`/`state`
+// shares one caveat: those fields are `Ordering::Relaxed` throughout, but
+// shuttle 0.9.1 only correctly models `SeqCst` (it treats every other
+// ordering as `SeqCst`). A `Relaxed`-specific bug is invisible here
+// regardless of how exhaustively a scenario searches, even though it's
+// reachable on real hardware -- only the surrounding CAS/transition logic
+// is actually under test.
 #[cfg(all(test, shuttle))]
 mod shuttle_tests {
     use super::*;
@@ -548,19 +557,6 @@ mod shuttle_tests {
     const EVENTS_PER_WRITER: u64 = 3;
     const DRAIN_TICKS: usize = 3;
 
-    fn sample_event() -> crate::format::ClockSyncEvent {
-        crate::format::ClockSyncEvent {
-            timestamp_ns: 1000,
-            realtime_ns: 2000,
-        }
-    }
-
-    fn enabled_shared_state() -> SharedState {
-        let ss = SharedState::new(0);
-        ss.enable();
-        ss
-    }
-
     crate::shuttle_test! {
         default;
         // Shuttle counterpart of `concurrent_record_and_drain_preserves_event_count`:
@@ -568,6 +564,9 @@ mod shuttle_tests {
         // the drain epoch and intrusively drains, exploring interleavings
         // exhaustively instead of sampling them. Every recorded event must reach
         // the collector exactly once, regardless of schedule.
+        //
+        // Keeping real-thread proptest above because of the `Ordering::Relaxed` caveat
+        // this scenario shares with the others below (see module comments).
         fn shuttle_concurrent_record_and_drain() {
             let ss = Arc::new(enabled_shared_state());
 
@@ -619,6 +618,153 @@ mod shuttle_tests {
                 total,
                 WRITERS as u64 * EVENTS_PER_WRITER,
                 "every recorded event must reach the collector exactly once"
+            );
+        }
+    }
+
+    const LIFECYCLE_WRITERS: usize = 2;
+
+    crate::shuttle_test! {
+        default;
+        // `disable()` raced against the recording gate, `if_enabled`
+        //
+        // Every `Some` return must land exactly one event in the collector,
+        // and every `None` must record nothing, so the collector total equals the number
+        // of `Some`s, no matter where `disable`/`enable`/`mark_stopped`
+        // interleave.
+        //
+        // This does NOT assert "no events arrive after disable()". A writer that passed
+        // `is_enabled()` completes its write after `disable()` returns (by design).
+        //
+        // Also subject to the `Ordering::Relaxed` caveat (see module comments).
+        fn shuttle_disable_races_record() {
+            let ss = Arc::new(enabled_shared_state());
+
+            let writers: Vec<_> = (0..LIFECYCLE_WRITERS)
+                .map(|_| {
+                    let ss = ss.clone();
+                    crate::primitives::thread::spawn(move || {
+                        let mut recorded = 0u64;
+                        for _ in 0..EVENTS_PER_WRITER {
+                            // Production entry point, not the `#[cfg(test)]`
+                            // `SharedState::record_encodable_event` shortcut:
+                            // the enabled check and the write must be one call.
+                            if ss
+                                .if_enabled(|buf| buf.record_encodable_event(&sample_event()))
+                                .is_some()
+                            {
+                                recorded += 1;
+                            }
+                        }
+                        recorded
+                    })
+                })
+                .collect();
+
+            let lifecycle = {
+                let ss = ss.clone();
+                crate::primitives::thread::spawn(move || {
+                    ss.disable(); // Enabled -> Disabled
+                    ss.enable(); // Disabled -> Enabled (re-arm)
+                    ss.disable();
+                    ss.mark_stopped(); // terminal
+                })
+            };
+
+            let mut expected = 0u64;
+            for w in writers {
+                expected += w.join().unwrap();
+            }
+            lifecycle.join().unwrap();
+
+            // `Stopped` is terminal regardless of schedule: a `disable()` or
+            // `enable()` that lost the race must not have clobbered it back
+            // to a live state. Catches a CAS -> plain `store` regression in
+            // either.
+            assert!(ss.is_stopped(), "Stopped must be terminal");
+            ss.enable();
+            assert!(!ss.is_enabled(), "enable() must be a no-op once stopped");
+
+            // Drain happens after `mark_stopped`: draining is
+            // state-independent, so buffered events are still recoverable
+            // at shutdown.
+            ss.bump_drain_epoch();
+            ss.drain_all_tl_buffers();
+
+            let mut total = 0u64;
+            while let Some(batch) = ss.collector.next() {
+                total += batch.event_count();
+            }
+            assert_eq!(ss.collector.take_dropped_batches(), 0);
+            assert_eq!(
+                total, expected,
+                "every if_enabled that returned Some must yield exactly one event"
+            );
+        }
+    }
+
+    crate::shuttle_test! {
+        default;
+        // Writer threads exit *while* the drainer is mid-drain, so the TLB
+        // `Drop` flush (`encoder.rs`'s thread-local buffer handle) overlaps
+        // `drain_all_tl_buffers`'s `Weak::upgrade` + prune logic.
+        //
+        // Whether a writer still holds a pending event at exit is schedule-dependent.
+        // So some interleavings exercise upgrade-vs-teardown without exercising the
+        // `Drop` flush itself.
+        //
+        // Also subject to the `Ordering::Relaxed` caveat (see module comments).
+        fn shuttle_writer_exit_races_drain() {
+            let ss = Arc::new(enabled_shared_state());
+
+            let writers: Vec<_> = (0..WRITERS)
+                .map(|_| {
+                    let ss = ss.clone();
+                    crate::primitives::thread::spawn(move || {
+                        ss.if_enabled(|buf| buf.record_encodable_event(&sample_event()));
+                        // Return immediately: the next scheduling points are
+                        // the thread-local destructor, the final `Arc`
+                        // decrement, and the `Mutex` drop.
+                    })
+                })
+                .collect();
+
+            let drainer = {
+                let ss = ss.clone();
+                crate::primitives::thread::spawn(move || {
+                    for _ in 0..DRAIN_TICKS {
+                        ss.bump_drain_epoch();
+                        // No `yield_now` grace here, unlike
+                        // `shuttle_concurrent_record_and_drain`: draining
+                        // while handles are still live is the point.
+                        ss.drain_all_tl_buffers();
+                    }
+                })
+            };
+
+            // Deliberately NOT joined before the drainer runs.
+            for w in writers {
+                w.join().unwrap();
+            }
+            drainer.join().unwrap();
+
+            ss.bump_drain_epoch();
+            ss.drain_all_tl_buffers();
+
+            let mut total = 0u64;
+            while let Some(batch) = ss.collector.next() {
+                total += batch.event_count();
+            }
+            assert_eq!(ss.collector.take_dropped_batches(), 0);
+            assert_eq!(
+                total, WRITERS as u64,
+                "each writer's event must arrive exactly once, whether flushed by \
+                 the intrusive drain or by the TLB Drop impl on thread exit"
+            );
+            assert_eq!(
+                ss.tl_buffers.lock().unwrap().len(),
+                0,
+                "all handles are dead after join; the final drain must prune them"
             );
         }
     }

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -534,3 +534,92 @@ mod tests {
         }
     }
 }
+
+#[cfg(all(test, shuttle))]
+mod shuttle_tests {
+    use super::*;
+
+    // Shuttle's search cost grows with interleaving
+    // space, unlike a real-thread proptest. Widening these (or using
+    // shuttle::rand, as pipeline_shuttle_tests.rs does) would exercise more
+    // events per buffer, at lower coverage density per iteration at this
+    // scenario's `depth = 3` (from `default`).
+    const WRITERS: usize = 3;
+    const EVENTS_PER_WRITER: u64 = 3;
+    const DRAIN_TICKS: usize = 3;
+
+    fn sample_event() -> crate::format::ClockSyncEvent {
+        crate::format::ClockSyncEvent {
+            timestamp_ns: 1000,
+            realtime_ns: 2000,
+        }
+    }
+
+    fn enabled_shared_state() -> SharedState {
+        let ss = SharedState::new(0);
+        ss.enable();
+        ss
+    }
+
+    crate::shuttle_test! {
+        default;
+        // Shuttle counterpart of `concurrent_record_and_drain_preserves_event_count`:
+        // writer threads record events while a drainer thread concurrently bumps
+        // the drain epoch and intrusively drains, exploring interleavings
+        // exhaustively instead of sampling them. Every recorded event must reach
+        // the collector exactly once, regardless of schedule.
+        fn shuttle_concurrent_record_and_drain() {
+            let ss = Arc::new(enabled_shared_state());
+
+            let writers: Vec<_> = (0..WRITERS)
+                .map(|_| {
+                    let ss = ss.clone();
+                    crate::primitives::thread::spawn(move || {
+                        for _ in 0..EVENTS_PER_WRITER {
+                            ss.record_encodable_event(&sample_event());
+                        }
+                    })
+                })
+                .collect();
+
+            let drainer = {
+                let ss = ss.clone();
+                crate::primitives::thread::spawn(move || {
+                    for _ in 0..DRAIN_TICKS {
+                        ss.bump_drain_epoch();
+                        // Grace period for an in-flight writer to self-flush
+                        // before the intrusive drain locks its buffer, mirroring
+                        // the real flush loop's tick-then-drain gap.
+                        shuttle::thread::yield_now();
+                        ss.drain_all_tl_buffers();
+                    }
+                })
+            };
+
+            for w in writers {
+                w.join().unwrap();
+            }
+            drainer.join().unwrap();
+
+            // Writers have exited, so their TLB `Drop` impls flushed any
+            // remaining events. Final bump+drain prunes dead handles.
+            ss.bump_drain_epoch();
+            ss.drain_all_tl_buffers();
+
+            let mut total: u64 = 0;
+            while let Some(batch) = ss.collector.next() {
+                total += batch.event_count();
+            }
+            assert_eq!(
+                ss.collector.take_dropped_batches(),
+                0,
+                "collector must not evict a batch under this workload"
+            );
+            assert_eq!(
+                total,
+                WRITERS as u64 * EVENTS_PER_WRITER,
+                "every recorded event must reach the collector exactly once"
+            );
+        }
+    }
+}

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -537,22 +537,16 @@ mod tests {
     }
 }
 
-// Every scenario below that touches `drain_epoch`/`flush_epoch`/`state`
-// shares one caveat: those fields are `Ordering::Relaxed` throughout, but
-// shuttle 0.9.1 only correctly models `SeqCst` (it treats every other
-// ordering as `SeqCst`). A `Relaxed`-specific bug is invisible here
-// regardless of how exhaustively a scenario searches, even though it's
-// reachable on real hardware -- only the surrounding CAS/transition logic
-// is actually under test.
+// Every scenario below shares a caveat: `drain_epoch`/`flush_epoch`/`state`
+// are `Ordering::Relaxed`, but shuttle 0.9.1 treats every ordering as
+// `SeqCst`. A `Relaxed`-specific bug is invisible here no matter how
+// exhaustively a scenario searches.
 #[cfg(all(test, shuttle))]
 mod shuttle_tests {
     use super::*;
 
-    // Shuttle's search cost grows with interleaving
-    // space, unlike a real-thread proptest. Widening these (or using
-    // shuttle::rand, as pipeline_shuttle_tests.rs does) would exercise more
-    // events per buffer, at lower coverage density per iteration at this
-    // scenario's `depth = 3` (from `default`).
+    // Small values kept: shuttle's search cost grows with interleaving
+    // space, unlike a real-thread proptest.
     const WRITERS: usize = 3;
     const EVENTS_PER_WRITER: u64 = 3;
     const DRAIN_TICKS: usize = 3;
@@ -560,13 +554,8 @@ mod shuttle_tests {
     crate::shuttle_test! {
         default;
         // Shuttle counterpart of `concurrent_record_and_drain_preserves_event_count`:
-        // writer threads record events while a drainer thread concurrently bumps
-        // the drain epoch and intrusively drains, exploring interleavings
-        // exhaustively instead of sampling them. Every recorded event must reach
-        // the collector exactly once, regardless of schedule.
-        //
-        // Keeping real-thread proptest above because of the `Ordering::Relaxed` caveat
-        // this scenario shares with the others below (see module comments).
+        // exhaustively explores interleavings instead of sampling. Keeping
+        // the real-thread proptest too, for the `Ordering::Relaxed` caveat above.
         fn shuttle_concurrent_record_and_drain() {
             let ss = Arc::new(enabled_shared_state());
 
@@ -628,19 +617,12 @@ mod shuttle_tests {
     crate::shuttle_test! {
         default;
         // `disable`/`enable`/`mark_stopped` raced against the recording
-        // gate, `if_enabled` -> `EventBuffer::record_encodable_event`. The
-        // shutdown-adjacent lifecycle transition other tests in this crate
-        // skip (they `enable()` once at setup and never leave `Enabled`).
-        //
-        // Every `Some` return must land exactly one event in the collector,
-        // and every `None` must record nothing, so the collector total equals the number
-        // of `Some`s, no matter where `disable`/`enable`/`mark_stopped`
-        // interleave.
-        //
-        // This does NOT assert "no events arrive after disable()". A writer that passed
-        // `is_enabled()` completes its write after `disable()` returns (by design).
-        //
-        // Also subject to the `Ordering::Relaxed` caveat (see module comments).
+        // gate (`if_enabled`). The shutdown-adjacent transition other
+        // tests skip. Every `Some` must land exactly one event, every
+        // `None` zero, regardless of interleaving. Does NOT assert "no
+        // events after disable()": a writer that passed `is_enabled()`
+        // completes its write after `disable()` returns, by design. Also
+        // subject to the `Ordering::Relaxed` caveat above.
         fn shuttle_disable_races_record() {
             let ss = Arc::new(enabled_shared_state());
 
@@ -713,14 +695,10 @@ mod shuttle_tests {
     crate::shuttle_test! {
         default;
         // Writer threads exit *while* the drainer is mid-drain, so the TLB
-        // `Drop` flush (`encoder.rs`'s thread-local buffer handle) overlaps
-        // `drain_all_tl_buffers`'s `Weak::upgrade` + prune logic.
-        //
-        // Whether a writer still holds a pending event at exit is schedule-dependent.
-        // So some interleavings exercise upgrade-vs-teardown without exercising the
-        // `Drop` flush itself.
-        //
-        // Also subject to the `Ordering::Relaxed` caveat (see module comments).
+        // `Drop` flush overlaps `drain_all_tl_buffers`'s `Weak::upgrade`+prune
+        // logic. Not every interleaving exercises the `Drop` flush itself,
+        // since that depends on whether a writer still holds a pending event
+        // at exit. Also subject to the `Ordering::Relaxed` caveat above.
         fn shuttle_writer_exit_races_drain() {
             let ss = Arc::new(enabled_shared_state());
 

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -771,19 +771,38 @@ mod tests {
 
     crate::shuttle_test! {
         default;
-        // Writer threads exit *while* the drainer is mid-drain, so the TLB
-        // `Drop` flush overlaps `drain_all_tl_buffers`'s `Weak::upgrade`+prune
-        // logic. Not every interleaving exercises the `Drop` flush itself,
-        // since that depends on whether a writer still holds a pending event
-        // at exit. Also subject to the `Ordering::Relaxed` caveat above.
+        // Writer threads emit one event through `Dial9Handle` and exit
+        // immediately, racing `run_flush_loop`'s own ~5ms polling +
+        // grace-period cadence. Each writer holds exactly one event, so
+        // a plain id-presence check works regardless of which path
+        // flushed it. Also subject to the `Ordering::Relaxed` caveat above.
         fn shuttle_writer_exit_races_drain() {
-            let ss = Arc::new(enabled_shared_state());
+            let _ts_guard = metrique_timesource::set_time_source(
+                metrique_timesource::TimeSource::custom(
+                    metrique_timesource::fakes::StaticTimeSource::at_time(std::time::UNIX_EPOCH),
+                ),
+            );
+
+            let writer = MemoryBuffer::builder()
+                .max_total_size(100 * 1024 * 1024)
+                .max_segment_size(256)
+                .build()
+                .unwrap();
+            let fs = writer.fs_handle().expect("in-memory writer exposes its fs");
+
+            let shared = Arc::new(SharedState::new(0));
+            let mut recorder = Recorder::start(shared, writer, None, || || {});
+            recorder.handle().enable();
+            let handle = recorder.handle().clone();
 
             let writers: Vec<_> = (0..WRITERS)
-                .map(|_| {
-                    let ss = ss.clone();
+                .map(|id| {
+                    let handle = handle.clone();
                     crate::primitives::thread::spawn(move || {
-                        ss.if_enabled(|buf| buf.record_encodable_event(&sample_event()));
+                        handle.record_event(LifecycleEvent {
+                            timestamp_ns: id as u64,
+                            id: id as u64,
+                        });
                         // Return immediately: the next scheduling points are
                         // the thread-local destructor, the final `Arc`
                         // decrement, and the `Mutex` drop.
@@ -791,43 +810,21 @@ mod tests {
                 })
                 .collect();
 
-            let drainer = {
-                let ss = ss.clone();
-                crate::primitives::thread::spawn(move || {
-                    for _ in 0..DRAIN_TICKS {
-                        ss.bump_drain_epoch();
-                        // No `yield_now` grace here, unlike
-                        // `shuttle_concurrent_record_and_drain`: draining
-                        // while handles are still live is the point.
-                        ss.drain_all_tl_buffers();
-                    }
-                })
-            };
-
-            // Deliberately NOT joined before the drainer runs.
             for w in writers {
                 w.join().unwrap();
             }
-            drainer.join().unwrap();
 
-            ss.bump_drain_epoch();
-            ss.drain_all_tl_buffers();
+            // Flushes, seals the final segment, joins the flush thread.
+            recorder.stop_flush_thread();
 
-            let mut total = 0u64;
-            while let Some(batch) = ss.collector.next() {
-                assert!(batch.event_count() > 0, "empty batch reached collector");
-                total += batch.event_count();
-            }
-            assert_eq!(ss.collector.take_dropped_batches(), 0);
+            let decoded = decode_all_lifecycle_events(&fs);
+            let mut ids: Vec<u64> = decoded.iter().map(|e| e.id).collect();
+            ids.sort_unstable();
             assert_eq!(
-                total, WRITERS as u64,
+                ids,
+                (0..WRITERS as u64).collect::<Vec<_>>(),
                 "each writer's event must arrive exactly once, whether flushed by \
-                 the intrusive drain or by the TLB Drop impl on thread exit"
-            );
-            assert_eq!(
-                ss.tl_buffers.lock().unwrap().len(),
-                0,
-                "all handles are dead after join; the final drain must prune them"
+                 the flush loop's intrusive drain or by the TLB Drop impl on thread exit"
             );
         }
     }

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -607,6 +607,7 @@ mod shuttle_tests {
 
             let mut total: u64 = 0;
             while let Some(batch) = ss.collector.next() {
+                assert!(batch.event_count() > 0, "empty batch reached collector");
                 total += batch.event_count();
             }
             assert_eq!(
@@ -626,7 +627,10 @@ mod shuttle_tests {
 
     crate::shuttle_test! {
         default;
-        // `disable()` raced against the recording gate, `if_enabled`
+        // `disable`/`enable`/`mark_stopped` raced against the recording
+        // gate, `if_enabled` -> `EventBuffer::record_encodable_event`. The
+        // shutdown-adjacent lifecycle transition other tests in this crate
+        // skip (they `enable()` once at setup and never leave `Enabled`).
         //
         // Every `Some` return must land exactly one event in the collector,
         // and every `None` must record nothing, so the collector total equals the number
@@ -684,6 +688,8 @@ mod shuttle_tests {
             assert!(ss.is_stopped(), "Stopped must be terminal");
             ss.enable();
             assert!(!ss.is_enabled(), "enable() must be a no-op once stopped");
+            ss.disable();
+            assert!(ss.is_stopped(), "disable() must not un-stop a terminal state");
 
             // Drain happens after `mark_stopped`: draining is
             // state-independent, so buffered events are still recoverable
@@ -693,6 +699,7 @@ mod shuttle_tests {
 
             let mut total = 0u64;
             while let Some(batch) = ss.collector.next() {
+                assert!(batch.event_count() > 0, "empty batch reached collector");
                 total += batch.event_count();
             }
             assert_eq!(ss.collector.take_dropped_batches(), 0);
@@ -753,6 +760,7 @@ mod shuttle_tests {
 
             let mut total = 0u64;
             while let Some(batch) = ss.collector.next() {
+                assert!(batch.event_count() > 0, "empty batch reached collector");
                 total += batch.event_count();
             }
             assert_eq!(ss.collector.take_dropped_batches(), 0);

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -548,68 +548,6 @@ mod tests {
     // space, unlike a real-thread proptest.
     const WRITERS: usize = 3;
     const EVENTS_PER_WRITER: u64 = 3;
-    const DRAIN_TICKS: usize = 3;
-
-    crate::shuttle_test! {
-        default;
-        // Shuttle counterpart of `concurrent_record_and_drain_preserves_event_count`:
-        // exhaustively explores interleavings instead of sampling. Keeping
-        // the real-thread proptest too, for the `Ordering::Relaxed` caveat above.
-        fn shuttle_concurrent_record_and_drain() {
-            let ss = Arc::new(enabled_shared_state());
-
-            let writers: Vec<_> = (0..WRITERS)
-                .map(|_| {
-                    let ss = ss.clone();
-                    crate::primitives::thread::spawn(move || {
-                        for _ in 0..EVENTS_PER_WRITER {
-                            ss.record_encodable_event(&sample_event());
-                        }
-                    })
-                })
-                .collect();
-
-            let drainer = {
-                let ss = ss.clone();
-                crate::primitives::thread::spawn(move || {
-                    for _ in 0..DRAIN_TICKS {
-                        ss.bump_drain_epoch();
-                        // Grace period for an in-flight writer to self-flush
-                        // before the intrusive drain locks its buffer, mirroring
-                        // the real flush loop's tick-then-drain gap.
-                        shuttle::thread::yield_now();
-                        ss.drain_all_tl_buffers();
-                    }
-                })
-            };
-
-            for w in writers {
-                w.join().unwrap();
-            }
-            drainer.join().unwrap();
-
-            // Writers have exited, so their TLB `Drop` impls flushed any
-            // remaining events. Final bump+drain prunes dead handles.
-            ss.bump_drain_epoch();
-            ss.drain_all_tl_buffers();
-
-            let mut total: u64 = 0;
-            while let Some(batch) = ss.collector.next() {
-                assert!(batch.event_count() > 0, "empty batch reached collector");
-                total += batch.event_count();
-            }
-            assert_eq!(
-                ss.collector.take_dropped_batches(),
-                0,
-                "collector must not evict a batch under this workload"
-            );
-            assert_eq!(
-                total,
-                WRITERS as u64 * EVENTS_PER_WRITER,
-                "every recorded event must reach the collector exactly once"
-            );
-        }
-    }
 
     const LIFECYCLE_WRITERS: usize = 2;
 

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -313,25 +313,23 @@ impl EventBuffer<'_> {
 }
 
 #[cfg(test)]
-fn sample_event() -> crate::format::ClockSyncEvent {
-    crate::format::ClockSyncEvent {
-        timestamp_ns: 1000,
-        realtime_ns: 2000,
-    }
-}
-
-/// Helper: create a SharedState with recording enabled.
-#[cfg(test)]
-fn enabled_shared_state() -> SharedState {
-    let ss = SharedState::new(0);
-    ss.enable();
-    ss
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use crate::primitives::sync::atomic::AtomicBool;
+
+    fn sample_event() -> crate::format::ClockSyncEvent {
+        crate::format::ClockSyncEvent {
+            timestamp_ns: 1000,
+            realtime_ns: 2000,
+        }
+    }
+
+    /// Helper: create a SharedState with recording enabled.
+    fn enabled_shared_state() -> SharedState {
+        let ss = SharedState::new(0);
+        ss.enable();
+        ss
+    }
 
     #[test]
     fn record_event_registers_tl_buffer_handle() {
@@ -535,15 +533,14 @@ mod tests {
             );
         }
     }
-}
 
-// Every scenario below shares a caveat: `drain_epoch`/`flush_epoch`/`state`
-// are `Ordering::Relaxed`, but shuttle 0.9.1 treats every ordering as
-// `SeqCst`. A `Relaxed`-specific bug is invisible here no matter how
-// exhaustively a scenario searches.
-#[cfg(all(test, shuttle))]
-mod shuttle_tests {
-    use super::*;
+    // Every scenario below shares a caveat: `drain_epoch`/`flush_epoch`/`state`
+    // are `Ordering::Relaxed`, but shuttle 0.9.1 treats every ordering as
+    // `SeqCst`. A `Relaxed`-specific bug is invisible here no matter how
+    // exhaustively a scenario searches.
+    #[cfg(shuttle)]
+    mod shuttle_tests {
+        use super::*;
 
     // Small values kept: shuttle's search cost grows with interleaving
     // space, unlike a real-thread proptest.
@@ -753,5 +750,6 @@ mod shuttle_tests {
                 "all handles are dead after join; the final drain must prune them"
             );
         }
+    }
     }
 }

--- a/dial9-core/src/shared_state.rs
+++ b/dial9-core/src/shared_state.rs
@@ -541,6 +541,8 @@ mod tests {
     #[cfg(shuttle)]
     mod shuttle_tests {
         use super::*;
+        use crate::buffer::MemoryBuffer;
+        use crate::recording::Recorder;
 
     // Small values kept: shuttle's search cost grows with interleaving
     // space, unlike a real-thread proptest.
@@ -611,80 +613,158 @@ mod tests {
 
     const LIFECYCLE_WRITERS: usize = 2;
 
+    // Shared with `shuttle_writer_exit_races_drain`: both drive a
+    // `Recorder`/flush thread and assert only on decoded, sealed output.
+
+    /// Round-trip event recorded through [`Dial9Handle`](crate::handle::Dial9Handle).
+    #[derive(dial9_trace_format::TraceEvent, Clone, Debug, serde::Deserialize)]
+    struct LifecycleEvent {
+        #[traceevent(timestamp)]
+        timestamp_ns: u64,
+        id: u64,
+    }
+
+    fn decode_lifecycle_events(data: &[u8]) -> Vec<LifecycleEvent> {
+        use dial9_trace_format::decoder::Decoder;
+        let Some(mut dec) = Decoder::new(data) else {
+            assert!(data.is_empty(), "failed to decode a non-empty segment");
+            return vec![];
+        };
+        let mut out = Vec::new();
+        dec.for_each_event(|ev| {
+            if ev.name == "LifecycleEvent"
+                && let Ok(decoded) = ev.deserialize::<LifecycleEvent>()
+            {
+                out.push(decoded);
+            }
+        })
+        .expect("decode failed");
+        out
+    }
+
+    /// Drain every sealed segment the in-memory writer has produced so far.
+    fn decode_all_lifecycle_events(fs: &crate::fs::Fs) -> Vec<LifecycleEvent> {
+        let mut decoded = Vec::new();
+        loop {
+            let taken = fs.take_files();
+            if taken.segments.is_empty() {
+                break;
+            }
+            for seg in taken.segments {
+                let (_seg_ref, payload, _accounting) = seg.load().unwrap();
+                decoded.extend(decode_lifecycle_events(&payload.into_vec()));
+            }
+        }
+        decoded
+    }
+
     crate::shuttle_test! {
         default;
-        // `disable`/`enable`/`mark_stopped` raced against the recording
-        // gate (`if_enabled`). The shutdown-adjacent transition other
-        // tests skip. Every `Some` must land exactly one event, every
-        // `None` zero, regardless of interleaving. Does NOT assert "no
-        // events after disable()": a writer that passed `is_enabled()`
-        // completes its write after `disable()` returns, by design. Also
-        // subject to the `Ordering::Relaxed` caveat above.
+        // `disable`/`enable` raced against recording, through the
+        // `Recorder`/`Dial9Handle`/flush-thread stack. `record_event`
+        // doesn't report whether a call actually landed, so this checks
+        // decoded output directly: no duplicate ids, no un-attempted
+        // ids, and `Stopped` stays terminal under a raced `enable`/
+        // `disable`. Also subject to the `Ordering::Relaxed` caveat above.
         fn shuttle_disable_races_record() {
-            let ss = Arc::new(enabled_shared_state());
+            let _ts_guard = metrique_timesource::set_time_source(
+                metrique_timesource::TimeSource::custom(
+                    metrique_timesource::fakes::StaticTimeSource::at_time(std::time::UNIX_EPOCH),
+                ),
+            );
+
+            // Small segments so the writer/drain race actually forces
+            // rotation; the total budget is far above this test's data so
+            // the ring never evicts before we drain it.
+            let writer = MemoryBuffer::builder()
+                .max_total_size(100 * 1024 * 1024)
+                .max_segment_size(256)
+                .build()
+                .unwrap();
+            let fs = writer.fs_handle().expect("in-memory writer exposes its fs");
+
+            let shared = Arc::new(SharedState::new(0));
+            let mut recorder = Recorder::start(shared, writer, None, || || {});
+            recorder.handle().enable();
+            let handle = recorder.handle().clone();
+
+            let next_id = Arc::new(AtomicU64::new(0));
+            let attempted: Arc<Mutex<Vec<u64>>> = Arc::new(Mutex::new(Vec::new()));
 
             let writers: Vec<_> = (0..LIFECYCLE_WRITERS)
                 .map(|_| {
-                    let ss = ss.clone();
+                    let handle = handle.clone();
+                    let next_id = next_id.clone();
+                    let attempted = attempted.clone();
                     crate::primitives::thread::spawn(move || {
-                        let mut recorded = 0u64;
                         for _ in 0..EVENTS_PER_WRITER {
-                            // Production entry point, not the `#[cfg(test)]`
-                            // `SharedState::record_encodable_event` shortcut:
-                            // the enabled check and the write must be one call.
-                            if ss
-                                .if_enabled(|buf| buf.record_encodable_event(&sample_event()))
-                                .is_some()
-                            {
-                                recorded += 1;
-                            }
+                            let id = next_id.fetch_add(1, Ordering::Relaxed);
+                            attempted.lock().unwrap().push(id);
+                            handle.record_event(LifecycleEvent {
+                                timestamp_ns: id,
+                                id,
+                            });
                         }
-                        recorded
                     })
                 })
                 .collect();
 
             let lifecycle = {
-                let ss = ss.clone();
+                let handle = handle.clone();
                 crate::primitives::thread::spawn(move || {
-                    ss.disable(); // Enabled -> Disabled
-                    ss.enable(); // Disabled -> Enabled (re-arm)
-                    ss.disable();
-                    ss.mark_stopped(); // terminal
+                    handle.disable(); // Enabled -> Disabled
+                    handle.enable(); // Disabled -> Enabled (re-arm)
+                    handle.disable();
                 })
             };
 
-            let mut expected = 0u64;
             for w in writers {
-                expected += w.join().unwrap();
+                w.join().unwrap();
             }
             lifecycle.join().unwrap();
+
+            // Flushes, seals the final segment, joins the flush thread,
+            // then calls `SharedState::mark_stopped`.
+            recorder.stop_flush_thread();
 
             // `Stopped` is terminal regardless of schedule: a `disable()` or
             // `enable()` that lost the race must not have clobbered it back
             // to a live state. Catches a CAS -> plain `store` regression in
             // either.
-            assert!(ss.is_stopped(), "Stopped must be terminal");
-            ss.enable();
-            assert!(!ss.is_enabled(), "enable() must be a no-op once stopped");
-            ss.disable();
-            assert!(ss.is_stopped(), "disable() must not un-stop a terminal state");
+            assert!(handle.is_stopped(), "Stopped must be terminal");
+            handle.enable();
+            assert!(!handle.is_enabled(), "enable() must be a no-op once stopped");
+            handle.disable();
+            assert!(
+                handle.is_stopped(),
+                "disable() must not un-stop a terminal state"
+            );
 
-            // Drain happens after `mark_stopped`: draining is
-            // state-independent, so buffered events are still recoverable
-            // at shutdown.
-            ss.bump_drain_epoch();
-            ss.drain_all_tl_buffers();
+            let decoded = decode_all_lifecycle_events(&fs);
+            let attempted = attempted.lock().unwrap();
+            let attempted_ids: std::collections::HashSet<u64> =
+                attempted.iter().copied().collect();
 
-            let mut total = 0u64;
-            while let Some(batch) = ss.collector.next() {
-                assert!(batch.event_count() > 0, "empty batch reached collector");
-                total += batch.event_count();
+            let mut decoded_ids: Vec<u64> = decoded.iter().map(|e| e.id).collect();
+            for id in &decoded_ids {
+                assert!(
+                    attempted_ids.contains(id),
+                    "decoded event id {id} was never attempted"
+                );
             }
-            assert_eq!(ss.collector.take_dropped_batches(), 0);
+            decoded_ids.sort_unstable();
+            let mut deduped = decoded_ids.clone();
+            deduped.dedup();
             assert_eq!(
-                total, expected,
-                "every if_enabled that returned Some must yield exactly one event"
+                deduped.len(),
+                decoded_ids.len(),
+                "an event id was recorded more than once: {decoded_ids:?}"
+            );
+            assert!(
+                decoded_ids.len() <= attempted.len(),
+                "more events landed ({}) than were ever attempted ({})",
+                decoded_ids.len(),
+                attempted.len()
             );
         }
     }


### PR DESCRIPTION
#764 

## Summary
- Adds `shuttle` coverage for `SharedState` concurrency paths
  - writer/drainer race on the intrusive-drain path (shuttle counterpart of the existing real-thread proptest)
  - `disable`/`enable`/`mark_stopped` raced against concurrent recording
  - writer's thread-exit flush racing `drain_all_tl_buffers`

## Notes
- New scenarios were mutation-tested.
- Scoped to `SharedState`
- `drain_epoch`/`flush_epoch`/`state` are `Ordering::Relaxed`; shuttle only models `SeqCst`. A `Relaxed`-specific bug would slip through (that's why the proptest is kept)
- `shuttle_disable_races_record` doesn't assert "no events after `disable()`". The gate is load-then-record, not atomic, so that's expected behavior.
- `shuttle_writer_exit_races_drain` covers a distinct interleaving shape, but mutation testing didn't turn up a bug only it catches