### PR TITLE
fix(viewer): expand inlined frames innermost-first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(viewer)* inlined frames no longer render upside down. Both the server-side
+  aggregation path and `symbolizeChain` flattened an address's inline group
+  outermost-first inside a leaf→root callchain, so every inline edge appeared
+  reversed — a callee looked like the caller of the function it was inlined into
+  (for example `make_poll_start` calling `record_poll_start`). The group is now
+  emitted innermost-first, keeping the flat chain uniformly leaf→root.
+  `SAMPLES_FORMAT_VERSION` is bumped to 9, so cached aggregate rollups written
+  with the old ordering are abandoned and repopulate lazily.
+
 ## [0.5.0](https://github.com/dial9-rs/dial9/compare/dial9-v0.5.0-rc2.1...dial9-v0.5.0) - 2026-08-26
 
 ### Fixed

--- a/dial9-viewer/skills/dial9-html-report/SKILL.md
+++ b/dial9-viewer/skills/dial9-html-report/SKILL.md
@@ -259,7 +259,8 @@ Place standalone flamegraph files in `report/flamegraphs/<name>.html`. They load
 **Key points:**
 - `buildWorkerSpans` + `attachCpuSamples` decorates each sample with `.spawnLoc` (the source location where the task was spawned). This is required for any recipe that filters by spawn location.
 - Polls in `ws.workerSpans[workerId].polls` have `.taskId`, `.start`, `.end`. Use these to filter samples by task or by poll duration.
-- `trace.callframeSymbols` is a `Map<string, entry|entry[]>` where each entry is `{symbol, location}`. Array entries are inlined frames (index 0 = outermost).
+- `trace.callframeSymbols` is a `Map<string, entry|entry[]>` where each entry is `{symbol, location}`. An array value means the address has inlined frames, indexed by inline depth: index 0 is the function that owns the machine code and the last index is the innermost inlined callee (the frame actually executing). `symbolizeChain` flattens this the right way round; hand-rolled lookups must pick the last element for a leaf.
+- `sample.callchain` is leaf→root: `callchain[0]` is the on-CPU frame, the last element is the outermost caller.
 
 ### Recipes
 
