### PR TITLE
fix(viewer): preserve out-of-pane browse selection

### DIFF
--- a/dial9-viewer/ui/src/pages/browser/heatmap-interact.test.ts
+++ b/dial9-viewer/ui/src/pages/browser/heatmap-interact.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { BrowserActions } from "./actions.js";
+import type { BrowserEls } from "./dom.js";
+import { mountHeatmapInteraction } from "./heatmap-interact.js";
+import { createBrowserStore, type HeatmapSelection } from "./state.js";
+
+type Listener = (event: Record<string, unknown>) => void;
+
+class FakeEventTarget {
+  private readonly listeners = new Map<string, Listener[]>();
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  dispatch(type: string, event: Record<string, unknown> = {}): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+class FakeElement extends FakeEventTarget {
+  constructor(private readonly ancestors: readonly string[] = []) {
+    super();
+  }
+
+  closest(selector: string): FakeElement | null {
+    return this.ancestors.includes(selector) ? this : null;
+  }
+
+  getBoundingClientRect(): DOMRect {
+    return { left: 0, top: 0, width: 100 } as DOMRect;
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("heatmap pointer interaction", () => {
+  it("keeps a selection when its drag ends outside the pane", () => {
+    const win = new FakeEventTarget();
+    const doc = new FakeEventTarget();
+    vi.stubGlobal("Element", FakeElement);
+    vi.stubGlobal("window", win);
+    vi.stubGlobal("document", doc);
+
+    const plot = new FakeElement(["#heatmap-view"]);
+    const canvas = new FakeElement() as FakeElement & { clientWidth: number };
+    canvas.clientWidth = 100;
+    const reset = new FakeElement();
+    const els = {
+      heatmapPlot: plot,
+      heatmapCanvas: canvas,
+      heatmapResetZoom: reset,
+    } as unknown as BrowserEls;
+
+    const store = createBrowserStore();
+    store.update("browse", {
+      rows: [
+        {
+          service: "service",
+          host: "host",
+          label: "service / host",
+          segments: [],
+          totalBytes: 0,
+          tiled: [],
+          gaps: [],
+        },
+      ],
+      selection: null,
+    });
+    const selection: HeatmapSelection = {
+      keys: ["trace.bin"],
+      bytes: 1,
+      t0: 10,
+      t1: 50,
+      rows: [0, 0],
+    };
+    const setHeatmapSelection = vi.fn((next: HeatmapSelection | null) => {
+      store.update("browse", { selection: next });
+    });
+    const actions = {
+      finalizeSelection: vi.fn(() => {
+        store.update("browse", { selection });
+      }),
+      selectSegmentAt: vi.fn(),
+      zoomToX: vi.fn(),
+      resetHeatmapZoom: vi.fn(),
+      setHeatmapSelection,
+    } as unknown as BrowserActions;
+
+    mountHeatmapInteraction({ store, els, actions });
+
+    plot.dispatch("mousedown", {
+      clientX: 10,
+      clientY: 5,
+      altKey: false,
+      preventDefault: vi.fn(),
+    });
+    win.dispatch("mouseup", { clientX: 50, clientY: 40 });
+    doc.dispatch("click", { target: new FakeElement() });
+
+    expect(store.getState().browse.selection).toBe(selection);
+    expect(setHeatmapSelection).not.toHaveBeenCalled();
+
+    // The suppression is one-shot: the next genuine click-away still clears.
+    doc.dispatch("click", { target: new FakeElement() });
+    expect(store.getState().browse.selection).toBeNull();
+  });
+});

--- a/dial9-viewer/ui/src/pages/browser/heatmap-interact.test.ts
+++ b/dial9-viewer/ui/src/pages/browser/heatmap-interact.test.ts
@@ -21,8 +21,11 @@ class FakeEventTarget {
 }
 
 class FakeElement extends FakeEventTarget {
-  constructor(private readonly ancestors: readonly string[] = []) {
+  private readonly ancestors: readonly string[];
+
+  constructor(ancestors: readonly string[] = []) {
     super();
+    this.ancestors = ancestors;
   }
 
   closest(selector: string): FakeElement | null {

--- a/dial9-viewer/ui/src/pages/browser/heatmap-interact.ts
+++ b/dial9-viewer/ui/src/pages/browser/heatmap-interact.ts
@@ -15,6 +15,9 @@ export function mountHeatmapInteraction({ store, els, actions }: PageCtx): void 
   let zooming = false;
   let startX = 0;
   let startY = 0;
+  // A drag ending outside the plot emits a trailing click on an ancestor.
+  // Consume that click so it cannot clear the selection committed on mouseup.
+  let justDraggedOnHeatmap = false;
 
   function localXY(e: MouseEvent): { x: number; y: number } {
     const rect = els.heatmapPlot.getBoundingClientRect();
@@ -30,6 +33,7 @@ export function mountHeatmapInteraction({ store, els, actions }: PageCtx): void 
 
   els.heatmapPlot.addEventListener("mousedown", (e) => {
     if (!store.getState().browse.rows.length) return;
+    justDraggedOnHeatmap = false;
     dragging = true;
     zooming = e.altKey;
     const { x, y } = localXY(e);
@@ -54,6 +58,7 @@ export function mountHeatmapInteraction({ store, els, actions }: PageCtx): void 
     store.update("transient", { drag: null });
     if (zooming) {
       zooming = false;
+      justDraggedOnHeatmap = true;
       actions.zoomToX(Math.min(x, startX), Math.max(x, startX));
       return;
     }
@@ -62,6 +67,7 @@ export function mountHeatmapInteraction({ store, els, actions }: PageCtx): void 
     if (dx <= DRAG_INTENT_PX && dy <= DRAG_INTENT_PX) {
       actions.selectSegmentAt(startX, startY); // treat as a click
     } else {
+      justDraggedOnHeatmap = true;
       actions.finalizeSelection(
         Math.min(x, startX),
         Math.max(x, startX),
@@ -85,6 +91,9 @@ export function mountHeatmapInteraction({ store, els, actions }: PageCtx): void 
   // current selection. Clicks inside the plot are handled by its own
   // mousedown/up; clicks on the action buttons must preserve the selection.
   document.addEventListener("click", (e) => {
+    const wasDrag = justDraggedOnHeatmap;
+    justDraggedOnHeatmap = false;
+    if (wasDrag) return;
     const s = store.getState();
     if (s.ui.tab !== "browse" || !s.browse.selection) return;
     const target = e.target instanceof Element ? e.target : null;


### PR DESCRIPTION
fixes #644 by preventing the synthetic click after an out-of-pane drag from clearing the new selection. Includes a regression test.

