### PR TITLE
fix(viewer): don't report a rotation-stranded poll as a long poll

### DIFF
--- a/dial9-viewer/src/ingest/decode.rs
+++ b/dial9-viewer/src/ingest/decode.rs
@@ -140,6 +140,7 @@ pub(crate) fn decode_samples_with_stats(
     let t_polls = Instant::now();
     let mut poll_timeline = polls::PollTimeline::reconstruct(&events);
     stats.poll_reconstruct = t_polls.elapsed();
+    stats.polls_end_unproven = poll_timeline.end_unproven();
 
     let t_samples = Instant::now();
     let mut stacks_dict: FxHashMap<[u8; 16], Vec<String>> = FxHashMap::default();

--- a/dial9-viewer/src/ingest/decode/polls.rs
+++ b/dial9-viewer/src/ingest/decode/polls.rs
@@ -42,6 +42,7 @@ pub(crate) struct PollTimeline {
     records: Vec<PollRecord>,
     by_worker: FxHashMap<u64, Vec<usize>>,
     sample_counts: Vec<(u32, u32)>,
+    end_unproven: u64,
 }
 
 /// Per-task readiness bookkeeping used while reconstructing polls.
@@ -51,6 +52,25 @@ struct TaskState {
     instrumented: Option<bool>,
     polling: bool,
     terminated: bool,
+}
+
+/// Why a poll span is being closed, which decides whether its `end` is
+/// evidence or a guess.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CloseReason {
+    /// An explicit `PollEnd`: the only event that proves when a poll stopped.
+    Explicit,
+    /// A `WorkerPark`. The worker parks on its own thread straight after the
+    /// poll yields, so the park bounds the poll even with its `PollEnd` lost
+    /// (the `block_in_place` handoff case).
+    Park,
+    /// Nothing proves when the poll ended - a later `PollStart` on the same
+    /// worker, the same task reappearing on another worker, or a `WorkerUnpark`
+    /// showing the worker sat parked meanwhile. The interval between the
+    /// `PollStart` and this event may be mostly or entirely unobserved, so no
+    /// span is emitted: a guessed `end` reads downstream as a long off-CPU poll
+    /// (0 CPU samples over a wide span) that never happened.
+    Unproven,
 }
 
 /// A poll open on a worker while its `PollEnd` has not yet arrived.
