### PR TITLE
fix(viewer): use sampled active-task totals in analysis

### DIFF
--- a/dial9-viewer/skills/dial9-red-flags/scripts/red_flag_scan.js
+++ b/dial9-viewer/skills/dial9-red-flags/scripts/red_flag_scan.js
@@ -16,7 +16,7 @@ function resolve(name) {
 }
 
 const { parseTrace, EVENT_TYPES, deduplicateSamples } = require(resolve('trace_parser.js'));
-const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline,
+const { activeTaskSeries, buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline,
         computeSchedulingDelays, buildSpanData, globalQueueSeries } = require(resolve('trace_analysis.js'));
 
 async function redFlagScan(tracePath) {
@@ -31,6 +31,7 @@ async function redFlagScan(tracePath) {
     const spans = buildWorkerSpans(trace.events, workerIds, maxTs, trace.blockInPlaceGaps);
     attachCpuSamples(trace.cpuSamples, spans.workerSpans);
     const taskTimeline = buildActiveTaskTimeline(trace.taskSpawnTimes, trace.taskTerminateTimes);
+    const activeTaskSamples = activeTaskSeries(trace, taskTimeline);
     const schedDelays = computeSchedulingDelays(spans.workerSpans, workerIds, spans.wakesByTask);
 
     const findings = [];
@@ -56,7 +57,7 @@ async function redFlagScan(tracePath) {
     }
 
     // 2. Task leak detection
-    const samples = taskTimeline.activeTaskSamples;
+    const samples = activeTaskSamples;
     if (samples.length > 10) {
       const first = samples[0].count;
       const last = samples[samples.length - 1].count;

--- a/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
+++ b/dial9-viewer/skills/dial9-toolkit/scripts/analyze.js
@@ -20,7 +20,7 @@ function resolve(name) {
 }
 
 const { parseTrace, EVENT_TYPES, formatFrame, symbolizeChain, deduplicateSamples, deriveCapabilities } = require(resolve('trace_parser.js'));
-const { buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline,
+const { activeTaskSeries, buildWorkerSpans, attachCpuSamples, buildActiveTaskTimeline,
         computeSchedulingDelays, filterPointsOfInterest, buildSpanData, analyzeAllocations,
         globalQueueSeries } = require(resolve('trace_analysis.js'));
 const { diagnoseSetup } = require(resolve('diagnose_setup.js'));
@@ -179,6 +179,7 @@ function accumulateTrace(acc, trace, sourceFile) {
   const spans = buildWorkerSpans(trace.events, workerIds, maxTs, trace.blockInPlaceGaps);
   attachCpuSamples(trace.cpuSamples, spans.workerSpans);
   const taskTimeline = buildActiveTaskTimeline(trace.taskSpawnTimes, trace.taskTerminateTimes);
+  const activeTaskSamples = activeTaskSeries(trace, taskTimeline);
   const schedDelays = computeSchedulingDelays(spans.workerSpans, workerIds, spans.wakesByTask);
 
   // Scalars
@@ -243,7 +244,7 @@ function accumulateTrace(acc, trace, sourceFile) {
   }
 
   // Task timeline
-  for (const s of taskTimeline.activeTaskSamples) acc.taskTimelineSamples.push(s);
+  for (const s of activeTaskSamples) acc.taskTimelineSamples.push(s);
 
   // Maps
   for (const [k, v] of trace.taskSpawnLocs) acc.taskSpawnLocs.set(k, v);
@@ -497,21 +498,12 @@ function reportAnalysis(a, label) {
 
   const atSamples = a.taskTimeline.activeTaskSamples;
   if (atSamples.length > 0) {
-    // Recompute from merged spawn/terminate maps for accurate cross-file count
-    // Tasks that terminate without a recorded spawn were alive at trace start
-    let preExisting = 0;
-    for (const [taskId] of taskTerminateTimes) {
-      if (!taskSpawnTimes.has(taskId)) preExisting++;
-    }
-    const taskEvents = [];
-    for (const [, t] of taskSpawnTimes) taskEvents.push({ t, delta: 1 });
-    for (const [, t] of taskTerminateTimes) taskEvents.push({ t, delta: -1 });
-    taskEvents.sort((a, b) => a.t - b.t);
-    let count = preExisting, peak = preExisting;
-    for (const te of taskEvents) { count += te.delta; if (count > peak) peak = count; }
-    const alive = count;
-    console.log(`\n  Peak active tasks: ${peak}${preExisting > 0 ? ` (${preExisting} pre-existing at trace start)` : ''}`);
-    console.log(`  Active at trace end: ${alive}`);
+    const first = atSamples[0].count;
+    const alive = atSamples[atSamples.length - 1].count;
+    const peak = atSamples.reduce((m, s) => Math.max(m, s.count), -Infinity);
+    console.log(`\n  Peak active tasks: ${peak}`);
+    console.log(`  Active at first sample: ${first}`);
+    console.log(`  Active at last sample: ${alive}`);
     if (alive > peak / 2 && alive === peak) {
       console.log('  ⚠ POSSIBLE TASK LEAK — active count grew monotonically');
       const alive = new Map();
@@ -941,6 +933,7 @@ async function parseWorkerMain(traceFile, cachePath) {
     // current traces (buildWorkerSpans' queueSamples is empty once producers
     // emit RuntimeMetricsEvent instead of QueueSampleEvent).
     runtimeMetrics: trace.runtimeMetrics || [],
+    legacyActiveTaskSamples: trace.legacyActiveTaskSamples || [],
   }});
   for (const e of trace.events) writeLine({ t: 'e', d: e });
   for (const s of trace.cpuSamples) writeLine({ t: 'c', d: s });
@@ -983,6 +976,7 @@ function loadCacheFile(cachePath) {
   raw.events = events; raw.cpuSamples = cpuSamples; raw.customEvents = customEvents;
   if (!raw.segmentMetadata) raw.segmentMetadata = new Map();
   if (!raw.runtimeMetrics) raw.runtimeMetrics = []; // pre-RuntimeMetrics cache files
+  if (!raw.legacyActiveTaskSamples) raw.legacyActiveTaskSamples = [];
   // Pre-capability cache files: re-derive from the cached metadata and spawn times.
   if (raw.hasFullTaskCoverage === undefined) Object.assign(raw, deriveCapabilities(raw.segmentMetadata, raw.taskSpawnTimes ?? new Map()));
   raw.allocEvents = allocEvents; raw.freeEvents = freeEvents;
@@ -998,6 +992,7 @@ function analyzeWorkerMain(cachePath) {
   const spans = buildWorkerSpans(trace.events, wids, maxTs, trace.blockInPlaceGaps);
   attachCpuSamples(trace.cpuSamples, spans.workerSpans);
   const taskTimeline = buildActiveTaskTimeline(trace.taskSpawnTimes, trace.taskTerminateTimes);
+  const activeTaskSamples = activeTaskSeries(trace, taskTimeline);
   const schedDelays = computeSchedulingDelays(spans.workerSpans, wids, spans.wakesByTask);
   const onCpu = trace.cpuSamples.filter(s => s.source === 0);
   const offCpu = trace.cpuSamples.filter(s => s.source === 1);
@@ -1014,7 +1009,7 @@ function analyzeWorkerMain(cachePath) {
     queueMax: 0, queueSum: 0, queueCount: 0,
     schedDelayTotal: schedDelays.length, schedDelayHighCount: 0, schedDelayWorst: [],
     schedDelayValues: schedDelays.map(sd => Math.max(1, Math.round(sd.delay))),
-    taskTimelineSamples: taskTimeline.activeTaskSamples,
+    taskTimelineSamples: activeTaskSamples,
     taskSpawnLocs: mapToEntries(trace.taskSpawnLocs),
     taskSpawnTimes: mapToEntries(trace.taskSpawnTimes),
     taskTerminateTimes: mapToEntries(trace.taskTerminateTimes),

--- a/dial9-viewer/skills/dial9-trace-analysis/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-analysis/SKILL.md
@@ -47,8 +47,9 @@ process.stderr.write('\n');
 2. Extract worker IDs from non-queue, non-wake events
 3. `buildWorkerSpans(events, workerIds, maxTs)` reconstructs poll/park/active spans
 4. `attachCpuSamples(cpuSamples, workerSpans)` attaches profiling data to poll spans
-5. `buildActiveTaskTimeline(taskSpawnTimes, taskTerminateTimes)` builds task count over time
-6. `computeSchedulingDelays(workerSpans, workerIds, wakesByTask)` computes wake-to-poll latencies
+5. `buildActiveTaskTimeline(taskSpawnTimes, taskTerminateTimes)` builds the lifecycle fallback and task-first-poll index
+6. `activeTaskSeries(trace, taskTimeline)` selects the sampled process-wide task count when available
+7. `computeSchedulingDelays(workerSpans, workerIds, wakesByTask)` computes wake-to-poll latencies
 
 ## analyzeTraces return schema
 
@@ -187,7 +188,16 @@ Attaches each CPU sample to the poll span it falls within. After calling:
 
 ## buildActiveTaskTimeline(taskSpawnTimes, taskTerminateTimes)
 
-Returns `{activeTaskSamples: [{t, count}], taskFirstPoll}`. The count at each point is the number of tasks that have been spawned but not yet terminated. Useful for detecting task leaks.
+Returns `{activeTaskSamples: [{t, count}], taskFirstPoll}`. The count is derived from spawn/terminate events and is the fallback for traces without sampled counts.
+
+## activeTaskSeries(trace, taskTimeline)
+
+Returns the authoritative process-wide `[{t, count}]` series. Current
+per-runtime `RuntimeMetricsEvent.alive_tasks` samples are summed by flush cycle;
+transitional `QueueSampleEvent.active_tasks` samples are already process-wide;
+older traces fall back to `taskTimeline.activeTaskSamples`. Prefer this helper
+for charts, summaries, and leak detection because sampled counts include tasks
+that were already alive when a partial trace began.
 
 ## computeSchedulingDelays(workerSpans, workerIds, wakesByTask)
 

--- a/dial9-viewer/skills/dial9-trace-loading/SKILL.md
+++ b/dial9-viewer/skills/dial9-trace-loading/SKILL.md
@@ -31,6 +31,7 @@ description: Parse and load dial9 Tokio runtime trace files. Covers the ParsedTr
   runtimeWorkers: Map<string, number[]>, // runtime name → worker IDs
   segmentMetadata: Map<string, string>,  // latest segment metadata key → value
   runtimeMetrics: [{t, runtimeName, globalQueue, aliveTasks}], // per-runtime scheduler samples (empty on pre-RuntimeMetrics traces)
+  legacyActiveTaskSamples: [{t, count}], // process-wide QueueSample active-task samples from the transitional format
   truncated: boolean,
   timeFiltered: boolean,
   filterStartTime: number|null,          // start of time range filter (ns), null if unfiltered

--- a/dial9-viewer/ui/src/components/overlay/data.ts
+++ b/dial9-viewer/ui/src/components/overlay/data.ts
@@ -5,11 +5,14 @@
 //
 // LaneData omits the GLOBAL injection-queue series and the active-task timeline
 // (the lanes do not draw them); the tooltip/info readout need both, so we run
-// the core builders once more here. This is a one-time O(events) cost at trace
-// load (wired through store.derived over the `trace` slice), NOT a per-frame
-// cost.
+// the core builders once more here, including the sampled active-task series.
+// This is a one-time O(events) cost at trace load (wired through store.derived
+// over the `trace` slice), NOT a per-frame cost.
 
-import { buildActiveTaskTimeline } from "../../lib/trace/index.js";
+import {
+  activeTaskSeries,
+  buildActiveTaskTimeline,
+} from "../../lib/trace/index.js";
 import {
   deriveRuntimeGroups,
   deriveRuntimeMetrics,
@@ -77,6 +80,7 @@ export function deriveOverlayData(trace: ParsedTrace): OverlayData {
     trace.taskSpawnTimes,
     trace.taskTerminateTimes,
   );
+  const activeTaskSamples = activeTaskSeries(trace, timeline);
 
   return {
     workerIds,
@@ -87,7 +91,7 @@ export function deriveOverlayData(trace: ParsedTrace): OverlayData {
     columnarSpans: spanData.columnarSpans,
     workerQueueSamples: spanResult.workerQueueSamples,
     queueSamples: spanResult.queueSamples,
-    activeTaskSamples: timeline.activeTaskSamples,
+    activeTaskSamples,
     blockInPlaceGaps: trace.blockInPlaceGaps,
     hasCpuTime: trace.hasCpuTime,
     hasSchedWait: trace.hasSchedWait,

--- a/dial9-viewer/ui/src/lib/trace/analysis.ts
+++ b/dial9-viewer/ui/src/lib/trace/analysis.ts
@@ -10,6 +10,7 @@
 import "./core-globals.js";
 
 export {
+  activeTaskSeries,
   analyzeAllocations,
   attachCpuSamples,
   buildActiveTaskTimeline,
@@ -29,6 +30,7 @@ export {
   globalQueueSeries,
   hasCpuProfileSamples,
   selectSpanRenderSet,
+  sumActiveTasksByCycle,
   sumGlobalQueueByCycle,
 } from "../../../trace_analysis.js";
 

--- a/dial9-viewer/ui/src/lib/trace/index.ts
+++ b/dial9-viewer/ui/src/lib/trace/index.ts
@@ -180,6 +180,7 @@ export type { SpanAncestry, SpanList } from "./query.js";
 
 // analysis.ts - the trace_analysis.js facade.
 export {
+  activeTaskSeries,
   analyzeAllocations,
   attachCpuSamples,
   buildActiveTaskTimeline,
@@ -200,6 +201,7 @@ export {
   globalQueueSeries,
   hasCpuProfileSamples,
   selectSpanRenderSet,
+  sumActiveTasksByCycle,
   sumGlobalQueueByCycle,
 } from "./analysis.js";
 export type {

--- a/dial9-viewer/ui/src/pages/viewer/queue-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-model.test.ts
@@ -149,6 +149,23 @@ describe("buildQueueRenderModel", () => {
     expect(m.activeTask!.points[0]).toEqual({ x: 25, count: 8 });
   });
 
+  it("carries the first sampled task count backward instead of inventing zero", () => {
+    const m = buildQueueRenderModel({
+      data: queueData({
+        activeTaskSamples: [
+          { t: 25, count: 56 },
+          { t: 75, count: 50 },
+        ],
+      }),
+      viewStart: 0,
+      viewEnd: 100,
+      drawW: 100,
+    });
+    expect(m.activeTask!.startCount).toBe(56);
+    expect(m.activeTask!.maxTasks).toBe(56);
+    expect(m.activeTask!.points[0]).toEqual({ x: 25, count: 56 });
+  });
+
   it("has no active-task overlay when the trace lacks the timeline", () => {
     const m = buildQueueRenderModel({
       data: queueData({ queueSamples: [{ t: 5, global: 1 }] }),

--- a/dial9-viewer/ui/src/pages/viewer/queue-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-model.test.ts
@@ -316,6 +316,30 @@ describe("computeQueueData / deriveQueueWindow", () => {
     expect(data.hasTaskTracking).toBe(false);
   });
 
+  it("uses sampled active-task totals instead of restarting partial traces at zero", () => {
+    const trace = {
+      events: [],
+      maxTs: 1000,
+      blockInPlaceGaps: [],
+      runtimeWorkers: new Map(),
+      runtimeMetrics: [
+        { t: 100, runtimeName: "", globalQueue: 0, aliveTasks: 40 },
+        { t: 100, runtimeName: "io", globalQueue: 0, aliveTasks: 3 },
+      ],
+      legacyActiveTaskSamples: [],
+      taskSpawnTimes: new Map([[1, 110]]),
+      taskTerminateTimes: new Map(),
+      taskSpawnLocs: new Map([[1, "spawn.rs:1"]]),
+      spawnLocations: new Map([["spawn.rs:1", "spawn.rs:1"]]),
+      hasTaskTracking: true,
+      hasLocalQueueDepth: false,
+    } as unknown as ParsedTrace;
+
+    const data = computeQueueData(trace);
+    expect(data.activeTaskSamples).toEqual([{ t: 100, count: 43 }]);
+    expect(data.taskFirstPoll.get(1)).toBe(110);
+  });
+
   it("resolves complete for an empty segments slice, oversized when a segment is", () => {
     const complete = deriveQueueWindow({
       segments: { segments: new Map() },

--- a/dial9-viewer/ui/src/pages/viewer/queue-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-model.ts
@@ -16,7 +16,10 @@
 
 import type { ParsedTrace, TimeRange } from "../../types/trace.js";
 import type { StoreState } from "../../types/state.js";
-import { buildActiveTaskTimeline } from "../../lib/trace/index.js";
+import {
+  activeTaskSeries,
+  buildActiveTaskTimeline,
+} from "../../lib/trace/index.js";
 import {
   deriveRuntimeMetrics,
   deriveWorkerIds,
@@ -86,8 +89,9 @@ export const EMPTY_QUEUE_DATA: QueueData = {
 
 /**
  * Derive the queue track's frame-invariant data for one parsed trace. Runs
- * buildWorkerSpans (global + per-worker queue series) and
- * buildActiveTaskTimeline (active-task counts + taskFirstPoll). Call once per
+ * buildWorkerSpans (global + per-worker queue series),
+ * buildActiveTaskTimeline (lifecycle fallback + taskFirstPoll), and
+ * activeTaskSeries (sampled process-wide counts when available). Call once per
  * trace and cache (store.derived over the `trace` slice) - never per frame.
  */
 export function computeQueueData(trace: ParsedTrace | null): QueueData {
@@ -99,6 +103,7 @@ export function computeQueueData(trace: ParsedTrace | null): QueueData {
     trace.taskSpawnTimes,
     trace.taskTerminateTimes,
   );
+  const activeTaskSamples = activeTaskSeries(trace, timeline);
   // The global-queue series comes from per-runtime RuntimeMetrics (summed per
   // cycle) when the trace has them; otherwise fall back to the legacy
   // pre-summed QueueSample series that buildWorkerSpans extracts.
@@ -123,7 +128,7 @@ export function computeQueueData(trace: ParsedTrace | null): QueueData {
     workerIds,
     queueSamples,
     mergedLocalSamples: merged,
-    activeTaskSamples: timeline.activeTaskSamples,
+    activeTaskSamples,
     taskFirstPoll: timeline.taskFirstPoll,
     taskSpawnLocs: trace.taskSpawnLocs,
     spawnLocations: trace.spawnLocations,

--- a/dial9-viewer/ui/src/pages/viewer/queue-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-model.ts
@@ -429,12 +429,12 @@ function buildActiveTaskModel(
 
   // Bounded window: samples are t-sorted, so seek the edges by binary search
   // instead of scanning all ~O(tasks) samples every frame. `startCount` is the
-  // level entering the view = the last sample with t <= viewStart (upperBound-1);
-  // a sample exactly at viewStart seeds AND becomes the first point, matching the
-  // old scan.
+  // level entering the view = the last sample with t <= viewStart (upperBound-1).
+  // Before the first sample, carry that first known level backward rather than
+  // inventing a zero that renders as a false startup jump.
   let a = 0, b = n;
   while (a < b) { const m = (a + b) >>> 1; if (samples[m]!.t <= viewStart) a = m + 1; else b = m; }
-  const startCount = a > 0 ? samples[a - 1]!.count : 0;
+  const startCount = a > 0 ? samples[a - 1]!.count : samples[0]!.count;
 
   const from = lowerBoundT(samples, viewStart);
   let maxTasks = Math.max(1, startCount);

--- a/dial9-viewer/ui/src/types/probe.ts
+++ b/dial9-viewer/ui/src/types/probe.ts
@@ -29,6 +29,7 @@ import type {
   SymbolFrame,
 } from "../../trace_parser.js";
 import {
+  activeTaskSeries,
   buildWorkerSpans,
   computeRuntimeGroups,
   buildRuntimeFilterData,
@@ -55,6 +56,7 @@ import {
   makeBarCoalescer,
   pixelDownsampleSpans,
   pixelCoverage,
+  sumActiveTasksByCycle,
 } from "../../trace_analysis.js";
 import type {
   WorkerLane,
@@ -262,7 +264,10 @@ export function probeAnalysis(trace: ParsedTrace): void {
 
   const atResult = buildActiveTaskTimeline(trace.taskSpawnTimes, trace.taskTerminateTimes);
   void atResult.taskFirstPoll.get(1);
-  const firstSample = atResult.activeTaskSamples[0];
+  const summedActiveTasks = sumActiveTasksByCycle(trace.runtimeMetrics);
+  const activeTasks = activeTaskSeries(trace, atResult);
+  void summedActiveTasks.length;
+  const firstSample = activeTasks[0];
   if (firstSample !== undefined) void (firstSample.t + firstSample.count);
 
   const schedDelays = computeSchedulingDelays(workerSpans, workerIds, spanResult.wakesByTask);

--- a/dial9-viewer/ui/src/types/trace_analysis.d.ts
+++ b/dial9-viewer/ui/src/types/trace_analysis.d.ts
@@ -126,6 +126,11 @@ declare module "*/trace_analysis.js" {
     runtimeMetrics: readonly RuntimeMetricsSample[]
   ): { t: number; global: number }[];
 
+  /** Sum per-runtime alive-task counts into a process-wide timeline. */
+  export function sumActiveTasksByCycle(
+    runtimeMetrics: readonly RuntimeMetricsSample[]
+  ): { t: number; count: number }[];
+
   /**
    * The process-wide global injection-queue timeline, from whichever event
    * generation the trace carries: per-runtime `RuntimeMetricsEvent`s summed per
@@ -136,6 +141,16 @@ declare module "*/trace_analysis.js" {
     trace: Pick<ParsedTrace, "runtimeMetrics">,
     workerSpansResult: Pick<WorkerSpansResult, "queueSamples">
   ): { t: number; global: number }[];
+
+  /**
+   * The process-wide active-task timeline. Prefers sampled RuntimeMetrics,
+   * falls back to transitional QueueSample active-task samples, then to
+   * lifecycle-derived spawn/terminate counts.
+   */
+  export function activeTaskSeries(
+    trace: Pick<ParsedTrace, "runtimeMetrics" | "legacyActiveTaskSamples">,
+    taskTimeline: { activeTaskSamples: { t: number; count: number }[] }
+  ): { t: number; count: number }[];
 
   /**
    * Attach CPU samples to the poll spans they fall within. Mutates poll

--- a/dial9-viewer/ui/src/types/trace_parser.d.ts
+++ b/dial9-viewer/ui/src/types/trace_parser.d.ts
@@ -192,6 +192,14 @@ declare module "*/trace_parser.js" {
     aliveTasks: number;
   }
 
+  /** Process-wide active-task sample decoded from the superseded QueueSampleEvent. */
+  export interface LegacyActiveTaskSample {
+    /** Monotonic sample timestamp (ns). */
+    t: number;
+    /** Tasks alive across all attached runtimes. */
+    count: number;
+  }
+
   /**
    * A detected block-in-place handoff interval. Worker attribution inside
    * [startNs, endNs) is unknowable: samples in the gap have workerId
@@ -265,6 +273,12 @@ declare module "*/trace_parser.js" {
      * `RuntimeMetricsEvent` (those carry a summed `QueueSample` instead).
      */
     runtimeMetrics: RuntimeMetricsSample[];
+    /**
+     * Process-wide active-task samples from the transitional QueueSampleEvent
+     * format. Empty for traces before that field and for current traces, which
+     * carry per-runtime counts in `runtimeMetrics`.
+     */
+    legacyActiveTaskSamples: LegacyActiveTaskSample[];
     customEvents: CustomTraceEvent[];
     /**
      * Columnar span-producing custom events (SpanEnter/Exit/Close and annotated

--- a/dial9-viewer/ui/tests/core/trace_analysis.test.ts
+++ b/dial9-viewer/ui/tests/core/trace_analysis.test.ts
@@ -24,8 +24,10 @@ const { EVENT_TYPES, parseTrace } = require("../../trace_parser.js") as {
   parseTrace: (buf: Buffer) => Promise<any>;
 };
 const {
+  activeTaskSeries,
   buildWorkerSpans,
   globalQueueSeries,
+  sumActiveTasksByCycle,
   sumGlobalQueueByCycle,
   attachCpuSamples,
   buildActiveTaskTimeline,
@@ -345,6 +347,24 @@ describe("sumGlobalQueueByCycle", () => {
   });
 });
 
+describe("sumActiveTasksByCycle", () => {
+  it("sums per-runtime alive-task counts per cycle timestamp and sorts by t", () => {
+    const summed = sumActiveTasksByCycle([
+      { t: 20, runtimeName: "", globalQueue: 0, aliveTasks: 7 },
+      { t: 10, runtimeName: "", globalQueue: 0, aliveTasks: 40 },
+      { t: 10, runtimeName: "io", globalQueue: 0, aliveTasks: 3 },
+    ]);
+    expect(summed).toEqual([
+      { t: 10, count: 43 },
+      { t: 20, count: 7 },
+    ]);
+  });
+
+  it("is empty for no samples", () => {
+    expect(sumActiveTasksByCycle([])).toEqual([]);
+  });
+});
+
 describe("globalQueueSeries", () => {
   it("prefers summed RuntimeMetrics over the legacy queueSamples", () => {
     const trace = {
@@ -381,6 +401,46 @@ describe("globalQueueSeries", () => {
     } else {
       expect(series).toBe(spans.queueSamples);
     }
+  });
+});
+
+describe("activeTaskSeries", () => {
+  const lifecycle = {
+    activeTaskSamples: [{ t: 11, count: 1 }],
+  };
+
+  it("prefers summed RuntimeMetrics so partial traces retain their baseline", () => {
+    const series = activeTaskSeries(
+      {
+        runtimeMetrics: [
+          { t: 10, runtimeName: "", globalQueue: 0, aliveTasks: 40 },
+          { t: 10, runtimeName: "io", globalQueue: 0, aliveTasks: 3 },
+        ],
+        legacyActiveTaskSamples: [{ t: 10, count: 999 }],
+      },
+      lifecycle,
+    );
+    expect(series).toEqual([{ t: 10, count: 43 }]);
+  });
+
+  it("falls back to transitional QueueSample active-task samples", () => {
+    const legacy = [{ t: 10, count: 17 }];
+    expect(
+      activeTaskSeries(
+        { runtimeMetrics: [], legacyActiveTaskSamples: legacy },
+        lifecycle,
+      ),
+    ).toBe(legacy);
+  });
+
+  it("falls back to lifecycle deltas when no sampled counts exist", () => {
+    expect(
+      activeTaskSeries(
+        { runtimeMetrics: [], legacyActiveTaskSamples: [] },
+        lifecycle,
+      ),
+    ).toBe(lifecycle.activeTaskSamples);
+    expect(activeTaskSeries({}, lifecycle)).toBe(lifecycle.activeTaskSamples);
   });
 });
 

--- a/dial9-viewer/ui/tests/core/trace_parser_active_tasks.test.ts
+++ b/dial9-viewer/ui/tests/core/trace_parser_active_tasks.test.ts
@@ -1,0 +1,24 @@
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const { decodeLegacyActiveTaskSample } = require("../../trace_parser.js") as {
+  decodeLegacyActiveTaskSample: (
+    timestamp: number,
+    fields: { active_tasks?: number | string | bigint | null },
+  ) => { t: number; count: number } | null;
+};
+
+describe("legacy QueueSample active-task decoding", () => {
+  it("preserves a present active_tasks field", () => {
+    expect(decodeLegacyActiveTaskSample(123, { active_tasks: "42" })).toEqual({
+      t: 123,
+      count: 42,
+    });
+  });
+
+  it("does not invent zero for traces whose schema predates active_tasks", () => {
+    expect(decodeLegacyActiveTaskSample(123, {})).toBeNull();
+    expect(decodeLegacyActiveTaskSample(123, { active_tasks: null })).toBeNull();
+  });
+});

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -646,6 +646,22 @@
   }
 
   /**
+   * Sum per-runtime alive-task counts into one process-wide timeline.
+   *
+   * @param {import('./trace_parser.js').RuntimeMetricsSample[]} runtimeMetrics
+   * @returns {Array<{t: number, count: number}>} sorted by t
+   */
+  function sumActiveTasksByCycle(runtimeMetrics) {
+    const byTs = new Map();
+    for (const s of runtimeMetrics) {
+      byTs.set(s.t, (byTs.get(s.t) ?? 0) + s.aliveTasks);
+    }
+    return [...byTs.entries()]
+      .map(([t, count]) => ({ t, count }))
+      .sort((a, b) => a.t - b.t);
+  }
+
+  /**
    * The process-wide global injection-queue timeline for a trace, from whichever
    * event generation the trace carries. THE one place that decision is made, so
    * every consumer (viewer queue track, skill scripts) reads the same series:
@@ -665,6 +681,35 @@
       return sumGlobalQueueByCycle(runtimeMetrics);
     }
     return workerSpansResult.queueSamples;
+  }
+
+  /**
+   * The process-wide active-task timeline from whichever event generation the
+   * trace carries:
+   *
+   * - Current traces carry per-runtime `RuntimeMetricsEvent`s, summed per cycle.
+   * - The transitional QueueSample generation carries an already-summed
+   *   `active_tasks` field in `legacyActiveTaskSamples`.
+   * - Older traces fall back to spawn/terminate lifecycle deltas.
+   *
+   * Sampled counts are authoritative when available because they include tasks
+   * that were already alive when a partial trace began.
+   *
+   * @param {import('./trace_parser.js').ParsedTrace} trace
+   * @param {{activeTaskSamples: Array<{t: number, count: number}>}} taskTimeline
+   *   the `buildActiveTaskTimeline` result for the same trace
+   * @returns {Array<{t: number, count: number}>} sorted by t
+   */
+  function activeTaskSeries(trace, taskTimeline) {
+    const runtimeMetrics = trace.runtimeMetrics;
+    if (runtimeMetrics && runtimeMetrics.length > 0) {
+      return sumActiveTasksByCycle(runtimeMetrics);
+    }
+    const legacySamples = trace.legacyActiveTaskSamples;
+    if (legacySamples && legacySamples.length > 0) {
+      return legacySamples;
+    }
+    return taskTimeline.activeTaskSamples;
   }
 
   /**
@@ -1945,7 +1990,9 @@
   // Export for both browser and Node.js
   const analysisExports = {
     buildWorkerSpans,
+    activeTaskSeries,
     globalQueueSeries,
+    sumActiveTasksByCycle,
     sumGlobalQueueByCycle,
     computeRuntimeGroups,
     buildRuntimeFilterData,

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -29,6 +29,16 @@
     }
 
     /**
+     * Decode the optional active-task count carried by the superseded
+     * QueueSampleEvent. Traces predating that field legitimately omit it, so
+     * absence means "no sample", never zero.
+     */
+    function decodeLegacyActiveTaskSample(timestamp, fields) {
+        if (fields.active_tasks == null) return null;
+        return { t: timestamp, count: num(fields.active_tasks) };
+    }
+
+    /**
      * Intern a callchain frame address to its "0x…" hex string, deduped per
      * parse. Callchains across millions of samples/dumps/allocs share very few
      * distinct addresses (same code paths), so caching the hex string collapses
@@ -400,6 +410,7 @@
      *   threadNames: Map<number, string>,
      *   runtimeWorkers: Map<string, number[]>,
      *   segmentMetadata: Map<string, string>,
+     *   legacyActiveTaskSamples: Array<{t: number, count: number}>,
      * }} ParsedTrace
      */
 
@@ -716,6 +727,10 @@
             // (a handful per 10ms), so kept as a plain side-channel array rather
             // than routed through the columnar scheduler-event store.
             runtimeMetrics: [],
+            // QueueSampleEvent briefly carried a process-wide active-task count
+            // before RuntimeMetricsEvent replaced it. Keep that optional field
+            // in a side channel so traces from that generation remain useful.
+            legacyActiveTaskSamples: [],
             taskDumps: new Map(), // taskId → [{timestamp, callchain}] sorted by timestamp
             customEvents: [], // unrecognized event types: {name, timestamp, fields}
             // Schema active when each custom event was decoded. Kept parallel to
@@ -1188,6 +1203,7 @@
         const runtimeWorkers = state.runtimeWorkers;
         const segmentMetadata = state.segmentMetadata;
         const runtimeMetrics = state.runtimeMetrics;
+        const legacyActiveTaskSamples = state.legacyActiveTaskSamples;
         const taskDumps = state.taskDumps;
         const customEvents = state.customEvents;
         const spanEventSink = state.spanEventSink;
@@ -1324,6 +1340,12 @@
                 });
                 break;
             case "QueueSampleEvent":
+                {
+                    const activeTaskSample = decodeLegacyActiveTaskSample(ts, v);
+                    if (activeTaskSample != null) {
+                        legacyActiveTaskSamples.push(activeTaskSample);
+                    }
+                }
                 if (events.pushEvent) {
                     events.pushEvent(4, ts, 0, 0, num(v.global_queue), 0, 0, 0, null, undefined, undefined, undefined);
                     break;
@@ -1600,6 +1622,7 @@
             runtimeWorkers,
             segmentMetadata,
             runtimeMetrics,
+            legacyActiveTaskSamples,
             taskDumps,
             customEvents,
             customEventSchemas,
@@ -1753,6 +1776,7 @@
             runtimeWorkers,
             segmentMetadata,
             runtimeMetrics,
+            legacyActiveTaskSamples,
             customEvents,
             taskDumps,
             clockSyncAnchors,
@@ -2111,6 +2135,8 @@
         raw.events = events;
         raw.cpuSamples = cpuSamples;
         if (!raw.segmentMetadata) raw.segmentMetadata = new Map();
+        if (!raw.runtimeMetrics) raw.runtimeMetrics = [];
+        if (!raw.legacyActiveTaskSamples) raw.legacyActiveTaskSamples = [];
         // Cache files written before the capability fields were serialized:
         // re-derive them from the cached metadata and spawn times.
         if (raw.hasFullTaskCoverage === undefined) {
@@ -2491,6 +2517,9 @@
             deduplicateSamples,
             deriveBlockInPlaceGaps,
             deriveCapabilities,
+            // Exported for focused backwards-compatibility tests. Not part of
+            // the browser API.
+            decodeLegacyActiveTaskSample,
             // Exported for unit tests: the single-event span schema compiler
             // and its runtime timing resolution. Not part of the browser API.
             compileSingleEventSpanSchema,


### PR DESCRIPTION
## User-facing behavior

The process-wide active-task line and cursor readout now use Tokio's sampled
alive-task count when it is present. A partial trace therefore starts from the
actual number of tasks already alive instead of restarting at zero from the
first observed `TaskSpawnEvent`.

The same total is used by the agent toolkit and red-flag task-leak analysis, so
CLI and viewer results agree.

Compatibility is preserved across all trace generations:

- current `RuntimeMetricsEvent.alive_tasks` values are summed across runtimes
  sharing a flush-cycle timestamp;
- transitional `QueueSampleEvent.active_tasks` values are decoded as the
  already process-wide total;
- older traces fall back to the existing spawn/terminate-derived timeline.

See #496.
