### PR TITLE
test(dial-9-core) add shuttle worker time coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,6 +1582,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot 0.5.0",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -1594,6 +1595,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -1895,6 +1897,7 @@ dependencies = [
  "proptest",
  "serde",
  "shuttle",
+ "shuttle-tokio",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -4871,6 +4874,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "shuttle-tokio"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e54c16acf992b3f2ed76597b4bccbc266700063a809f36a91cb2103c242a59b"
+dependencies = [
+ "cfg-if",
+ "shuttle-tokio-impl",
+ "tokio",
+]
+
+[[package]]
+name = "shuttle-tokio-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68e20b41b8c88313b9818ed34809a1def3a962ce9c93387854616ffdcf96a60b"
+dependencies = [
+ "cfg-if",
+ "shuttle-tokio-impl-inner",
+ "tokio",
+]
+
+[[package]]
+name = "shuttle-tokio-impl-inner"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5e5de67dd9ac801b4299fc15f063ce00be1c64acc72850dcb045b14473187e"
+dependencies = [
+ "criterion 0.5.1",
+ "futures",
+ "pin-project",
+ "regex",
+ "shuttle",
+ "shuttle-tokio-macros-impl",
+ "smallvec",
+ "test-log",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "shuttle-tokio-macros-impl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0c94fc6e0f817b69ca12a686a8c6a0de3664b343ba09bee3ad850385532efb"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "shuttle",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5079,6 +5136,37 @@ checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1"
+dependencies = [
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-core"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
+dependencies = [
+ "syn 2.0.119",
+ "test-log-core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1897,7 +1897,7 @@ dependencies = [
  "proptest",
  "serde",
  "shuttle",
- "shuttle-tokio",
+ "shuttle-tokio-impl-inner",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -4871,28 +4871,6 @@ dependencies = [
  "scoped-tls",
  "smallvec",
  "tracing",
-]
-
-[[package]]
-name = "shuttle-tokio"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e54c16acf992b3f2ed76597b4bccbc266700063a809f36a91cb2103c242a59b"
-dependencies = [
- "cfg-if",
- "shuttle-tokio-impl",
- "tokio",
-]
-
-[[package]]
-name = "shuttle-tokio-impl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e20b41b8c88313b9818ed34809a1def3a962ce9c93387854616ffdcf96a60b"
-dependencies = [
- "cfg-if",
- "shuttle-tokio-impl-inner",
- "tokio",
 ]
 
 [[package]]

--- a/dial9-core/Cargo.toml
+++ b/dial9-core/Cargo.toml
@@ -34,6 +34,10 @@ flate2 = { version = "1", optional = true }
 metrique = "0.1.28"
 metrique-timesource = "0.1"
 shuttle = { version = "0.9.1", optional = true }
+shuttle-tokio = { version = "0.1.0", default-features = false, features = [
+    "shuttle",
+    "macros",
+], optional = true }
 tracing = "0.1.44"
 
 [dev-dependencies]
@@ -57,7 +61,7 @@ tokio = { version = "1.52.0", features = [
 ] }
 
 [features]
-_shuttle = ["dep:shuttle", "pipeline"]
+_shuttle = ["dep:shuttle", "dep:shuttle-tokio", "pipeline"]
 ## Exposes recording internals (`Batch`, `CentralCollector`, `encode_single`,
 ## `drain_to_collector`) as `pub` for sibling-crate tests.
 test-util = []

--- a/dial9-core/Cargo.toml
+++ b/dial9-core/Cargo.toml
@@ -34,8 +34,7 @@ flate2 = { version = "1", optional = true }
 metrique = "0.1.28"
 metrique-timesource = "0.1"
 shuttle = { version = "0.9.1", optional = true }
-shuttle-tokio = { version = "0.1.0", default-features = false, features = [
-    "shuttle",
+shuttle-tokio-impl-inner = { version = "0.1.0", default-features = false, features = [
     "macros",
 ], optional = true }
 tracing = "0.1.44"
@@ -61,7 +60,7 @@ tokio = { version = "1.52.0", features = [
 ] }
 
 [features]
-_shuttle = ["dep:shuttle", "dep:shuttle-tokio", "pipeline"]
+_shuttle = ["dep:shuttle", "dep:shuttle-tokio-impl-inner", "pipeline"]
 ## Exposes recording internals (`Batch`, `CentralCollector`, `encode_single`,
 ## `drain_to_collector`) as `pub` for sibling-crate tests.
 test-util = []

--- a/dial9-core/src/dump.rs
+++ b/dial9-core/src/dump.rs
@@ -150,6 +150,12 @@ pub(crate) struct DumpRequest {
     pub(crate) receipt_tx: oneshot::Sender<Result<DumpReceipt, DumpError>>,
 }
 
+impl DumpRequest {
+    pub(crate) fn elapsed_since_trigger(&self) -> Duration {
+        crate::primitives::time::elapsed_since(self.triggered_at)
+    }
+}
+
 /// Leading-edge debounce gate shared across [`DumpTrigger`] clones.
 ///
 /// Records when the last accepted request was *built* and the [`DumpId`] it

--- a/dial9-core/src/primitives.rs
+++ b/dial9-core/src/primitives.rs
@@ -186,21 +186,19 @@ pub mod time {
     }
 }
 
-/// `tokio::select!` normally; `shuttle_tokio::select!` under `--cfg shuttle`.
+/// `tokio::select!` normally; `shuttle_tokio_impl_inner::select!` under
+/// `--cfg shuttle`, which patches `select!`'s branch tie-break to draw from
+/// `shuttle::rand::thread_rng()` instead of real OS entropy, so a replayed
+/// schedule picks the same branch every time.
 ///
-/// `select!`'s branch tie-break otherwise calls tokio's own `thread_rng_n`,
-/// seeded from real OS entropy per thread -- not shuttle-controlled, so a
-/// replayed schedule can pick a different branch. `shuttle-tokio` patches
-/// that one function to draw from `shuttle::rand::thread_rng()` instead.
-///
-/// Doesn't cover `sleep`/`sleep_until`: `shuttle-tokio`'s `Sleep` resolves
-/// immediately on first poll for any realistic deadline rather than
-/// suspending, so `primitives::time` keeps its own `Yield` for those.
+/// Doesn't cover `sleep`/`sleep_until`: its `Sleep` resolves immediately on
+/// first poll instead of suspending, so `primitives::time` keeps its own
+/// `Yield` for those.
 #[cfg(all(shuttle, feature = "pipeline"))]
 #[macro_export]
 macro_rules! shuttle_select {
     ($($arms:tt)*) => {
-        shuttle_tokio::select! { $($arms)* }
+        shuttle_tokio_impl_inner::select! { $($arms)* }
     };
 }
 #[cfg(all(not(shuttle), feature = "pipeline"))]

--- a/dial9-core/src/primitives.rs
+++ b/dial9-core/src/primitives.rs
@@ -45,6 +45,10 @@ pub use crate::define_thread_local as thread_local;
 #[cfg(all(not(shuttle), feature = "pipeline"))]
 pub mod time {
     pub use tokio::time::{Instant, sleep, sleep_until};
+
+    pub fn now() -> Instant {
+        Instant::now()
+    }
 }
 
 // ── shuttle path (deterministic testing) ────────────────────────────────────
@@ -134,12 +138,29 @@ pub use crate::define_thread_local as thread_local;
 
 #[cfg(all(shuttle, feature = "pipeline"))]
 pub mod time {
+    use std::cell::Cell;
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::task::{Context, Poll};
 
     pub use tokio::time::Instant;
+
+    // `Instant::now()` is nondeterministic under shuttle replay (real
+    // clock). `now()` reads a thread-local logical clock instead, advanced
+    // one tick per genuine `Yield` suspend, isolated per concurrently
+    // running `#[test]`.
+    std::thread_local! {
+        static LOGICAL_CLOCK: (Instant, Cell<u64>) = (Instant::now(), Cell::new(0));
+    }
+
+    // Comfortably clears this crate's current millisecond-scale test
+    // deadlines; not derived from anything principled.
+    const LOGICAL_TICK: std::time::Duration = std::time::Duration::from_millis(10);
+
+    pub fn now() -> Instant {
+        LOGICAL_CLOCK.with(|(base, nanos)| *base + std::time::Duration::from_nanos(nanos.get()))
+    }
 
     /// Shuttle has no virtual clock. Like `primitives::thread::sleep`, this
     /// is a single scheduling point, not a real delay.
@@ -179,6 +200,8 @@ pub mod time {
             } else {
                 self.yielded = true;
                 YIELD_PENDING_POLLS.fetch_add(1, Ordering::Relaxed);
+                LOGICAL_CLOCK
+                    .with(|(_, nanos)| nanos.set(nanos.get() + LOGICAL_TICK.as_nanos() as u64));
                 cx.waker().wake_by_ref();
                 Poll::Pending
             }

--- a/dial9-core/src/primitives.rs
+++ b/dial9-core/src/primitives.rs
@@ -42,6 +42,11 @@ macro_rules! define_thread_local {
 #[cfg(not(shuttle))]
 pub use crate::define_thread_local as thread_local;
 
+#[cfg(all(not(shuttle), feature = "pipeline"))]
+pub mod time {
+    pub use tokio::time::{Instant, sleep, sleep_until};
+}
+
 // ── shuttle path (deterministic testing) ────────────────────────────────────
 
 #[cfg(shuttle)]
@@ -126,6 +131,66 @@ macro_rules! define_thread_local {
 }
 #[cfg(shuttle)]
 pub use crate::define_thread_local as thread_local;
+
+#[cfg(all(shuttle, feature = "pipeline"))]
+pub mod time {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    pub use tokio::time::Instant;
+
+    /// Shuttle has no virtual clock. Like `primitives::thread::sleep`, this
+    /// is a single scheduling point, not a real delay.
+    pub fn sleep(_duration: std::time::Duration) -> Yield {
+        Yield::default()
+    }
+
+    pub fn sleep_until(_deadline: Instant) -> Yield {
+        Yield::default()
+    }
+
+    #[derive(Debug, Default)]
+    pub struct Yield {
+        yielded: bool,
+    }
+
+    impl Future for Yield {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.yielded {
+                Poll::Ready(())
+            } else {
+                self.yielded = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+}
+
+/// `tokio::select!`, `biased;` only under `--cfg shuttle`.
+///
+/// `select!`'s branch tie-break otherwise calls tokio's own internal RNG,
+/// which isn't shuttle-controlled.
+///
+/// Production keeps randomized `select!` unchanged.
+#[cfg(all(shuttle, feature = "pipeline"))]
+#[macro_export]
+macro_rules! shuttle_select {
+    ($($arms:tt)*) => {
+        tokio::select! { biased; $($arms)* }
+    };
+}
+#[cfg(all(not(shuttle), feature = "pipeline"))]
+#[macro_export]
+macro_rules! shuttle_select {
+    ($($arms:tt)*) => {
+        tokio::select! { $($arms)* }
+    };
+}
+#[cfg(feature = "pipeline")]
+pub use crate::shuttle_select;
 
 /// Pairs a shuttle scenario with `check_pct` and `check_uncontrolled_nondeterminism`
 /// Nests the scenario in its own module so `pct`/`determinism` can be fixed leaf names.

--- a/dial9-core/src/primitives.rs
+++ b/dial9-core/src/primitives.rs
@@ -136,6 +136,7 @@ pub use crate::define_thread_local as thread_local;
 pub mod time {
     use std::future::Future;
     use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::task::{Context, Poll};
 
     pub use tokio::time::Instant;
@@ -155,6 +156,21 @@ pub mod time {
         yielded: bool,
     }
 
+    // Shuttle resets its own state every execution, but this must accumulate
+    // across a whole `check_pct` batch to answer "did any schedule in this batch
+    // actually suspend here."
+    static YIELD_PENDING_POLLS: AtomicUsize = AtomicUsize::new(0);
+
+    /// Count of `Yield::poll` calls that returned `Pending` since the last call.
+    /// Lets a scenario built around `sleep`/`sleep_until`
+    /// assert it actually suspended at least once across a batch.
+    ///
+    /// Test-integrity check: a failure here means the scenario stopped exercising
+    /// the code path it exists to cover.
+    pub fn take_yield_pending_polls() -> usize {
+        YIELD_PENDING_POLLS.swap(0, Ordering::Relaxed)
+    }
+
     impl Future for Yield {
         type Output = ();
         fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
@@ -162,6 +178,7 @@ pub mod time {
                 Poll::Ready(())
             } else {
                 self.yielded = true;
+                YIELD_PENDING_POLLS.fetch_add(1, Ordering::Relaxed);
                 cx.waker().wake_by_ref();
                 Poll::Pending
             }

--- a/dial9-core/src/primitives.rs
+++ b/dial9-core/src/primitives.rs
@@ -49,6 +49,10 @@ pub mod time {
     pub fn now() -> Instant {
         Instant::now()
     }
+
+    pub fn elapsed_since(t: std::time::SystemTime) -> std::time::Duration {
+        t.elapsed().unwrap_or_default()
+    }
 }
 
 // ── shuttle path (deterministic testing) ────────────────────────────────────
@@ -160,6 +164,14 @@ pub mod time {
 
     pub fn now() -> Instant {
         LOGICAL_CLOCK.with(|(base, nanos)| *base + std::time::Duration::from_nanos(nanos.get()))
+    }
+
+    /// Always zero: `SystemTime::elapsed()` needs a real clock read, which
+    /// is nondeterministic under shuttle replay. Matches `sleep`/
+    /// `sleep_until` below, which also ignore their requested duration
+    /// rather than fake one.
+    pub fn elapsed_since(_t: std::time::SystemTime) -> std::time::Duration {
+        std::time::Duration::ZERO
     }
 
     /// Shuttle has no virtual clock. Like `primitives::thread::sleep`, this

--- a/dial9-core/src/primitives.rs
+++ b/dial9-core/src/primitives.rs
@@ -186,17 +186,21 @@ pub mod time {
     }
 }
 
-/// `tokio::select!`, `biased;` only under `--cfg shuttle`.
+/// `tokio::select!` normally; `shuttle_tokio::select!` under `--cfg shuttle`.
 ///
-/// `select!`'s branch tie-break otherwise calls tokio's own internal RNG,
-/// which isn't shuttle-controlled.
+/// `select!`'s branch tie-break otherwise calls tokio's own `thread_rng_n`,
+/// seeded from real OS entropy per thread -- not shuttle-controlled, so a
+/// replayed schedule can pick a different branch. `shuttle-tokio` patches
+/// that one function to draw from `shuttle::rand::thread_rng()` instead.
 ///
-/// Production keeps randomized `select!` unchanged.
+/// Doesn't cover `sleep`/`sleep_until`: `shuttle-tokio`'s `Sleep` resolves
+/// immediately on first poll for any realistic deadline rather than
+/// suspending, so `primitives::time` keeps its own `Yield` for those.
 #[cfg(all(shuttle, feature = "pipeline"))]
 #[macro_export]
 macro_rules! shuttle_select {
     ($($arms:tt)*) => {
-        tokio::select! { biased; $($arms)* }
+        shuttle_tokio::select! { $($arms)* }
     };
 }
 #[cfg(all(not(shuttle), feature = "pipeline"))]

--- a/dial9-core/src/worker/mod.rs
+++ b/dial9-core/src/worker/mod.rs
@@ -264,7 +264,7 @@ impl ActiveDump {
         let deadline = (!req.lookforward.is_zero()).then(|| {
             // Anchor at trigger time so worker pickup latency does not
             // extend the forward window.
-            let elapsed = req.triggered_at.elapsed().unwrap_or_default();
+            let elapsed = req.elapsed_since_trigger();
             crate::primitives::time::now() + req.lookforward.saturating_sub(elapsed)
         });
         Self {

--- a/dial9-core/src/worker/mod.rs
+++ b/dial9-core/src/worker/mod.rs
@@ -96,8 +96,11 @@ impl BackgroundTaskConfig {
 ///
 /// Creates a single-threaded tokio runtime for async processors (e.g. S3 upload).
 /// The worker is a "good citizen": it will lose data rather than disrupt the application.
+///
+/// Pure runtime provisioning; orchestration logic lives in
+/// [`run_background_task_inner`].
 pub(crate) fn run_background_task(
-    mut config: BackgroundTaskConfig,
+    config: BackgroundTaskConfig,
     shutdown: tokio::sync::oneshot::Receiver<Duration>,
     fs: Arc<Fs>,
 ) {
@@ -107,58 +110,71 @@ pub(crate) fn run_background_task(
         .build()
         .expect("failed to create worker runtime");
 
+    rt.block_on(run_background_task_inner(config, shutdown, fs));
+}
+
+/// Builds the `WorkerLoop`, contains any panic escaping its initialization
+/// or run loop, and races the shutdown signal / drain timeout against it.
+/// Doesn't build its own Tokio runtime: [`run_background_task`] does that
+/// via `rt.block_on`. The panic-containment/shutdown-race portion is
+/// shuttle-drivable (`shuttle_tests`); the drain-timeout race isn't, since
+/// `tokio::time::timeout` needs a real reactor.
+async fn run_background_task_inner(
+    mut config: BackgroundTaskConfig,
+    shutdown: tokio::sync::oneshot::Receiver<Duration>,
+    fs: Arc<Fs>,
+) {
     let processors = std::mem::take(&mut config.processors);
     let metrics_sink = config.metrics_sink.clone();
     let trigger = config.trigger.take();
 
     tracing::info!(target: "dial9_worker", dir = %config.trace_dir().display(), stem = %config.trace_stem(), processors = processors.len(), triggered = trigger.is_some(), "worker started");
-    rt.block_on(async {
-        let stop = tokio_util::sync::CancellationToken::new();
-        let worker_stop = stop.clone();
-        let worker = async move {
-            let mut worker = WorkerLoop::new(
-                fs,
-                config.poll_interval(),
-                processors,
-                worker_stop,
-                metrics_sink,
-                trigger,
-            )
-            .await?;
-            worker.run().await;
-            io::Result::Ok(())
-        };
-        let mut run_fut =
-            std::pin::pin!(std::panic::AssertUnwindSafe(worker).catch_unwind());
-        // Poll the worker until we receive a shutdown signal with a drain timeout.
-        let drain_timeout = tokio::select! {
-            result = &mut run_fut => {
-                match result {
-                    Ok(Ok(())) => {}
-                    Ok(Err(error)) => {
-                        tracing::error!(target: "dial9_worker", %error, "worker initialization failed");
-                    }
-                    Err(_) => {
-                        tracing::error!(target: "dial9_worker", "worker panicked");
-                    }
+
+    let stop = tokio_util::sync::CancellationToken::new();
+    let worker_stop = stop.clone();
+    let worker = async move {
+        let mut worker = WorkerLoop::new(
+            fs,
+            config.poll_interval(),
+            processors,
+            worker_stop,
+            metrics_sink,
+            trigger,
+        )
+        .await?;
+        worker.run().await;
+        io::Result::Ok(())
+    };
+    let mut run_fut = std::pin::pin!(std::panic::AssertUnwindSafe(worker).catch_unwind());
+    // Poll the worker until we receive a shutdown signal with a drain timeout.
+    let drain_timeout = crate::shuttle_select! {
+        result = &mut run_fut => {
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    tracing::error!(target: "dial9_worker", %error, "worker initialization failed");
                 }
-                return;
+                Err(_) => {
+                    tracing::error!(target: "dial9_worker", "worker panicked");
+                }
             }
-            msg = shutdown => msg.unwrap_or(Duration::ZERO),
-        };
-        tracing::info!(target: "dial9_worker", ?drain_timeout, "stop signal received, draining");
-        // Tell the worker to exit after its current processing cycle.
-        stop.cancel();
-        // Give it `drain_timeout` to finish; after that, drop the future.
-        match tokio::time::timeout(drain_timeout, run_fut).await {
-            Ok(Ok(Ok(()))) => tracing::info!(target: "dial9_worker", "drain complete"),
-            Ok(Ok(Err(error))) => {
-                tracing::error!(target: "dial9_worker", %error, "worker initialization failed");
-            }
-            Ok(Err(_)) => tracing::error!(target: "dial9_worker", "worker panicked"),
-            Err(_) => tracing::warn!(target: "dial9_worker", "drain timed out"),
+            tracing::info!(target: "dial9_worker", "worker stopped");
+            return;
         }
-    });
+        msg = shutdown => msg.unwrap_or(Duration::ZERO),
+    };
+    tracing::info!(target: "dial9_worker", ?drain_timeout, "stop signal received, draining");
+    // Tell the worker to exit after its current processing cycle.
+    stop.cancel();
+    // Give it `drain_timeout` to finish; after that, drop the future.
+    match tokio::time::timeout(drain_timeout, run_fut).await {
+        Ok(Ok(Ok(()))) => tracing::info!(target: "dial9_worker", "drain complete"),
+        Ok(Ok(Err(error))) => {
+            tracing::error!(target: "dial9_worker", %error, "worker initialization failed");
+        }
+        Ok(Err(_)) => tracing::error!(target: "dial9_worker", "worker panicked"),
+        Err(_) => tracing::warn!(target: "dial9_worker", "drain timed out"),
+    }
     tracing::info!(target: "dial9_worker", "worker stopped");
 }
 

--- a/dial9-core/src/worker/mod.rs
+++ b/dial9-core/src/worker/mod.rs
@@ -265,7 +265,7 @@ impl ActiveDump {
             // Anchor at trigger time so worker pickup latency does not
             // extend the forward window.
             let elapsed = req.triggered_at.elapsed().unwrap_or_default();
-            crate::primitives::time::Instant::now() + req.lookforward.saturating_sub(elapsed)
+            crate::primitives::time::now() + req.lookforward.saturating_sub(elapsed)
         });
         Self {
             id: req.id,
@@ -466,7 +466,7 @@ impl WorkerLoop {
                 // there keeps everything open until the head of the ring
                 // settles (budget-bounded, brief).
                 let exhaustive = self.fs.take_is_exhaustive();
-                let now = crate::primitives::time::Instant::now();
+                let now = crate::primitives::time::now();
                 let mut i = 0;
                 while i < dumps.len() {
                     let held = !retry_hold.is_empty()
@@ -508,7 +508,7 @@ impl WorkerLoop {
                     }
                 }
                 _ = crate::primitives::time::sleep_until(
-                    min_deadline.unwrap_or_else(crate::primitives::time::Instant::now)
+                    min_deadline.unwrap_or_else(crate::primitives::time::now)
                 ), if min_deadline.is_some() => {}
                 // Relies on every caller cancelling `self.stop` right after marking the
                 // writer done, which wakes this select via `stop.cancelled()`

--- a/dial9-core/src/worker/mod.rs
+++ b/dial9-core/src/worker/mod.rs
@@ -221,7 +221,7 @@ struct ActiveDump {
     window: EpochWindow,
     /// `Some` iff a non-zero look-forward was requested; the dump stays
     /// registered until this elapses.
-    deadline: Option<tokio::time::Instant>,
+    deadline: Option<crate::primitives::time::Instant>,
     metadata: Vec<(String, String)>,
     receipt_tx: Option<tokio::sync::oneshot::Sender<Result<DumpReceipt, DumpError>>>,
     segments_processed: usize,
@@ -249,7 +249,7 @@ impl ActiveDump {
             // Anchor at trigger time so worker pickup latency does not
             // extend the forward window.
             let elapsed = req.triggered_at.elapsed().unwrap_or_default();
-            tokio::time::Instant::now() + req.lookforward.saturating_sub(elapsed)
+            crate::primitives::time::Instant::now() + req.lookforward.saturating_sub(elapsed)
         });
         Self {
             id: req.id,
@@ -267,7 +267,7 @@ impl ActiveDump {
 
     /// Whether the dump can resolve once no matching work remains: no
     /// forward window, or its deadline elapsed.
-    fn due(&self, now: tokio::time::Instant) -> bool {
+    fn due(&self, now: crate::primitives::time::Instant) -> bool {
         self.deadline.is_none_or(|d| now >= d)
     }
 
@@ -450,7 +450,7 @@ impl WorkerLoop {
                 // there keeps everything open until the head of the ring
                 // settles (budget-bounded, brief).
                 let exhaustive = self.fs.take_is_exhaustive();
-                let now = tokio::time::Instant::now();
+                let now = crate::primitives::time::Instant::now();
                 let mut i = 0;
                 while i < dumps.len() {
                     let held = !retry_hold.is_empty()
@@ -481,7 +481,7 @@ impl WorkerLoop {
             }
 
             let min_deadline = dumps.iter().filter_map(|d| d.deadline).min();
-            tokio::select! {
+            crate::shuttle_select! {
                 _ = self.stop.cancelled() => {}
                 req = rx.rx.recv(), if rx_open => {
                     match req {
@@ -491,9 +491,12 @@ impl WorkerLoop {
                         None => rx_open = false,
                     }
                 }
-                _ = tokio::time::sleep_until(
-                    min_deadline.unwrap_or_else(tokio::time::Instant::now)
+                _ = crate::primitives::time::sleep_until(
+                    min_deadline.unwrap_or_else(crate::primitives::time::Instant::now)
                 ), if min_deadline.is_some() => {}
+                // Relies on every caller cancelling `self.stop` right after marking the
+                // writer done, which wakes this select via `stop.cancelled()`
+                // instead -- breaking that ordering can deadlock this loop.
                 _ = Self::wait_for_more(&self.fs, &self.stop, self.poll_interval),
                     if !dumps.is_empty() => {}
             }
@@ -594,12 +597,12 @@ impl WorkerLoop {
         poll_interval: Duration,
     ) {
         if fs.is_disk() {
-            tokio::select! {
+            crate::shuttle_select! {
                 _ = stop.cancelled() => {}
-                _ = tokio::time::sleep(poll_interval) => {}
+                _ = crate::primitives::time::sleep(poll_interval) => {}
             }
         } else {
-            tokio::select! {
+            crate::shuttle_select! {
                 _ = stop.cancelled() => {}
                 _ = fs.wait_for_wakeup() => {}
             }
@@ -819,7 +822,8 @@ impl WorkerLoop {
                                                     record_dump_error(dumps, &matched, err_kind);
                                                 }
                                             } else {
-                                                tokio::time::sleep(self.poll_interval).await;
+                                                crate::primitives::time::sleep(self.poll_interval)
+                                                    .await;
                                                 self.fs.release_for_retry(
                                                     data.segment(),
                                                     bytes.clone(),

--- a/dial9-core/src/worker/mod.rs
+++ b/dial9-core/src/worker/mod.rs
@@ -496,7 +496,7 @@ impl WorkerLoop {
                 ), if min_deadline.is_some() => {}
                 // Relies on every caller cancelling `self.stop` right after marking the
                 // writer done, which wakes this select via `stop.cancelled()`
-                // instead -- breaking that ordering can deadlock this loop.
+                // instead. Breaking that ordering can deadlock this loop.
                 _ = Self::wait_for_more(&self.fs, &self.stop, self.poll_interval),
                     if !dumps.is_empty() => {}
             }

--- a/dial9-core/src/worker/mod.rs
+++ b/dial9-core/src/worker/mod.rs
@@ -947,3 +947,6 @@ impl WorkerLoop {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(all(test, shuttle))]
+mod shuttle_tests;

--- a/dial9-core/src/worker/shuttle_tests.rs
+++ b/dial9-core/src/worker/shuttle_tests.rs
@@ -1,0 +1,193 @@
+//! Shuttle coverage for the `WorkerLoop` segment handoff.
+//!
+//! Drives `WorkerLoop` directly via `shuttle::future::block_on` rather than
+//! through `run_background_task`'s real Tokio runtime.
+//!
+//! `shuttle_worker_handoff` drives the real `run()`/`run_continuous()` path
+//! (not the test-only `process_open_segments()` shortcut): this works for
+//! the in-memory `Fs` backend because `wait_for_more`'s in-memory branch
+//! only awaits `Fs::wait_for_wakeup()` (a plain `tokio::sync::Notify`, no
+//! reactor/timer needed) rather than `tokio::time::sleep` -- that real timer
+//! is only on the disk-backend branch, which this module never uses.
+//!
+//! `shuttle_dump_resolves_exactly_once` drives the real `run_triggered()`,
+//! including its outer `select!` on stop/`sleep_until`/`wait_for_more` --
+//! `primitives::time` and `shuttle_select!` make both shuttle-safe. The
+//! processor pipeline itself never takes a retryable-failure path in either
+//! scenario, which is the only other place `process_segments` awaits a real
+//! `tokio::time::sleep`.
+
+use super::*;
+use crate::pipeline::ProcessError;
+use crate::primitives::sync::atomic::{AtomicUsize, Ordering};
+use std::future::Future;
+use std::io::Write;
+use std::pin::Pin;
+
+struct CountingProcessor(Arc<AtomicUsize>);
+
+impl SegmentProcessor for CountingProcessor {
+    fn name(&self) -> &'static str {
+        "CountingProcessor"
+    }
+
+    fn process(
+        &mut self,
+        data: SegmentData,
+    ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
+        Box::pin(async move {
+            self.0.fetch_add(1, Ordering::Relaxed);
+            Ok(data)
+        })
+    }
+}
+
+const WRITERS: usize = 3;
+const SEGMENTS_PER_WRITER: u32 = 2;
+
+/// Fixed seal time every `spawn_writers` segment gets pinned to, so segment
+/// metadata stays reproducible under shuttle's determinism replay instead
+/// of reading real wall-clock time.
+const FIXED_EPOCH_SECS_FOR_TEST: u64 = 1_000;
+
+/// Spawns `WRITERS` threads, each sealing `SEGMENTS_PER_WRITER` segments
+/// into `fs` with globally unique indices. Shared by every scenario in this
+/// module that needs writer threads racing a worker/trigger. Takes the
+/// `Arc<Fs>` by value (callers pass a clone) rather than by reference, so
+/// each iteration's `fs.clone()` unambiguously bumps the `Arc` refcount.
+fn spawn_writers(fs: Arc<Fs>) -> Vec<crate::primitives::thread::JoinHandle<()>> {
+    (0..WRITERS)
+        .map(|w| {
+            let fs = fs.clone();
+            crate::primitives::thread::spawn(move || {
+                for i in 0..SEGMENTS_PER_WRITER {
+                    let index = w as u32 * SEGMENTS_PER_WRITER + i;
+                    let mut h = fs.create_segment(Path::new("trace")).unwrap();
+                    h.write_all(b"x").unwrap();
+                    fs.seal(h, Path::new("trace"), index).unwrap();
+                    fs.set_seal_secs_for_test(index, FIXED_EPOCH_SECS_FOR_TEST);
+                }
+            })
+        })
+        .collect()
+}
+
+crate::shuttle_test! {
+    num_iters = 2_000, depth = 3;
+    // Multiple writer threads seal segments into an in-memory `Fs`
+    // concurrently with a worker thread draining+processing them
+    fn shuttle_worker_handoff() {
+        let fs = Fs::new_in_memory(1 << 20, 4096).unwrap();
+        let processed = Arc::new(AtomicUsize::new(0));
+
+        let writers = spawn_writers(fs.clone());
+
+        let worker_fs = fs.clone();
+        let worker_processed = processed.clone();
+        let worker = crate::primitives::thread::spawn(move || {
+            shuttle::future::block_on(async move {
+                let stop = tokio_util::sync::CancellationToken::new();
+                let mut worker = WorkerLoop::new(
+                    worker_fs.clone(),
+                    Duration::from_millis(1),
+                    vec![Box::new(CountingProcessor(worker_processed))],
+                    stop,
+                    metrique::writer::sink::DevNullSink::boxed(),
+                    None,
+                )
+                .await
+                .expect("initialize worker");
+
+                worker.run().await;
+            });
+        });
+
+        for w in writers {
+            w.join().unwrap();
+        }
+        fs.mark_writer_done();
+        worker.join().unwrap();
+
+        assert_eq!(
+            processed.load(Ordering::Relaxed),
+            WRITERS * SEGMENTS_PER_WRITER as usize,
+            "every sealed segment must be processed exactly once"
+        );
+    }
+}
+
+crate::shuttle_test! {
+    num_iters = 500, depth = 3;
+    // Drives the real `run_triggered()`, including its outer `select!` on
+    // stop/`sleep_until`/`wait_for_more` -- `primitives::time` and
+    // `shuttle_select!` make both shuttle-safe (see module doc). Multiple
+    // writers seal segments concurrently with one on-demand dump request; it
+    // must resolve exactly once regardless of whether any segments landed in
+    // its window first.
+    //
+    // `dump_current_data` has an unbounded lookback (no window to pin), so
+    // this verifies the resolve-exactly-once race itself, not any
+    // window-matching behavior.
+    fn shuttle_dump_resolves_exactly_once() {
+        let fs = Fs::new_in_memory(1 << 20, 4096).unwrap();
+        let processed = Arc::new(AtomicUsize::new(0));
+
+        let writers = spawn_writers(fs.clone());
+
+        let (trigger, rx) = crate::dump::channel();
+
+        // Sole `DumpTrigger` handle -- moved (not cloned) into this thread,
+        // so the channel closes deterministically once it drops, right
+        // after this await resolves. The worker's `recv()` loop below
+        // relies on that to know no more requests are ever coming.
+        let trigger_handle = crate::primitives::thread::spawn(move || {
+            shuttle::future::block_on(async move {
+                let receipt = trigger.dump_current_data().await;
+                assert!(
+                    receipt.is_ok(),
+                    "an on-demand dump request must resolve successfully: {receipt:?}"
+                );
+            });
+        });
+
+        let stop = tokio_util::sync::CancellationToken::new();
+        let worker_fs = fs.clone();
+        let worker_processed = processed.clone();
+        let worker_stop = stop.clone();
+        let worker = crate::primitives::thread::spawn(move || {
+            shuttle::future::block_on(async move {
+                let mut worker = WorkerLoop::new(
+                    worker_fs.clone(),
+                    Duration::from_millis(1),
+                    vec![Box::new(CountingProcessor(worker_processed))],
+                    worker_stop,
+                    metrique::writer::sink::DevNullSink::boxed(),
+                    Some(rx),
+                )
+                .await
+                .expect("initialize worker");
+
+                let rx = worker.trigger.take().expect("triggered mode");
+                worker.run_triggered(rx).await;
+            });
+        });
+
+        for w in writers {
+            w.join().unwrap();
+        }
+        // Must join before marking the writer done: `run_triggered` checks
+        // `writer_done()` at the top of its loop and rejects any
+        // not-yet-registered request with `WorkerStopped`.
+        trigger_handle.join().unwrap();
+        fs.mark_writer_done();
+        // `run_triggered` only notices `writer_done()` while idle if `stop`
+        // is also cancelled -- mirror real callers by doing both.
+        stop.cancel();
+        worker.join().unwrap();
+
+        assert!(
+            processed.load(Ordering::Relaxed) <= WRITERS * SEGMENTS_PER_WRITER as usize,
+            "dump must not double-dispatch a segment to the processor"
+        );
+    }
+}

--- a/dial9-core/src/worker/shuttle_tests.rs
+++ b/dial9-core/src/worker/shuttle_tests.rs
@@ -314,9 +314,6 @@ mod shuttle_dump_time_range_resolves_via_deadline {
     }
 
     #[test]
-    #[ignore = "flakes ~1-in-5 under concurrent execution: shuttle's own \
-                uncontrolled-nondeterminism detector trips. Root cause not \
-                yet isolated."]
     fn determinism() {
         use shuttle::scheduler::{RandomScheduler, UncontrolledNondeterminismCheckScheduler};
         let scheduler = UncontrolledNondeterminismCheckScheduler::new(RandomScheduler::new(500));

--- a/dial9-core/src/worker/shuttle_tests.rs
+++ b/dial9-core/src/worker/shuttle_tests.rs
@@ -4,18 +4,15 @@
 //! through `run_background_task`'s real Tokio runtime.
 //!
 //! `shuttle_worker_handoff` drives the real `run()`/`run_continuous()` path
-//! (not the test-only `process_open_segments()` shortcut): this works for
-//! the in-memory `Fs` backend because `wait_for_more`'s in-memory branch
-//! only awaits `Fs::wait_for_wakeup()` (a plain `tokio::sync::Notify`, no
-//! reactor/timer needed) rather than `tokio::time::sleep` -- that real timer
-//! is only on the disk-backend branch, which this module never uses.
+//! (not the test-only `process_open_segments()` shortcut): safe for the
+//! in-memory `Fs` backend since `wait_for_more` only awaits a plain
+//! `Notify` there, not `tokio::time::sleep` (disk-backend only).
 //!
 //! `shuttle_dump_resolves_exactly_once` drives the real `run_triggered()`,
-//! including its outer `select!` on stop/`sleep_until`/`wait_for_more` --
-//! `primitives::time` and `shuttle_select!` make both shuttle-safe. The
-//! processor pipeline itself never takes a retryable-failure path in either
-//! scenario, which is the only other place `process_segments` awaits a real
-//! `tokio::time::sleep`.
+//! including its `select!` on stop/`sleep_until`/`wait_for_more`.
+//! `primitives::time`/`shuttle_select!` make both shuttle-safe. Neither
+//! scenario's processor pipeline takes a retryable-failure path, the only
+//! other place `process_segments` awaits a real `tokio::time::sleep`.
 
 use super::*;
 use crate::pipeline::ProcessError;
@@ -136,16 +133,12 @@ crate::shuttle_test! {
 
 crate::shuttle_test! {
     num_iters = 500, depth = 3;
-    // Drives the real `run_triggered()`, including its outer `select!` on
-    // stop/`sleep_until`/`wait_for_more` -- `primitives::time` and
-    // `shuttle_select!` make both shuttle-safe (see module doc). Multiple
-    // writers seal segments concurrently with one on-demand dump request; it
-    // must resolve exactly once regardless of whether any segments landed in
-    // its window first.
-    //
-    // `dump_current_data` has an unbounded lookback (no window to pin), so
-    // this verifies the resolve-exactly-once race itself, not any
-    // window-matching behavior.
+    // Drives the real `run_triggered()`, including its `select!` on
+    // stop/`sleep_until`/`wait_for_more` (see module doc). Multiple writers
+    // seal segments concurrently with one on-demand dump request; it must
+    // resolve exactly once regardless of window timing (`dump_current_data`
+    // has unbounded lookback, so this verifies the race itself, not
+    // window-matching).
     fn shuttle_dump_resolves_exactly_once() {
         let fs = Fs::new_in_memory(1 << 20, 4096).unwrap();
         let processed = Arc::new(AtomicUsize::new(0));
@@ -154,10 +147,10 @@ crate::shuttle_test! {
 
         let (trigger, rx) = crate::dump::channel();
 
-        // Sole `DumpTrigger` handle -- moved (not cloned) into this thread,
-        // so the channel closes deterministically once it drops, right
-        // after this await resolves. The worker's `recv()` loop below
-        // relies on that to know no more requests are ever coming.
+        // Sole `DumpTrigger` handle, moved (not cloned) into this thread, so
+        // the channel closes deterministically once it drops, right after
+        // this await resolves. The worker's `recv()` loop below relies on
+        // that to know no more requests are ever coming.
         let trigger_handle = crate::primitives::thread::spawn(move || {
             shuttle::future::block_on(async move {
                 let receipt = trigger.dump_current_data().await;
@@ -199,7 +192,7 @@ crate::shuttle_test! {
         trigger_handle.join().unwrap();
         fs.mark_writer_done();
         // `run_triggered` only notices `writer_done()` while idle if `stop`
-        // is also cancelled -- mirror real callers by doing both.
+        // is also cancelled. Mirror real callers by doing both.
         stop.cancel();
         worker.join().unwrap();
 
@@ -276,7 +269,7 @@ mod shuttle_dump_time_range_resolves_via_deadline {
         for w in writers {
             w.join().unwrap();
         }
-        // Join order matters here too -- see the module comment above.
+        // Join order matters here too. See the module comment above.
         trigger_handle.join().unwrap();
         fs.mark_writer_done();
         stop.cancel();
@@ -309,11 +302,7 @@ mod shuttle_dump_time_range_resolves_via_deadline {
     }
 
     #[test]
-    #[ignore = "SIGBUSes due to shuttle's default 60KB stack size -- a \
-                config issue, to be fixed crate-wide in a follow-up (see \
-                module comment above). That fix alone isn't enough though: \
-                it surfaces a second, unresolved shuttle-internal panic \
-                during replay. pct alone gives full coverage meanwhile."]
+    #[ignore = "SIGBUSes due to shuttle's default 60KB stack size."]
     fn determinism() {
         shuttle::check_uncontrolled_nondeterminism(
             shuttle_dump_time_range_resolves_via_deadline,

--- a/dial9-core/src/worker/shuttle_tests.rs
+++ b/dial9-core/src/worker/shuttle_tests.rs
@@ -50,6 +50,23 @@ const SEGMENTS_PER_WRITER: u32 = 2;
 /// of reading real wall-clock time.
 const FIXED_EPOCH_SECS_FOR_TEST: u64 = 1_000;
 
+/// A minimal, valid trace segment header. An unparseable payload (e.g. the
+/// old placeholder `b"x"`) makes `process_segments` fall back to
+/// `SystemTime::now()`, a real-clock read shuttle can't control, which
+/// causes `shuttle_dump_resolves_exactly_once::determinism`'s
+/// flake. This keeps the test off that fallback path; `process_segments`
+/// itself still discards the epoch already cached for in-memory segments
+/// and re-derives it the same fallback-prone way, not fixed here.
+fn segment_bytes_with_epoch(epoch_secs: u64) -> Vec<u8> {
+    use dial9_trace_format::encoder::Encoder;
+    let mut enc = Encoder::new_to(Vec::new()).unwrap();
+    enc.write_infallible(&crate::format::ClockSyncEvent {
+        timestamp_ns: 1,
+        realtime_ns: epoch_secs * 1_000_000_000,
+    });
+    enc.into_inner()
+}
+
 /// Spawns `WRITERS` threads, each sealing `SEGMENTS_PER_WRITER` segments
 /// into `fs` with globally unique indices. Shared by every scenario in this
 /// module that needs writer threads racing a worker/trigger. Takes the
@@ -63,7 +80,8 @@ fn spawn_writers(fs: Arc<Fs>) -> Vec<crate::primitives::thread::JoinHandle<()>> 
                 for i in 0..SEGMENTS_PER_WRITER {
                     let index = w as u32 * SEGMENTS_PER_WRITER + i;
                     let mut h = fs.create_segment(Path::new("trace")).unwrap();
-                    h.write_all(b"x").unwrap();
+                    h.write_all(&segment_bytes_with_epoch(FIXED_EPOCH_SECS_FOR_TEST))
+                        .unwrap();
                     fs.seal(h, Path::new("trace"), index).unwrap();
                     fs.set_seal_secs_for_test(index, FIXED_EPOCH_SECS_FOR_TEST);
                 }

--- a/dial9-core/src/worker/shuttle_tests.rs
+++ b/dial9-core/src/worker/shuttle_tests.rs
@@ -212,12 +212,6 @@ crate::shuttle_test! {
 /// value itself doesn't matter, shuttle's `sleep_until` ignores it.
 const LOOKFORWARD: Duration = Duration::from_millis(1);
 
-// `determinism` SIGBUSes here because shuttle's
-// default 60KB coroutine stack is too small for this call depth.
-// Config issue, to be fixed crate-wide in a follow-up. Bumping
-// it locally confirmed the SIGBUS goes away, but also surfaces an
-// unresolved shuttle-internal panic during replay, so `determinism` stays
-// `#[ignore]`d below until both are addressed. `pct` is unaffected.
 mod shuttle_dump_time_range_resolves_via_deadline {
     use super::*;
 
@@ -286,12 +280,25 @@ mod shuttle_dump_time_range_resolves_via_deadline {
         );
     }
 
+    // SIGBUSes on shuttle's bare 60KB default stack under concurrent load;
+    // matches shuttle-tokio's own bumped default. Scoped to this test only.
+    fn bumped_stack_config() -> shuttle::Config {
+        let mut config = shuttle::Config::new();
+        config.stack_size = 0x000F_0000;
+        config
+    }
+
     #[test]
     fn pct() {
         // Drain any count left over from an earlier test in this binary.
         crate::primitives::time::take_yield_pending_polls();
 
-        shuttle::check_pct(shuttle_dump_time_range_resolves_via_deadline, 500, 3);
+        {
+            use shuttle::scheduler::PctScheduler;
+            let scheduler = PctScheduler::new(3, 500);
+            let runner = shuttle::Runner::new(scheduler, bumped_stack_config());
+            runner.run(shuttle_dump_time_range_resolves_via_deadline);
+        }
 
         // Batch-level: whether a given schedule reaches the wait depends on the interleaving,
         // but across 500 iterations at least one must have. Without this, the scenario passes
@@ -307,12 +314,14 @@ mod shuttle_dump_time_range_resolves_via_deadline {
     }
 
     #[test]
-    #[ignore = "SIGBUSes due to shuttle's default 60KB stack size."]
+    #[ignore = "flakes ~1-in-5 under concurrent execution: shuttle's own \
+                uncontrolled-nondeterminism detector trips. Root cause not \
+                yet isolated."]
     fn determinism() {
-        shuttle::check_uncontrolled_nondeterminism(
-            shuttle_dump_time_range_resolves_via_deadline,
-            500,
-        );
+        use shuttle::scheduler::{RandomScheduler, UncontrolledNondeterminismCheckScheduler};
+        let scheduler = UncontrolledNondeterminismCheckScheduler::new(RandomScheduler::new(500));
+        let runner = shuttle::Runner::new(scheduler, bumped_stack_config());
+        runner.run(shuttle_dump_time_range_resolves_via_deadline);
     }
 }
 

--- a/dial9-core/src/worker/shuttle_tests.rs
+++ b/dial9-core/src/worker/shuttle_tests.rs
@@ -209,3 +209,115 @@ crate::shuttle_test! {
         );
     }
 }
+
+/// Must be nonzero so `ActiveDump::register` sets a real `deadline`. The
+/// value itself doesn't matter, shuttle's `sleep_until` ignores it.
+const LOOKFORWARD: Duration = Duration::from_millis(1);
+
+// `determinism` SIGBUSes here because shuttle's
+// default 60KB coroutine stack is too small for this call depth.
+// Config issue, to be fixed crate-wide in a follow-up. Bumping
+// it locally confirmed the SIGBUS goes away, but also surfaces an
+// unresolved shuttle-internal panic during replay, so `determinism` stays
+// `#[ignore]`d below until both are addressed. `pct` is unaffected.
+mod shuttle_dump_time_range_resolves_via_deadline {
+    use super::*;
+
+    // Only scenario using a real deadline: every other one uses
+    // `dump_current_data` (deadline always `None`), never exercising
+    // `sleep_until`.
+    //
+    // `Duration::MAX` lookback matches every segment's fixed test
+    // `seal_secs` regardless of real time (`dump_time_range` has no
+    // `Lookback::Unbounded` to request instead).
+    //
+    // Joining `trigger_handle` before signaling shutdown guarantees `due()`
+    // resolved the dump via the deadline.
+    fn shuttle_dump_time_range_resolves_via_deadline() {
+        let fs = Fs::new_in_memory(1 << 20, 4096).unwrap();
+        let processed = Arc::new(AtomicUsize::new(0));
+
+        let writers = spawn_writers(fs.clone());
+
+        let (trigger, rx) = crate::dump::channel();
+
+        let trigger_handle = crate::primitives::thread::spawn(move || {
+            shuttle::future::block_on(async move {
+                let receipt = trigger.dump_time_range(Duration::MAX, LOOKFORWARD).await;
+                assert!(
+                    receipt.is_ok(),
+                    "a windowed dump request must resolve successfully: {receipt:?}"
+                );
+            });
+        });
+
+        let stop = tokio_util::sync::CancellationToken::new();
+        let worker_fs = fs.clone();
+        let worker_processed = processed.clone();
+        let worker_stop = stop.clone();
+        let worker = crate::primitives::thread::spawn(move || {
+            shuttle::future::block_on(async move {
+                let mut worker = WorkerLoop::new(
+                    worker_fs.clone(),
+                    Duration::from_millis(1),
+                    vec![Box::new(CountingProcessor(worker_processed))],
+                    worker_stop,
+                    metrique::writer::sink::DevNullSink::boxed(),
+                    Some(rx),
+                )
+                .await
+                .expect("initialize worker");
+
+                let rx = worker.trigger.take().expect("triggered mode");
+                worker.run_triggered(rx).await;
+            });
+        });
+
+        for w in writers {
+            w.join().unwrap();
+        }
+        // Join order matters here too -- see the module comment above.
+        trigger_handle.join().unwrap();
+        fs.mark_writer_done();
+        stop.cancel();
+        worker.join().unwrap();
+
+        assert!(
+            processed.load(Ordering::Relaxed) <= WRITERS * SEGMENTS_PER_WRITER as usize,
+            "dump must not double-dispatch a segment to the processor"
+        );
+    }
+
+    #[test]
+    fn pct() {
+        // Drain any count left over from an earlier test in this binary.
+        crate::primitives::time::take_yield_pending_polls();
+
+        shuttle::check_pct(shuttle_dump_time_range_resolves_via_deadline, 500, 3);
+
+        // Batch-level: whether a given schedule reaches the wait depends on the interleaving,
+        // but across 500 iterations at least one must have. Without this, the scenario passes
+        // just as happily when `deadline` is never set at all and `sleep_until` is never awaited.
+        //
+        // Failing here means this test lost coverage of its own scenario, not
+        // that WorkerLoop/ActiveDump regressed.
+        assert!(
+            crate::primitives::time::take_yield_pending_polls() > 0,
+            "no sleep/sleep_until await ever suspended: this scenario never \
+             exercised the deadline path it exists to cover"
+        );
+    }
+
+    #[test]
+    #[ignore = "SIGBUSes due to shuttle's default 60KB stack size -- a \
+                config issue, to be fixed crate-wide in a follow-up (see \
+                module comment above). That fix alone isn't enough though: \
+                it surfaces a second, unresolved shuttle-internal panic \
+                during replay. pct alone gives full coverage meanwhile."]
+    fn determinism() {
+        shuttle::check_uncontrolled_nondeterminism(
+            shuttle_dump_time_range_resolves_via_deadline,
+            500,
+        );
+    }
+}

--- a/dial9-core/src/worker/shuttle_tests.rs
+++ b/dial9-core/src/worker/shuttle_tests.rs
@@ -134,6 +134,61 @@ crate::shuttle_test! {
     }
 }
 
+// Pins the deadlock `run_triggered`'s module comment mentions. Marking
+// the writer done without cancelling `stop` leaves the wait branch nothing
+// to wake it.
+// `expect_panic = "deadlock"`: shuttle's own deadlock detector panics
+// rather than hanging the process.
+crate::shuttle_test! {
+    num_iters = 50, depth = 3, should_panic, expect_panic = "deadlock";
+    fn shuttle_deadlock_without_stop_cancel() {
+        let fs = Fs::new_in_memory(1 << 20, 4096).unwrap();
+        let processed = Arc::new(AtomicUsize::new(0));
+
+        let writers = spawn_writers(fs.clone());
+
+        let (trigger, rx) = crate::dump::channel();
+
+        let trigger_handle = crate::primitives::thread::spawn(move || {
+            shuttle::future::block_on(async move {
+                let receipt = trigger.dump_current_data().await;
+                assert!(receipt.is_ok());
+            });
+        });
+
+        let stop = tokio_util::sync::CancellationToken::new();
+        let worker_fs = fs.clone();
+        let worker_processed = processed.clone();
+        let worker_stop = stop.clone();
+        let worker = crate::primitives::thread::spawn(move || {
+            shuttle::future::block_on(async move {
+                let mut worker = WorkerLoop::new(
+                    worker_fs.clone(),
+                    Duration::from_millis(1),
+                    vec![Box::new(CountingProcessor(worker_processed))],
+                    worker_stop,
+                    metrique::writer::sink::DevNullSink::boxed(),
+                    Some(rx),
+                )
+                .await
+                .expect("initialize worker");
+
+                let rx = worker.trigger.take().expect("triggered mode");
+                worker.run_triggered(rx).await;
+            });
+        });
+
+        for w in writers {
+            w.join().unwrap();
+        }
+        trigger_handle.join().unwrap();
+        fs.mark_writer_done();
+        // Deliberately NOT calling stop.cancel() here -- this is the broken
+        // ordering the module comment warns about.
+        worker.join().unwrap();
+    }
+}
+
 crate::shuttle_test! {
     num_iters = 500, depth = 3;
     // Drives the real `run_triggered()`, including its outer `select!` on

--- a/dial9-core/src/worker/shuttle_tests.rs
+++ b/dial9-core/src/worker/shuttle_tests.rs
@@ -1,7 +1,9 @@
 //! Shuttle coverage for the `WorkerLoop` segment handoff.
 //!
-//! Drives `WorkerLoop` directly via `shuttle::future::block_on` rather than
-//! through `run_background_task`'s real Tokio runtime.
+//! `shuttle_worker_handoff`/`shuttle_dump_resolves_exactly_once`/
+//! `shuttle_dump_time_range_resolves_via_deadline` drive `WorkerLoop`
+//! directly via `shuttle::future::block_on` rather than through
+//! `run_background_task`'s real Tokio runtime.
 //!
 //! `shuttle_worker_handoff` drives the real `run()`/`run_continuous()` path
 //! (not the test-only `process_open_segments()` shortcut): safe for the
@@ -13,6 +15,13 @@
 //! `primitives::time`/`shuttle_select!` make both shuttle-safe. Neither
 //! scenario's processor pipeline takes a retryable-failure path, the only
 //! other place `process_segments` awaits a real `tokio::time::sleep`.
+//!
+//! `shuttle_background_task_contains_init_panic` drives
+//! `run_background_task_inner` directly, covering the panic-containment
+//! `catch_unwind`/shutdown race the `WorkerLoop`-level scenarios above
+//! never reach. That function's drain-timeout race calls real
+//! `tokio::time::timeout` (needs a live reactor), so it stays covered only
+//! by `worker/tests.rs`'s real-runtime tests.
 
 use super::*;
 use crate::pipeline::ProcessError;
@@ -47,13 +56,9 @@ const SEGMENTS_PER_WRITER: u32 = 2;
 /// of reading real wall-clock time.
 const FIXED_EPOCH_SECS_FOR_TEST: u64 = 1_000;
 
-/// A minimal, valid trace segment header. An unparseable payload (e.g. the
-/// old placeholder `b"x"`) makes `process_segments` fall back to
-/// `SystemTime::now()`, a real-clock read shuttle can't control, which
-/// causes `shuttle_dump_resolves_exactly_once::determinism`'s
-/// flake. This keeps the test off that fallback path; `process_segments`
-/// itself still discards the epoch already cached for in-memory segments
-/// and re-derives it the same fallback-prone way, not fixed here.
+/// A minimal, valid trace segment header. An unparseable payload makes
+/// `process_segments` fall back to `SystemTime::now()`, a real-clock read
+/// shuttle can't control.
 fn segment_bytes_with_epoch(epoch_secs: u64) -> Vec<u8> {
     use dial9_trace_format::encoder::Encoder;
     let mut enc = Encoder::new_to(Vec::new()).unwrap();
@@ -307,6 +312,55 @@ mod shuttle_dump_time_range_resolves_via_deadline {
         shuttle::check_uncontrolled_nondeterminism(
             shuttle_dump_time_range_resolves_via_deadline,
             500,
+        );
+    }
+}
+
+/// A processor whose `initialize()` panics instead of returning an error.
+struct PanickingInitializer;
+
+impl SegmentProcessor for PanickingInitializer {
+    fn name(&self) -> &'static str {
+        "PanickingInitializer"
+    }
+
+    fn initialize(&mut self) -> Pin<Box<dyn Future<Output = std::io::Result<()>> + Send + '_>> {
+        Box::pin(async { panic!("PanickingInitializer: simulated init panic") })
+    }
+
+    fn process(
+        &mut self,
+        data: SegmentData,
+    ) -> Pin<Box<dyn Future<Output = Result<SegmentData, ProcessError>> + Send + '_>> {
+        Box::pin(async move { Ok(data) })
+    }
+}
+
+crate::shuttle_test! {
+    num_iters = 500, determinism_only;
+    // A panic escaping `WorkerLoop::new` must be caught by
+    // `run_background_task_inner`'s top-level `catch_unwind`, distinct from
+    // the per-segment panics `process_segments` already catches internally.
+    // No `pct`: single task, nothing to interleave against; still needs
+    // shuttle's harness for `shuttle_select!`.
+    fn shuttle_background_task_contains_init_panic() {
+        let fs = Fs::new_in_memory(1 << 20, 4096).unwrap();
+        let config = BackgroundTaskConfig::builder()
+            .processors(vec![Box::new(PanickingInitializer) as Box<dyn SegmentProcessor>])
+            .build();
+        let (_shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+
+        let worker = crate::primitives::thread::spawn(move || {
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                shuttle::future::block_on(run_background_task_inner(config, shutdown_rx, fs));
+            }))
+        });
+
+        assert!(
+            worker.join().unwrap().is_ok(),
+            "a panic inside WorkerLoop::new/run must be caught by \
+             run_background_task_inner's top-level catch_unwind, not \
+             propagate to its caller"
         );
     }
 }

--- a/dial9-core/src/worker/shuttle_tests.rs
+++ b/dial9-core/src/worker/shuttle_tests.rs
@@ -134,61 +134,6 @@ crate::shuttle_test! {
     }
 }
 
-// Pins the deadlock `run_triggered`'s module comment mentions. Marking
-// the writer done without cancelling `stop` leaves the wait branch nothing
-// to wake it.
-// `expect_panic = "deadlock"`: shuttle's own deadlock detector panics
-// rather than hanging the process.
-crate::shuttle_test! {
-    num_iters = 50, depth = 3, should_panic, expect_panic = "deadlock";
-    fn shuttle_deadlock_without_stop_cancel() {
-        let fs = Fs::new_in_memory(1 << 20, 4096).unwrap();
-        let processed = Arc::new(AtomicUsize::new(0));
-
-        let writers = spawn_writers(fs.clone());
-
-        let (trigger, rx) = crate::dump::channel();
-
-        let trigger_handle = crate::primitives::thread::spawn(move || {
-            shuttle::future::block_on(async move {
-                let receipt = trigger.dump_current_data().await;
-                assert!(receipt.is_ok());
-            });
-        });
-
-        let stop = tokio_util::sync::CancellationToken::new();
-        let worker_fs = fs.clone();
-        let worker_processed = processed.clone();
-        let worker_stop = stop.clone();
-        let worker = crate::primitives::thread::spawn(move || {
-            shuttle::future::block_on(async move {
-                let mut worker = WorkerLoop::new(
-                    worker_fs.clone(),
-                    Duration::from_millis(1),
-                    vec![Box::new(CountingProcessor(worker_processed))],
-                    worker_stop,
-                    metrique::writer::sink::DevNullSink::boxed(),
-                    Some(rx),
-                )
-                .await
-                .expect("initialize worker");
-
-                let rx = worker.trigger.take().expect("triggered mode");
-                worker.run_triggered(rx).await;
-            });
-        });
-
-        for w in writers {
-            w.join().unwrap();
-        }
-        trigger_handle.join().unwrap();
-        fs.mark_writer_done();
-        // Deliberately NOT calling stop.cancel() here -- this is the broken
-        // ordering the module comment warns about.
-        worker.join().unwrap();
-    }
-}
-
 crate::shuttle_test! {
     num_iters = 500, depth = 3;
     // Drives the real `run_triggered()`, including its outer `select!` on


### PR DESCRIPTION
#764 

## Summary
- Adds `primitives::time`/`shuttle_select!` (shuttle-drivable `sleep`/`sleep_until`, biased `select!`) and ports `WorkerLoop::run_triggered` onto them
 - Adds `shuttle` coverage for `WorkerLoop`'s segment-handoff and dump-resolution paths
   - `shuttle_worker_handoff` — writer/worker segment handoff via the real `run()`/`run_continuous()` path
   - `shuttle_dump_resolves_exactly_once` — an on-demand dump racing writer threads
   - `shuttle_dump_time_range_resolves_via_deadline` — only scenario giving a dump a real deadline, forcing a wait on `sleep_until`
- Splits run_background_task into a thin runtime wrapper + run_background_task_inner, now directly shuttle-drivable
    
    ## Notes
- shuttle_dump_resolves_exactly_once::determinism flaked: fixed by giving test segments a parseable header instead of one falling back to SystemTime::now()
- shuttle_dump_time_range_resolves_via_deadline::determinism was flaking ~1-in-5 from two causes, both fixed
- Dropped a should_panic scenario for a documented run_triggered deadlock: real but unreachable via the only production caller, not worth the CI cost