### PR TITLE
fix(viewer): bound selected segment scopes

### DIFF
--- a/dial9-viewer/ui/src/pages/browser/actions.test.ts
+++ b/dial9-viewer/ui/src/pages/browser/actions.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createActions } from "./actions.js";
 import type { BrowserEls } from "./dom.js";
-import { createBrowserStore } from "./state.js";
+import { createBrowserStore, type HeatmapSegment } from "./state.js";
+import { toRows } from "./segments.js";
 
 function input(value = ""): HTMLInputElement {
   return { value } as HTMLInputElement;
@@ -323,5 +324,44 @@ describe("clearBrowseNoService", () => {
     expect(store.getState().browse.status.text).toBe(
       "Choose a service to browse its traces.",
     );
+  });
+});
+
+describe("heatmap segment selection", () => {
+  it("ends at the next segment start instead of its delayed upload time", () => {
+    const store = createBrowserStore();
+    const selected: HeatmapSegment = {
+      key: "traces/2026-04-09/1910/shale/h1/100-0.bin.gz",
+      size: 1,
+      start: 100,
+      // The segment rotated at 110, but S3 completed its upload a second later.
+      end: 111,
+      layout: "known",
+      service: "shale",
+      host: "h1",
+      bootId: "",
+    };
+    const next: HeatmapSegment = {
+      ...selected,
+      key: "traces/2026-04-09/1910/shale/h1/110-1.bin.gz",
+      start: 110,
+      end: 120,
+    };
+    const segments = [selected, next];
+    store.update("browse", {
+      segments,
+      rows: toRows(segments),
+      domain: { tMin: 100, tMax: 120 },
+    });
+    const els = browserEls("");
+    Object.assign(els, { heatmapCanvas: { clientWidth: 100, style: {} } });
+
+    createActions(store, els).selectSegmentAt(0, 0);
+
+    expect(store.getState().browse.selection).toMatchObject({
+      keys: [selected.key],
+      t0: 100,
+      t1: 110,
+    });
   });
 });

--- a/dial9-viewer/ui/src/pages/browser/actions.ts
+++ b/dial9-viewer/ui/src/pages/browser/actions.ts
@@ -854,7 +854,10 @@ export function createActions(store: BrowserStore, els: BrowserEls): BrowserActi
     const W = canvasWidth();
     const { tMin, tMax } = b.domain;
     const t = xToTime(x, tMin, tMax, W);
-    const hits = segmentsOverlapping(b.rows[r]!.segments, t, t);
+    // Use the same tiled spans the heatmap paints. A raw segment ends when its
+    // upload finishes, which can lag beyond the next segment's start; using it
+    // in the generated scope would include that next segment.
+    const hits = segmentsOverlapping(b.rows[r]!.tiled, t, t);
     if (!hits.length) {
       setHeatmapSelection(null);
       return;

--- a/dial9-viewer/ui/tests/core/trace_scope.test.js
+++ b/dial9-viewer/ui/tests/core/trace_scope.test.js
@@ -418,6 +418,52 @@ test("resolveScope uses half-open boundaries for adjacent segments", async () =>
   );
 });
 