@@ -74,6 +94,9 @@ struct Reconstructor {
     open_worker_by_task: FxHashMap<u64, u64>,
     tasks: FxHashMap<u64, TaskState>,
     records: Vec<PollRecord>,
+    /// Polls dropped because nothing proved their end. Surfaced through
+    /// [`DecodeStats`](super::types::DecodeStats) so the loss stays visible.
+    end_unproven: u64,
 }
 
 impl Reconstructor {
@@ -124,14 +147,28 @@ impl Reconstructor {
     }
 
     fn poll_start(&mut self, event: &PollStart) {
-        // Missing end events are segment/recovery artifacts. Close the span for
-        // duration accounting, but do not infer readiness from a wake inside it:
-        // only an explicit PollEnd proves when the task stopped running.
-        self.close_poll(event.worker_id, MonoNs(event.timestamp_ns), false);
+        // A poll still open here lost its PollEnd, typically to a rotation that
+        // cut this worker's buffer mid-poll: threads flush independently, so one
+        // worker's stream can end early in a file while others run on, and the
+        // missing PollEnd is sitting in the NEXT file.
+        //
+        // This PollStart bounds the poll only from above, and when it arrives on
+        // a different worker the bound is "when the task next ran anywhere" -
+        // which grows with how idle the task was, so the worst fabrications land
+        // on the least busy tasks. Drop rather than guess.
+        self.close_poll(
+            event.worker_id,
+            MonoNs(event.timestamp_ns),
+            CloseReason::Unproven,
+        );
         if let Some(other_worker) = self.open_worker_by_task.get(&event.task_id).copied()
             && other_worker != event.worker_id
         {
-            self.close_poll(other_worker, MonoNs(event.timestamp_ns), false);
+            self.close_poll(
+                other_worker,
+                MonoNs(event.timestamp_ns),
+                CloseReason::Unproven,
+            );
         }
 
         let state = self.tasks.entry(event.task_id).or_default();
@@ -157,14 +194,33 @@ impl Reconstructor {
     }
 
     fn poll_end(&mut self, event: &PollEnd) {
-        self.close_poll(event.worker_id, MonoNs(event.timestamp_ns), true);
+        self.close_poll(
+            event.worker_id,
+            MonoNs(event.timestamp_ns),
+            CloseReason::Explicit,
+        );
     }
 
     fn worker_park(&mut self, event: &WorkerPark) {
-        self.close_poll(event.worker_id, MonoNs(event.timestamp_ns), false);
+        self.close_poll(
+            event.worker_id,
+            MonoNs(event.timestamp_ns),
+            CloseReason::Park,
+        );
     }
 
-    fn close_poll(&mut self, worker_id: u64, end: MonoNs, explicit_end: bool) {
+    /// An unpark proves the worker was parked up to this instant, so a poll
+    /// still open across it was not running: its `PollEnd`, and the park that
+    /// would have bounded it, were both lost. The true end is unrecoverable.
+    fn worker_unpark(&mut self, event: &super::events::WorkerUnpark) {
+        self.close_poll(
+            event.worker_id,
+            MonoNs(event.timestamp_ns),
+            CloseReason::Unproven,
+        );
+    }
+
+    fn close_poll(&mut self, worker_id: u64, end: MonoNs, reason: CloseReason) {
         let Some(open) = self.open_by_worker.remove(&worker_id) else {
             return;
         };
@@ -172,13 +228,20 @@ impl Reconstructor {
 
         let state = self.tasks.entry(open.task_id).or_default();
         state.polling = false;
-        if explicit_end
+        // Only an explicit PollEnd proves when the task stopped running, so only
+        // it can turn a wake seen mid-poll into readiness for the next poll.
+        if reason == CloseReason::Explicit
             && !state.terminated
             && let Some(mut wake) = open.wake_during_poll
         {
             wake.timestamp = end;
             wake.kind = SchedulingDelayKind::WakeDuringPoll;
             state.ready = Some(wake);
+        }
+
+        if reason == CloseReason::Unproven {
+            self.end_unproven += 1;
+            return;
         }
 
         self.records.push(PollRecord {
@@ -268,10 +331,12 @@ impl PollTimeline {
                 TraceEvent::PollStart(event) => reconstructor.poll_start(event),
                 TraceEvent::PollEnd(event) => reconstructor.poll_end(event),
                 TraceEvent::WorkerPark(event) => reconstructor.worker_park(event),
-                TraceEvent::CpuSample(_) | TraceEvent::WorkerUnpark(_) => {}
+                TraceEvent::WorkerUnpark(event) => reconstructor.worker_unpark(event),
+                TraceEvent::CpuSample(_) => {}
             }
         }
         // Unclosed polls are segment-boundary artifacts and remain discarded.
+        let end_unproven = reconstructor.end_unproven;
         let mut records = reconstructor.records;
 
         records.sort_unstable_by_key(|poll| poll.start);
@@ -287,7 +352,15 @@ impl PollTimeline {
             records,
             by_worker,
             sample_counts,
+            end_unproven,
         }
+    }
+
+    /// Polls dropped because no event proved their end. A nonzero count means
+    /// the file lost `PollEnd`s - usually to a rotation that cut a worker's
+    /// buffer mid-poll, leaving the close in the next file.
+    pub(crate) fn end_unproven(&self) -> u64 {
+        self.end_unproven
     }
 
     /// Attribute one sample and return `(worker, poll_duration, spawn_location)`.
@@ -471,6 +544,22 @@ mod tests {
         }
     }
 
+    fn start_on(worker_id: u64, timestamp_ns: u64, task_id: u64) -> PollStart {
+        PollStart {
+            timestamp_ns,
+            worker_id,
+            task_id,
+            spawn_loc: Some("src/test.rs:1".to_string()),
+        }
+    }
+
+    fn end_on(worker_id: u64, timestamp_ns: u64) -> PollEnd {
+        PollEnd {
+            timestamp_ns,
+            worker_id,
+        }
+    }
+
     #[test]
     fn spawn_infers_first_poll_without_wake_events() {
         let mut reconstructor = Reconstructor::default();
@@ -550,7 +639,134 @@ mod tests {
         reconstructor.poll_start(&start(500, 7));
         reconstructor.poll_end(&end(520));
 
-        assert_eq!(reconstructor.records.len(), 2);
-        assert!(reconstructor.records[1].readiness.is_none());
+        // The synthetically closed poll is dropped - a PollStart bounds the
+        // stranded poll only from above - so the explicitly ended one is the
+        // single record, and the mid-poll wake did not become its readiness.
+        assert_eq!(reconstructor.records.len(), 1);
+        assert_eq!(reconstructor.records[0].start, MonoNs(500));
+        assert!(reconstructor.records[0].readiness.is_none());
+        assert_eq!(reconstructor.end_unproven, 1);
+    }
+
+    fn park(timestamp_ns: u64) -> TraceEvent {
+        TraceEvent::WorkerPark(WorkerPark {
+            timestamp_ns,
+            worker_id: 0,
+            tid: 100,
+        })
+    }
+
+    fn unpark(timestamp_ns: u64) -> TraceEvent {
+        TraceEvent::WorkerUnpark(WorkerUnpark {
+            timestamp_ns,
+            worker_id: 0,
+            tid: 100,
+        })
+    }
+
+    /// A park bounds the poll it interrupts: the worker parks on its own thread
+    /// straight after the poll yields, so the span is real even with the
+    /// `PollEnd` missing.
+    #[test]
+    fn park_bounds_a_poll_whose_end_was_lost() {
+        let events = vec![
+            TraceEvent::PollStart(start(1_000, 7)),
+            park(1_100),
+            unpark(31_000),
+            TraceEvent::PollStart(start(31_000, 8)),
+            TraceEvent::PollEnd(end(31_100)),
+        ];
+
+        let timeline = PollTimeline::reconstruct(&events);
+        let spans: Vec<_> = timeline
+            .records()
+            .iter()
+            .map(|p| (p.task_id, p.start.raw(), p.end.raw()))
+            .collect();
+        assert_eq!(spans, vec![(7, 1_000, 1_100), (8, 31_000, 31_100)]);
+    }
+
+    /// An unpark proves the worker was parked, so a poll still open across it
+    /// was not running. Its true end is unrecoverable and must not be invented
+    /// from the next `PollStart`.
+    #[test]
+    fn unpark_refutes_a_poll_left_open_across_an_idle_stretch() {
+        let events = vec![
+            TraceEvent::PollStart(start(1_000, 7)),
+            // PollEnd and WorkerPark both lost to a rotation cut.
+            unpark(31_000),
+            TraceEvent::PollStart(start(31_000, 8)),
+            TraceEvent::PollEnd(end(31_100)),
+        ];
+
+        let timeline = PollTimeline::reconstruct(&events);
+        let spans: Vec<_> = timeline
+            .records()
+            .iter()
+            .map(|p| (p.task_id, p.start.raw(), p.end.raw()))
+            .collect();
+        assert_eq!(
+            spans,
+            vec![(8, 31_000, 31_100)],
+            "the idle stretch must not surface as a poll of task 7"
+        );
+    }
+
+    /// The shape a forced rotation actually produces, and the one that caused
+    /// the reported 33.6ms phantom: threads flush independently, so worker 0's
+    /// stream ends mid-poll while worker 1's runs on. The task is next polled on
+    /// worker 1 much later, and the cross-worker close in `poll_start` used to
+    /// emit the whole interval as worker 0's poll.
+    ///
+    /// The bound here is "when the task next ran ANYWHERE", so it grows with how
+    /// idle the task was - a metric anti-correlated with the long-poll signal it
+    /// pollutes. Worker 0's poll is unrecoverable from this file alone (its
+    /// PollEnd is in the next one) and must not be emitted.
+    #[test]
+    fn a_rotation_cut_does_not_become_a_poll_on_the_stale_worker() {
+        let events = vec![
+            TraceEvent::PollStart(start_on(0, 1_000, 7)),
+            // Worker 0's buffer ends here; its PollEnd landed in the next file.
+            TraceEvent::PollStart(start_on(1, 34_000, 7)),
+            TraceEvent::PollEnd(end_on(1, 34_100)),
+        ];
+
+        let timeline = PollTimeline::reconstruct(&events);
+        let spans: Vec<_> = timeline
+            .records()
+            .iter()
+            .map(|p| (p.worker_id, p.task_id, p.start.raw(), p.end.raw()))
+            .collect();
+        assert_eq!(
+            spans,
+            vec![(1, 7, 34_000, 34_100)],
+            "the rotation gap must not surface as a 33us poll on worker 0"
+        );
+        assert_eq!(timeline.end_unproven(), 1);
+    }
+
+    /// With every event in the gap dropped, a later `PollStart` is the only
+    /// thing that can close the stranded poll - and it is not evidence of when
+    /// the poll ended, so no span may be emitted.
+    #[test]
+    fn poll_start_does_not_invent_a_span_across_an_unobserved_gap() {
+        let events = vec![
+            TraceEvent::PollStart(start(1_000, 7)),
+            // Recording off: PollEnd, park and unpark all lost.
+            TraceEvent::PollStart(start(31_000, 8)),
+            TraceEvent::PollEnd(end(31_100)),
+        ];
+
+        let timeline = PollTimeline::reconstruct(&events);
+        let spans: Vec<_> = timeline
+            .records()
+            .iter()
+            .map(|p| (p.task_id, p.start.raw(), p.end.raw()))
+            .collect();
+        assert_eq!(
+            spans,
+            vec![(8, 31_000, 31_100)],
+            "an unproven end must not become a 30us poll of task 7"
+        );
     }
 }

--- a/dial9-viewer/src/ingest/decode/types.rs
+++ b/dial9-viewer/src/ingest/decode/types.rs
@@ -222,6 +222,14 @@ pub struct DecodeStats {
     pub sort_events: std::time::Duration,
     /// Phase: reconstruct the poll timeline from park/unpark/poll events.
     pub poll_reconstruct: std::time::Duration,
+    /// Polls dropped because no event proved their end - usually a rotation cut
+    /// the worker's buffer mid-poll, so the `PollEnd` is in the next file.
+    ///
+    /// Nonzero means this file's poll durations are UNDERCOUNTED rather than
+    /// inflated. The alternative was guessing an end and reporting unobserved
+    /// time as a long poll; the honest recovery is to stitch the poll across the
+    /// two files, as the viewer's `computeWindowBoundaryPolls` does.
+    pub polls_end_unproven: u64,
     /// Phase: the sample loop (symbolication + per-sample poll attribution).
     pub sample_resolve: std::time::Duration,
     /// Phase: tracing/single-event span resolution.

--- a/dial9-viewer/ui/src/lib/trace/analysis.test.ts
+++ b/dial9-viewer/ui/src/lib/trace/analysis.test.ts
@@ -35,6 +35,34 @@ describe("analysis.ts wiring", () => {
     });
   });
 
+  it("buildWorkerSpans drops a poll left open across an unpark", () => {
+    const base = {
+      workerId: 0,
+      localQueue: 0,
+      globalQueue: 0,
+      cpuTime: 0,
+      schedWait: 0,
+      spawnLocId: null,
+      spawnLoc: null,
+    };
+    // Task 7's PollEnd and the park that would have bounded it were both lost.
+    // The unpark proves the worker sat parked, so the 30ms up to it is not a
+    // poll of task 7 - only task 8's explicitly ended poll survives.
+    const events = [
+      { ...base, taskId: 7, eventType: EVENT_TYPES.PollStart, timestamp: 1_000 },
+      { ...base, taskId: 0, eventType: EVENT_TYPES.WorkerUnpark, timestamp: 31_000 },
+      { ...base, taskId: 8, eventType: EVENT_TYPES.PollStart, timestamp: 31_000 },
+      { ...base, taskId: 8, eventType: EVENT_TYPES.PollEnd, timestamp: 31_100 },
+    ];
+    const { workerSpans } = buildWorkerSpans(events, [0], 32_000);
+    expect(workerSpans[0]?.polls).toHaveLength(1);
+    expect(workerSpans[0]?.polls[0]).toMatchObject({
+      start: 31_000,
+      end: 31_100,
+      taskId: 8,
+    });
+  });
+
   it("buildActiveTaskTimeline steps on spawn and terminate", () => {
     const { activeTaskSamples } = buildActiveTaskTimeline(
       new Map([

--- a/dial9-viewer/ui/src/lib/trace/columnar-pois.test.ts
+++ b/dial9-viewer/ui/src/lib/trace/columnar-pois.test.ts
@@ -142,8 +142,12 @@ describe("taskAggregates matches a fat reduction", () => {
           firstPollStart: Infinity, firstPollWorker: -1, workers: new Set(),
         };
         a.pollCount++;
-        a.totalPollNs += dur;
-        if (dur > a.longestPollNs) a.longestPollNs = dur;
+        // An open-ended poll's duration is unknown, so it contributes to the
+        // count and the worker set but not to total/longest.
+        if (!p.openEnded) {
+          a.totalPollNs += dur;
+          if (dur > a.longestPollNs) a.longestPollNs = dur;
+        }
         if (p.start < a.firstPollStart) { a.firstPollStart = p.start; a.firstPollWorker = w; }
         a.workers.add(w);
         fat.set(p.taskId, a);

--- a/dial9-viewer/ui/src/lib/trace/columnar-worker-spans.test.ts
+++ b/dial9-viewer/ui/src/lib/trace/columnar-worker-spans.test.ts
@@ -40,6 +40,33 @@ describe("ColumnarWorkerSpans", () => {
     expect(total).toBeGreaterThan(0);
   });
 
+  it("taskAggregates leaves an open-ended poll's unknown duration out of total/longest", () => {
+    // One task, two polls on one worker: a short explicitly ended poll and a
+    // much longer open-ended one (no PollEnd, so its end is only a bound). The
+    // long one must not become the task's longest poll.
+    const lane = {
+      polls: [
+        { start: 1_000, end: 1_100, taskId: 7, spawnLocId: null, spawnLoc: null },
+        { start: 2_000, end: 32_000, taskId: 7, spawnLocId: null, spawnLoc: null, openEnded: true },
+      ],
+      parks: [],
+      actives: [],
+    };
+    const store = ColumnarWorkerSpans.fromWorkerSpans({ 0: lane } as never);
+    const aggs = store.taskAggregates();
+    expect(aggs).toHaveLength(1);
+    expect(aggs[0]).toMatchObject({
+      taskId: 7,
+      // Both polls happened, so both are counted...
+      pollCount: 2,
+      // ...but only the proven one contributes duration.
+      totalPollNs: 100,
+      longestPollNs: 100,
+      firstPollStart: 1_000,
+      workerCount: 1,
+    });
+  });
+
   it("columnar parks + actives are field-for-field identical to the objects", () => {
     const store = ColumnarWorkerSpans.fromWorkerSpans(ws as never);
     let parks = 0, actives = 0;

--- a/dial9-viewer/ui/src/lib/trace/columnar-worker-spans.ts
+++ b/dial9-viewer/ui/src/lib/trace/columnar-worker-spans.ts
@@ -104,6 +104,8 @@ export interface PollsByTaskCSR {
   start: Float64Array;
   end: Float64Array;
   worker: Float64Array;
+  /** 1 = no matching PollEnd, so `end` is a bound, not the poll's real end. */
+  openEnded: Uint8Array;
 }
 
 /** Per-task poll aggregate for the Tasks tab index. Scalars only - reduced from
@@ -641,6 +643,7 @@ export class ColumnarWorkerSpans {
     const start = new Float64Array(off[T]!);
     const end = new Float64Array(off[T]!);
     const worker = new Float64Array(off[T]!);
+    const openEnded = new Uint8Array(off[T]!);
     const cur = off.slice(0, T);
     // Pass 2: fill.
     for (const [w, c] of this.byWorker) {
@@ -649,11 +652,12 @@ export class ColumnarWorkerSpans {
         if (!t) continue;
         const p = cur[slotOf.get(t)!]!++;
         start[p] = c.start[i]!; end[p] = c.end[i]!; worker[p] = w;
+        openEnded[p] = c.openEnded[i]!;
       }
     }
     // Sort each task slice by start (stable - matches the fat arr.sort tie-break).
-    for (let s = 0; s < T; s++) sortTriByStart(start, end, worker, off[s]!, off[s + 1]!);
-    return (this._pollsByTaskCSR = { slotOf, off, start, end, worker });
+    for (let s = 0; s < T; s++) sortTriByStart(start, end, worker, openEnded, off[s]!, off[s + 1]!);
+    return (this._pollsByTaskCSR = { slotOf, off, start, end, worker, openEnded });
   }
 
   /**
@@ -662,6 +666,14 @@ export class ColumnarWorkerSpans {
    * (the CSR slice is start-sorted, so slot 0 is the first). Never materializes
    * a PollView - the whole point of the columnar path. Tasks that never polled
    * are absent here; the caller unions them in from the spawn map.
+   *
+   * An open-ended poll has no matching PollEnd, so its `end` is only an upper
+   * bound - the interval up to it can be mostly idle (a park whose events were
+   * lost, or a block_in_place handoff at an unknown instant). It still counts as
+   * a poll and still names its workers, but its duration is unknown and is left
+   * out of `total`/`longest` rather than reported as time the task spent
+   * running. Including it made an unobserved gap read as the task's longest
+   * poll.
    */
   taskAggregates(): TaskPollAggregate[] {
     const csr = this.pollsByTaskCSR();
@@ -674,10 +686,11 @@ export class ColumnarWorkerSpans {
       let longest = 0;
       const workers = new Set<number>();
       for (let p = lo; p < hi; p++) {
+        workers.add(csr.worker[p]!);
+        if (csr.openEnded[p] === 1) continue;
         const dur = csr.end[p]! - csr.start[p]!;
         total += dur;
         if (dur > longest) longest = dur;
-        workers.add(csr.worker[p]!);
       }
       out.push({
         taskId,
@@ -1030,7 +1043,8 @@ export class ColumnarWorkerSpansBuilder {
  * ascending; ties keep insertion order (== the fat arr.sort tie-break, so the
  * mid-poll binary search + segment reconstruction pick the same poll). */
 function sortTriByStart(
-  pStart: Float64Array, pEnd: Float64Array, pWorker: Float64Array, lo: number, hi: number
+  pStart: Float64Array, pEnd: Float64Array, pWorker: Float64Array, pOpen: Uint8Array,
+  lo: number, hi: number
 ): void {
   const n = hi - lo;
   if (n < 2) return;
@@ -1039,8 +1053,13 @@ function sortTriByStart(
   const arr = Array.from({ length: n }, (_, k) => lo + k);
   arr.sort((x, y) => pStart[x]! - pStart[y]! || x - y);
   const ts = new Float64Array(n), te = new Float64Array(n), tw = new Float64Array(n);
-  for (let k = 0; k < n; k++) { ts[k] = pStart[arr[k]!]!; te[k] = pEnd[arr[k]!]!; tw[k] = pWorker[arr[k]!]!; }
+  const to = new Uint8Array(n);
+  for (let k = 0; k < n; k++) {
+    ts[k] = pStart[arr[k]!]!; te[k] = pEnd[arr[k]!]!; tw[k] = pWorker[arr[k]!]!;
+    to[k] = pOpen[arr[k]!]!;
+  }
   pStart.set(ts, lo);
   pEnd.set(te, lo);
   pWorker.set(tw, lo);
+  pOpen.set(to, lo);
 }

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -596,6 +596,16 @@
             openUnpark[w] = null;
           }
         } else if (e.eventType === EVENT_TYPES.WorkerUnpark) {
+          // An unpark with a poll still open means the poll's PollEnd AND the
+          // park that would have bounded it were both lost. The worker sat
+          // parked meanwhile, so the poll was not running: drop it rather than
+          // draw a bar over the park. Same reasoning as the trace-end discard
+          // below (#194) - `openPark[w]` is necessarily null here, because a
+          // park event would already have closed the poll above.
+          if (openPoll[w] != null) {
+            openPoll[w] = null;
+            openPollMeta[w] = null;
+          }
           if (openPark[w] != null) {
             workerSpans[w].parks.push({
               start: openPark[w],


### PR DESCRIPTION
Worker threads flush their trace buffers independently, so a segment rotation cuts each worker's stream at a different point. Everything after the cut lands in the next file. A poll open at that cut has its `PollEnd` in the *next* file, not this one.

This adds a classification of missing `PollEnd` to avoid inaccurately reporting `PollEnd` when events are cut off.

## Reviewer note

Also note `block_in_place` handoffs close via `PollStart` too, so those spans now drop instead of rendering open-ended. ADR-0002 already accepts that trade (`blockInPlaceGaps` is the honest channel), but the discriminator exists if we want them back: compare the tid bound to the worker at the poll's start against the tid at the close — `reconstruct` already computes `tid_handoff_gaps`.