@@ -360,16 +361,17 @@ const samples = trace.cpuSamples.filter(s =>
 ```js
 const SEARCH = 'load_native_certs';
 const samples = trace.cpuSamples.filter(s => {
-  const leaf = s.callchain[s.callchain.length - 1];
+  const leaf = s.callchain[0]; // callchain is leaf→root
   const sym = trace.callframeSymbols.get(leaf);
   if (!sym) return false;
-  // Handle both plain entries and inlined-frame arrays
-  const name = Array.isArray(sym) ? sym[0].symbol : sym.symbol;
+  // Handle both plain entries and inlined-frame arrays. For an array the
+  // innermost inlined callee is the last element — that is the leaf.
+  const name = Array.isArray(sym) ? sym[sym.length - 1].symbol : sym.symbol;
   return name && name.includes(SEARCH);
 });
 ```
 
-**When NOT to use:** When you want to find a function *anywhere* in the stack (not just at the leaf). Remove the `[s.callchain.length - 1]` indexing and iterate all frames with `.some()` instead.
+**When NOT to use:** When you want to find a function *anywhere* in the stack (not just at the leaf). Drop the `[0]` indexing and iterate all frames with `.some()` instead.
 
 ---
 

--- a/dial9-viewer/src/ingest/aggregate.rs
+++ b/dial9-viewer/src/ingest/aggregate.rs
@@ -42,7 +42,7 @@ pub(crate) const ORDER_VERSION: u32 = 1;
 /// repopulates lazily. The value is a monotonic cache namespace, not a schema
 /// revision, so skipped values are expected. The old tree is abandoned and
 /// GC'd out-of-band.
-pub const SAMPLES_FORMAT_VERSION: u32 = 8;
+pub const SAMPLES_FORMAT_VERSION: u32 = 9;
 
 /// Default raw-trace segment duration, in seconds. A source file covers
 /// `[epoch, epoch + segment_duration)`; the [`Scope`] time filter pads by this

--- a/dial9-viewer/src/ingest/decode.rs
+++ b/dial9-viewer/src/ingest/decode.rs
@@ -30,6 +30,7 @@ pub(crate) mod spans;
 mod types;
 
 use events::*;
+use lasso::{Rodeo, Spur};
 use rustc_hash::FxHashMap;
 #[cfg(test)]
 use spans::span_builder;
@@ -50,6 +51,45 @@ fn parse_source_key(key: &str) -> Option<(String, String, String)> {
 /// on directly opened or custom keys.
 fn unknown_source_fields() -> (String, String, String) {
     (String::new(), String::new(), String::new())
+}
+
+/// Flatten a callchain into frame names, expanding each address's inlined
+/// frames, and feed the names to `hasher` for the stack id.
+///
+/// Both the input callchain and the returned vector are leaf→root. `addr_to_keys`
+/// holds an address's symbols sorted ascending by inline depth (0 = the function
+/// that owns the machine code, 1..N = successively deeper inlined callees), so
+/// the group is emitted in *descending* depth order: the innermost inlined
+/// callee is nearest the leaf. Emitting depth 0 first would make the consumer's
+/// wholesale `.rev()` (see `server::flamegraph::build_flamegraph_tree`) invert
+/// every inline group, showing a callee as the caller of the function it was
+/// inlined into.
+///
+/// Addresses with no symbol entry contribute a single `0x…` frame.
+fn flatten_callchain(
+    callchain: &[u64],
+    addr_to_keys: &FxHashMap<u64, Vec<(u64, Spur)>>,
+    interner: &Rodeo,
+    hasher: &mut blake3::Hasher,
+) -> Vec<String> {
+    let mut frame_strings: Vec<String> = Vec::with_capacity(callchain.len());
+    for &addr in callchain {
+        match addr_to_keys.get(&addr) {
+            Some(entries) => {
+                for (_, key) in entries.iter().rev() {
+                    frame_strings.push(interner.resolve(key).to_string());
+                }
+            }
+            None => frame_strings.push(format!("0x{addr:x}")),
+        }
+    }
+    for (i, frame) in frame_strings.iter().enumerate() {
+        if i > 0 {
+            hasher.update(b"\x00");
+        }
+        hasher.update(frame.as_bytes());
+    }
+    frame_strings
 }
 
 /// Extract CPU samples from raw (already gunzipped) trace bytes.
@@ -168,30 +208,8 @@ pub(crate) fn decode_samples_with_stats(
                     cached
                 } else {
                     let mut hasher = blake3::Hasher::new();
-                    let mut first = true;
-                    let mut frame_strings: Vec<String> = Vec::new();
-
-                    for &addr in &s.callchain {
-                        if let Some(entries) = addr_to_keys.get(&addr) {
-                            for (_, key) in entries {
-                                let name = interner.resolve(key);
-                                if !first {
-                                    hasher.update(b"\x00");
-                                }
-                                hasher.update(name.as_bytes());
-                                frame_strings.push(name.to_string());
-                                first = false;
-                            }
-                        } else {
-                            let hex = format!("0x{addr:x}");
-                            if !first {
-                                hasher.update(b"\x00");
-                            }
-                            hasher.update(hex.as_bytes());
-                            frame_strings.push(hex);
-                            first = false;
-                        }
-                    }
+                    let frame_strings =
+                        flatten_callchain(&s.callchain, &addr_to_keys, &interner, &mut hasher);
 
                     if frame_strings.is_empty() {
                         continue;
@@ -514,6 +532,56 @@ fn union_intervals(intervals: &[(u64, u64)]) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// An inlined callee must land *below* (nearer the leaf than) the function
+    /// it was inlined into, because the flamegraph builder reverses the whole
+    /// frame vector. Getting this backwards renders impossible edges such as
+    /// `make_poll_start` calling `record_poll_start`.
+    #[test]
+    fn inlined_frames_flatten_innermost_first() {
+        let mut interner = Rodeo::default();
+        let outer = interner.get_or_intern("record_poll_start::{{closure}}");
+        let inner = interner.get_or_intern("make_poll_start");
+        let root = interner.get_or_intern("main");
+
+        let mut addr_to_keys: FxHashMap<u64, Vec<(u64, Spur)>> = FxHashMap::default();
+        // Symbols arrive sorted ascending by inline depth, as decode does.
+        addr_to_keys.insert(0x1000, vec![(0, outer), (1, inner)]);
+        addr_to_keys.insert(0x2000, vec![(0, root)]);
+
+        let mut hasher = blake3::Hasher::new();
+        // Callchain is leaf→root.
+        let frames = flatten_callchain(&[0x1000, 0x2000], &addr_to_keys, &interner, &mut hasher);
+        assert_eq!(
+            frames,
+            vec!["make_poll_start", "record_poll_start::{{closure}}", "main"],
+            "inlined callee must precede its containing function in a leaf→root stack"
+        );
+
+        // Root→leaf order, as the flamegraph trie walks it.
+        let caller_to_callee: Vec<&String> = frames.iter().rev().collect();
+        let inner_pos = caller_to_callee
+            .iter()
+            .position(|f| f.as_str() == "make_poll_start")
+            .unwrap();
+        let outer_pos = caller_to_callee
+            .iter()
+            .position(|f| f.as_str() == "record_poll_start::{{closure}}")
+            .unwrap();
+        assert!(
+            outer_pos < inner_pos,
+            "record_poll_start must be the parent of make_poll_start, got {caller_to_callee:?}"
+        );
+    }
+
+    #[test]
+    fn unsymbolized_addresses_flatten_to_hex_frames() {
+        let interner = Rodeo::default();
+        let addr_to_keys: FxHashMap<u64, Vec<(u64, Spur)>> = FxHashMap::default();
+        let mut hasher = blake3::Hasher::new();
+        let frames = flatten_callchain(&[0xdead, 0xbeef], &addr_to_keys, &interner, &mut hasher);
+        assert_eq!(frames, vec!["0xdead", "0xbeef"]);
+    }
 
     #[test]
     fn parse_source_key_supports_current_and_historical_layouts() {

--- a/dial9-viewer/tests/fixtures/demo-trace.properties.json
+++ b/dial9-viewer/tests/fixtures/demo-trace.properties.json
@@ -28,7 +28,7 @@
   "cpu_profile": {
     "count": 165,
     "distinct_stacks": 134,
-    "stack_sig_digest": "abf0aa7db2bc5094",
+    "stack_sig_digest": "becb5a8f46408f00",
     "ts_count": 165,
     "ts_span_ns": 4474824362,
     "ts_delta_digest": "db1670ba3ca3d0ae",

--- a/dial9-viewer/ui/src/types/trace_parser.d.ts
+++ b/dial9-viewer/ui/src/types/trace_parser.d.ts
@@ -462,8 +462,9 @@ declare module "*/trace_parser.js" {
   ): { text: string; docsUrl: string | null };
 
   /**
-   * Resolve a callchain (address strings) to frames; inlined frames are
-   * expanded in place (outermost first).
+   * Resolve a callchain (address strings) to frames. Leaf→root in, leaf→root
+   * out: an address's inlined frames are expanded in place innermost callee
+   * first, so `[0]` is always the leaf.
    */
   export function symbolizeChain(
     callchain: readonly string[],

--- a/dial9-viewer/ui/tests/core/trace_analysis.test.ts
+++ b/dial9-viewer/ui/tests/core/trace_analysis.test.ts
@@ -19,9 +19,10 @@ import { fileURLToPath } from "node:url";
 
 const require = createRequire(import.meta.url);
 
-const { EVENT_TYPES, parseTrace } = require("../../trace_parser.js") as {
+const { EVENT_TYPES, parseTrace, symbolizeChain } = require("../../trace_parser.js") as {
   EVENT_TYPES: Record<string, number>;
   parseTrace: (buf: Buffer) => Promise<any>;
+  symbolizeChain: (chain: string[], syms: Map<string, any>) => any[];
 };
 const {
   buildWorkerSpans,
@@ -779,6 +780,39 @@ describe("flamegraph", () => {
     ).toBe(1);
     const node = [...tree.children.values()][0] as any;
     expect(node.self, `unresolved node.self = ${node.self}, expected 1`).toBe(1);
+  });
+
+  // `symbolizeChain` returns a *flat* leaf→root chain, so it must expand an
+  // address's inline group in the opposite order to the tree walk above:
+  // innermost callee first. Consumers read [0] as the leaf or reverse the whole
+  // array; expanding depth-0-first inverted every inline edge, e.g. rendering
+  // `make_poll_start` as the caller of the `record_poll_start` closure it was
+  // inlined into.
+  it("symbolizeChain expands inlines innermost-first (leaf→root)", () => {
+    const callframeSymbols = new Map<string, any>([
+      [
+        "0x1000",
+        [
+          { symbol: "record_poll_start::{{closure}}", location: null },
+          { symbol: "make_poll_start", location: null },
+        ],
+      ],
+      ["0x2000", { symbol: "main", location: null }],
+    ]);
+    const chain = symbolizeChain(["0x1000", "0x2000"], callframeSymbols);
+    expect(chain.map((f) => f.symbol)).toEqual([
+      "make_poll_start",
+      "record_poll_start::{{closure}}",
+      "main",
+    ]);
+  });
+
+  it("symbolizeChain skips holes in sparse inline arrays", () => {
+    const sparse = new Array(3);
+    sparse[0] = { symbol: "outer_fn", location: null };
+    sparse[2] = { symbol: "leaf_fn", location: null };
+    const chain = symbolizeChain(["0x1000"], new Map<string, any>([["0x1000", sparse]]));
+    expect(chain.map((f) => f.symbol)).toEqual(["leaf_fn", "outer_fn"]);
   });
 
   it("weighted samples accumulate count, self, allocCount, selfAllocCount", () => {

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -2405,8 +2405,14 @@
 
     /**
      * Resolve a callchain (array of address strings) to frame objects.
-     * When an address has inlined frames (stored as an array in callframeSymbols),
-     * they are expanded in place (outermost first, then inlined callees).
+     *
+     * A callchain is leaf→root, and so is the returned array. An address with
+     * inlined frames is stored in `callframeSymbols` as an array indexed by
+     * inline depth (`[0]` = the function that owns the machine code, `[i>0]` =
+     * successively deeper inlined callees), so the group is expanded in place in
+     * *reverse*: innermost callee first, keeping the whole array leaf→root.
+     * Expanding it depth-0-first would make callers appear below their callees
+     * for consumers that read `[0]` as the leaf or reverse the array wholesale.
      * @param {string[]} callchain - Address strings like "0x55cc6d053893"
      * @param {Map<string, {symbol: string, location: string|null}|Array>} callframeSymbols
      * @returns {{symbol: string, location: string|null}[]}
@@ -2420,7 +2426,12 @@
                 continue;
             }
             if (Array.isArray(entry)) {
-                for (const e of entry) result.push(e);
+                for (let i = entry.length - 1; i >= 0; i--) {
+                    // Sparse arrays can miss an inline slot when a depth>0
+                    // SymbolTableEntry arrives without its depth-0 sibling.
+                    const e = entry[i];
+                    if (e) result.push(e);
+                }
                 continue;
             }
             if (typeof entry === "string") {

--- a/dial9-viewer/ui/trace_properties.js
+++ b/dial9-viewer/ui/trace_properties.js
@@ -80,7 +80,7 @@
 
   /**
    * The symbolized frame-name signature of a sample's callchain: the sequence
-   * of frame symbol names (inlines expanded, outermost→inlined), joined by
+   * of frame symbol names (leaf→root, inlines expanded innermost-first), joined by
    * {@link FRAME_SEP}. Hash-independent (no blake3 needed) and directly
    * comparable to the Rust side, which reconstructs the same names from its
    * stacks dictionary.

--- a/docs/aggregation-feature.md
+++ b/docs/aggregation-feature.md
@@ -119,7 +119,7 @@ Two independent version knobs, deliberately in opposite places:
 - **`ORDER_VERSION`** (= 1) lives *only* in the order-key hash input. Bump it to
   change the fetch-order permutation; persisted samples are order-independent
   and survive untouched.
-- **`SAMPLES_FORMAT_VERSION`** (= 8) lives *only* in the output path. Bump it
+- **`SAMPLES_FORMAT_VERSION`** (= 9) lives *only* in the output path. Bump it
   when changing *what* we persist; reads/writes then target a fresh empty tree
   that repopulates lazily on demand — no backfill job. The old tree is abandoned
   and GC'd out-of-band.


### PR DESCRIPTION
Fixes #855 

## The bug

The flamegraph rendered `make_poll_start` **calling** `record_poll_start::{{closure}}`. That is impossible — `record_poll_start` calls `make_poll_start` ([`runtime_context.rs:429`](https://github.com/dial9-rs/dial9/blob/main/dial9-tokio-telemetry/src/telemetry/recorder/runtime_context.rs#L429)). Every inline edge in the server-side flamegraph was upside down.

## Root cause

Stacks are **leaf→root** everywhere: perf callchains, the flat frame vectors in the stacks dictionary, and `build_flamegraph_tree`, which reverses the whole vector to walk root→leaf.

An address's *inline group* is stored the other way round, by design — blazesym reports depth 0 as the function that owns the machine code and 1..N as successively deeper inlined callees.

Both flat-chain builders expanded that group in depth order:

```
[ record_poll_start::{{closure}}, make_poll_start, <caller>, … ]
   ^ depth 0                      ^ depth 1
```

The address-level order then reversed correctly; every inline group reversed *wrongly*.

The local (non-`api`) JS flamegraph was never affected: `buildFlamegraphTree` walks the callchain end→0 and iterates each group 0→N, so it never reverses a group.

## Verification

I manually verified this fix.