+test("resolveScope excludes a preceding segment whose upload lagged into the window", async () => {
+  // #649: a rotating writer's last_modified is when the *upload finished*, which
+  // lands after the next segment already started. A click scoped to exactly one
+  // segment ([its start, its successor's start]) must still resolve to that one
+  // segment — the previous segment's lagging end must not drag it in.
+  const s = {
+    bucket: "bkt",
+    prefix: "traces",
+    service: "shale",
+    hosts: ["h1"],
+    from: 1782760100,
+    to: 1782760160,
+  };
+  const selected = key("h1", 1782760100, 1);
+  const browse = {
+    objects: [
+      // Started 60s before the window; upload finished 5s INTO it.
+      { key: key("h1", 1782760040, 0), size: 10, last_modified: "2026-06-29T19:08:25Z" },
+      // The clicked segment; its own upload also laps past `to`.
+      { key: selected, size: 10, last_modified: "2026-06-29T19:09:25Z" },
+      { key: key("h1", 1782760160, 2), size: 10, last_modified: "2026-06-29T19:10:25Z" },
+    ],
+  };
+
+  const urls = await scope.resolveScope(s, async () => browse);
+  assert.deepStrictEqual(
+    urls.map((u) => new URL(u, "http://dial9.test").searchParams.get("key")),
+    [selected],
+    "upload lag must not widen the window to the neighbouring segments",
+  );
+});
+
+test("resolveScope keeps a genuine overlap from a different host", async () => {
+  // Ends are tiled per service/host row, so one host's rotation cadence can
+  // never mask another host's segment that really does cover the window.
+  const s = { bucket: "bkt", prefix: "traces", service: "shale", hosts: [], from: 1782760100, to: 1782760160 };
+  const browse = {
+    objects: [
+      { key: key("h1", 1782760100, 1), size: 10, last_modified: "2026-06-29T19:09:25Z" },
+      { key: key("h2", 1782760040, 0), size: 10, last_modified: "2026-06-29T19:10:25Z" },
+    ],
+  };
+  const urls = await scope.resolveScope(s, async () => browse);
+  assert.strictEqual(urls.length, 2, "h2 has no successor to clamp against, so its real span counts");
+});
+
 test("resolveScope sends an encoded service and retains client-side service filtering", async () => {
   const service = "checkout api+canary?";
   const s = {

--- a/dial9-viewer/ui/trace_scope.js
+++ b/dial9-viewer/ui/trace_scope.js
@@ -333,6 +333,36 @@
     return params.get(P.from) != null && params.get(P.to) != null;
   }
 
+  // Effective end of each candidate for the window-overlap test, keyed by S3
+  // key. A segment's `last_modified` is when its *upload finished*, which for a
+  // rotating writer lands after the next segment already started. Compared raw,
+  // that lag makes a segment overlap a window that begins at its successor's
+  // start — so a click scoped to exactly one segment would also re-resolve the
+  // one before it. Clamp each end to the next start on the same service/host
+  // (the same tiling the heatmap paints with), so consecutive segments meet at
+  // a single boundary instead of overlapping.
+  function tiledEnds(candidates) {
+    const byHost = new Map();
+    for (const c of candidates) {
+      const rowKey = c.service + " " + c.host;
+      let row = byHost.get(rowKey);
+      if (!row) byHost.set(rowKey, (row = []));
+      row.push(c);
+    }
+    const ends = new Map();
+    for (const row of byHost.values()) {
+      row.sort((a, b) => a.start - b.start);
+      for (let i = 0; i < row.length; i++) {
+        const next = row[i + 1];
+        let end = row[i].end;
+        // Clamp only on real overlap, and never back past the start.
+        if (next && next.start > row[i].start && next.start < end) end = next.start;
+        ends.set(row[i].key, end);
+      }
+    }
+    return ends;
+  }
+
   // Resolve a scope to the list of /api/object URLs its files map to. `fetchJson`
   // is an injected `(url) => Promise<parsedJson>` so each page supplies its own
   // credentialed fetch and the resolver stays unit-testable. Lists the window
@@ -350,21 +380,28 @@
     const objects = (result && result.objects) || [];
 
     const hostSet = new Set(scope.hosts || []);
-    const matched = [];
+    // Candidates first: parse and apply the host/service filters, then tile the
+    // ends within each row before testing window overlap.
+    const candidates = [];
     for (const obj of objects) {
       const p = parseKey(obj.key);
       // Window overlap: segment start (epoch) to last_modified (upload time).
       const start = p.epoch;
       if (!start) continue;
+      if (scope.service && p.service && p.service !== scope.service) continue;
+      if (hostSet.size && !hostSet.has(p.host)) continue;
       const end = obj.last_modified
         ? new Date(obj.last_modified).getTime() / 1000
         : start;
-      if (start >= scope.to || end <= scope.from) continue;
-      if (scope.service && p.service && p.service !== scope.service) continue;
-      if (hostSet.size && !hostSet.has(p.host)) continue;
-      matched.push({ key: obj.key, epoch: start });
+      candidates.push({ key: obj.key, service: p.service, host: p.host, start, end });
     }
-    matched.sort((a, b) => a.epoch - b.epoch || (a.key < b.key ? -1 : 1));
+    const ends = tiledEnds(candidates);
+    const matched = [];
+    for (const c of candidates) {
+      if (c.start >= scope.to || ends.get(c.key) <= scope.from) continue;
+      matched.push(c);
+    }
+    matched.sort((a, b) => a.start - b.start || (a.key < b.key ? -1 : 1));
     return objectTraceUrls(scope.bucket, matched.map((m) => m.key));
   }
 


### PR DESCRIPTION
#649 Fixes heatmap click selections that could include the following segment. Selection now uses the tiled
segment boundary, with a regression test covering the overlap.
