### PR TITLE
feat(viewer): show task spawn histograms by runtime

### DIFF
--- a/dial9-viewer/ui/src/components/canvas/lanes/data.ts
+++ b/dial9-viewer/ui/src/components/canvas/lanes/data.ts
@@ -19,6 +19,10 @@ import {
   type RuntimeMetrics,
 } from "../../../lib/trace/runtime-metrics-model.js";
 import { buildLaneIdentities, type LaneIdentity } from "./chrome.js";
+import {
+  deriveRuntimeTaskSpawns,
+  type RuntimeTaskSpawns,
+} from "../../../lib/trace/runtime-task-spawns.js";
 import { spansById as buildSpanByIdSingle } from "../../../lib/trace/index.js";
 import { LazySpansById, LazySpanByIdSingle } from "../../../lib/trace/columnar-spans.js";
 import type { ColumnarSpans, SpanByIdMulti, SpanByIdSingle } from "../../../lib/trace/columnar-spans.js";
@@ -40,6 +44,8 @@ export interface LaneData {
   /** Per-runtime scheduler metrics, drawn in each runtime's summary lane. Empty
    *  for pre-RuntimeMetrics traces. */
   runtimeMetrics: RuntimeMetrics;
+  /** Task-spawn timestamps attributed to each runtime by first-poll worker. */
+  runtimeTaskSpawns: RuntimeTaskSpawns;
   /** Runtime names that have a metric series (so a summary lane is emitted).
    *  Pair with the store's fold map to build `laneRowLayout`'s metrics opts. */
   metricsRuntimes: ReadonlySet<string>;
@@ -91,6 +97,11 @@ export function deriveLaneData(trace: ParsedTrace): LaneData {
   // name so it matches laneRowLayout's per-group check.
   const runtimeMetrics = deriveRuntimeMetrics(trace);
   const metricsRuntimes = metricsRuntimeNames(runtimeGroups, runtimeMetrics);
+  const runtimeTaskSpawns = deriveRuntimeTaskSpawns(
+    trace.taskSpawnTimes,
+    runtimeGroups,
+    workerSpans,
+  );
 
   // Lane identity: each worker's runtime accent + group name, by group order.
   const identities = buildLaneIdentities(runtimeGroups);
@@ -120,6 +131,7 @@ export function deriveLaneData(trace: ParsedTrace): LaneData {
     workerIds,
     runtimeGroups,
     runtimeMetrics,
+    runtimeTaskSpawns,
     metricsRuntimes,
     laneIdentity: identities.byWorker,
     runtimeAccents: identities.byRuntime,

--- a/dial9-viewer/ui/src/components/canvas/lanes/index.ts
+++ b/dial9-viewer/ui/src/components/canvas/lanes/index.ts
@@ -175,6 +175,7 @@ export function mountLanes(trackColumn: HTMLElement, store: ViewerStore): Mounte
       workerIds: data.workerIds,
       workerSpans: data.workerSpans,
       runtimeMetrics: data.runtimeMetrics,
+      runtimeTaskSpawns: data.runtimeTaskSpawns.byRuntime,
       laneIdentity: data.laneIdentity,
       runtimeAccents: data.runtimeAccents,
       workerQueueSamples: data.workerQueueSamples,

--- a/dial9-viewer/ui/src/components/canvas/lanes/lanes.test.ts
+++ b/dial9-viewer/ui/src/components/canvas/lanes/lanes.test.ts
@@ -331,7 +331,7 @@ describe("renderLanes: fixed-height rows + inner-scroll windowing", () => {
     // (q 7 / 194 tasks) - and the trace peak rides alongside it.
     expect(rec.fillTexts).toContain("global queue: 7 at view end \u00b7 peak 7");
     expect(rec.fillTexts).toContain("alive tasks: 194 at view end \u00b7 peak 194");
-    expect(rec.fillTexts.some((text) => text.startsWith("spawn peak:"))).toBe(true);
+    expect(rec.fillTexts).toContain("spawn peak:3 tasks/s");
   });
 
   it("a folded runtime-metrics lane keeps its numbers and drops the chart", () => {

--- a/dial9-viewer/ui/src/components/canvas/lanes/lanes.test.ts
+++ b/dial9-viewer/ui/src/components/canvas/lanes/lanes.test.ts
@@ -11,7 +11,10 @@ import {
   type LanesRenderInput,
 } from "./render.js";
 import { laneRowLayout } from "../../../lib/canvas/layout.js";
-import { EMPTY_RUNTIME_METRICS } from "../../../lib/trace/runtime-metrics-model.js";
+import {
+  EMPTY_RUNTIME_METRICS,
+  type RuntimeMetrics,
+} from "../../../lib/trace/runtime-metrics-model.js";
 import { resolveLaneClick } from "./click.js";
 import { assembleLaneHover } from "./hover.js";
 import type { PollSpan, TracingSpan, WorkerLane } from "../../../types/trace.js";
@@ -379,7 +382,7 @@ function metricsRows(collapsed: boolean) {
 }
 
 /** Two samples for the unnamed default runtime (the "main" group's wire key). */
-function metricsFixture() {
+function metricsFixture(): RuntimeMetrics {
   const mk = (t: number, q: number, tasks: number) => ({
     t,
     runtimeName: "",

--- a/dial9-viewer/ui/src/components/canvas/lanes/lanes.test.ts
+++ b/dial9-viewer/ui/src/components/canvas/lanes/lanes.test.ts
@@ -93,6 +93,7 @@ function baseInput(over: Partial<LanesRenderInput>): LanesRenderInput {
     workerIds: [0],
     workerSpans: { 0: emptyLane() },
     runtimeMetrics: EMPTY_RUNTIME_METRICS,
+    runtimeTaskSpawns: new Map(),
     laneIdentity: new Map(),
     runtimeAccents: new Map(),
     workerQueueSamples: {},
@@ -315,7 +316,11 @@ describe("renderLanes: fixed-height rows + inner-scroll windowing", () => {
   it("draws a runtime-metrics lane with its runtime name + current/peak values", () => {
     const rows = metricsRows(false);
     const rec = recordingCtx();
-    renderLanes(rec.ctx, { ...workersInput([0]), runtimeMetrics: metricsFixture() }, {
+    renderLanes(rec.ctx, {
+      ...workersInput([0]),
+      runtimeMetrics: metricsFixture(),
+      runtimeTaskSpawns: new Map([["main", [100, 101, 500]]]),
+    }, {
       time: layout(0, 1000, 300),
       height: 300,
       rowLayout: rows,
@@ -326,6 +331,7 @@ describe("renderLanes: fixed-height rows + inner-scroll windowing", () => {
     // (q 7 / 194 tasks) - and the trace peak rides alongside it.
     expect(rec.fillTexts).toContain("global queue: 7 at view end \u00b7 peak 7");
     expect(rec.fillTexts).toContain("alive tasks: 194 at view end \u00b7 peak 194");
+    expect(rec.fillTexts.some((text) => text.startsWith("spawn peak:"))).toBe(true);
   });
 
   it("a folded runtime-metrics lane keeps its numbers and drops the chart", () => {
@@ -342,6 +348,22 @@ describe("renderLanes: fixed-height rows + inner-scroll windowing", () => {
     // The title is NOT repeated: one line has no room for both, and the label
     // gutter names the row (labels.test.ts pins that).
     expect(rec.fillTexts).not.toContain("main runtime metrics");
+  });
+
+  it("labels alive tasks unavailable when an old runtime schema omitted them", () => {
+    const metrics = metricsFixture();
+    const main = metrics.byRuntime.get("")!;
+    main.aliveTasksAvailable = false;
+    main.samples = main.samples.map((sample) => ({ ...sample, aliveTasks: null }));
+    const rec = recordingCtx();
+    renderLanes(rec.ctx, { ...workersInput([0]), runtimeMetrics: metrics }, {
+      time: layout(0, 1000, 300),
+      height: 300,
+      rowLayout: metricsRows(false),
+      scrollTop: 0,
+    });
+    expect(rec.fillTexts).toContain("alive tasks: unavailable");
+    expect(rec.fillTexts.some((text) => text.startsWith("alive tasks: 0"))).toBe(false);
   });
 });
 
@@ -372,6 +394,7 @@ function metricsFixture() {
         "",
         {
           samples: [mk(100, 5, 190), mk(500, 7, 194)],
+          aliveTasksAvailable: true,
           maxAliveTasks: 194,
           maxGlobalQueue: 7,
         },

--- a/dial9-viewer/ui/src/components/canvas/lanes/render.ts
+++ b/dial9-viewer/ui/src/components/canvas/lanes/render.ts
@@ -86,6 +86,8 @@ export interface LanesRenderInput {
   /** Per-runtime scheduler metrics, drawn into each runtime's summary lane.
    *  Empty for pre-RuntimeMetrics traces (no summary lanes emitted). */
   runtimeMetrics: RuntimeMetrics;
+  /** Runtime group name -> sorted task-spawn timestamps. */
+  runtimeTaskSpawns: ReadonlyMap<string, readonly number[]>;
   /** worker id -> its owning runtime's accent (the lane's left rail). A worker
    *  absent from this map falls back to the default accent, so a caller that has
    *  not built identities still gets a rail. */
@@ -299,6 +301,7 @@ export function renderLanes(
       drawRuntimeMetricsLane(
         ctx,
         series,
+        input.runtimeTaskSpawns.get(r.name) ?? [],
         r,
         input.runtimeAccents.get(r.name) ?? DEFAULT_ACCENT,
         viewStart,

--- a/dial9-viewer/ui/src/components/canvas/lanes/runtime-metrics-lane.ts
+++ b/dial9-viewer/ui/src/components/canvas/lanes/runtime-metrics-lane.ts
@@ -223,10 +223,7 @@ export function drawRuntimeMetricsLane(
     ctx.font = "9px monospace";
     ctx.textAlign = "right";
     ctx.fillText(
-      `spawn peak:${formatSpawnRate(
-        (spawnHistogram.maxSpawns * 1_000_000_000) /
-          spawnHistogram.binDurationNs,
-      )}`,
+      `spawn peak:${formatSpawnRate(spawnHistogram.peakSpawnsPerSecond)}`,
       Math.max(0, drawW - 4),
       titleY,
     );

--- a/dial9-viewer/ui/src/components/canvas/lanes/runtime-metrics-lane.ts
+++ b/dial9-viewer/ui/src/components/canvas/lanes/runtime-metrics-lane.ts
@@ -21,12 +21,17 @@ import type { LaneDrawContext } from "./render.js";
 import { RAIL_W } from "./chrome.js";
 import type { RuntimeSeries } from "../../../lib/trace/runtime-metrics-model.js";
 import { queueBaselineY, queueScaleY } from "../../../lib/canvas/zero-baseline.js";
+import {
+  buildSpawnHistogram,
+  formatSpawnRate,
+} from "../../../lib/canvas/spawn-histogram.js";
 
 const LANE_BG = "#1d2440";
 const TOP_RULE = "#3d4a7a";
 const GLOBAL_FILL = "rgba(79,195,247,0.30)";
 const GLOBAL_STROKE = "#4fc3f7";
 const TASK_STROKE = "#81c784";
+const SPAWN_FILL = "rgba(129,199,132,0.28)";
 const TITLE = "#aeb6e0";
 const CARET = "#8b93c0";
 const BASELINE_RULE = "#2b3358";
@@ -56,6 +61,7 @@ export interface RuntimeMetricsLaneRow {
 export function drawRuntimeMetricsLane(
   ctx: LaneDrawContext,
   series: RuntimeSeries | undefined,
+  spawnTimes: readonly number[],
   row: RuntimeMetricsLaneRow,
   accent: string,
   viewStart: number,
@@ -102,6 +108,8 @@ export function drawRuntimeMetricsLane(
 
   // The series' level at the right edge of the view: the "right now" reading.
   const atEdge = levelAt(series, viewEnd);
+  const aliveTasksAvailable =
+    series.aliveTasksAvailable && atEdge.aliveTasks !== null;
 
   // The one-line strip: keep the numbers, drop the chart. Drawn on the title row
   // (whose title the fold omits) so a folded lane costs one line of height.
@@ -114,9 +122,15 @@ export function drawRuntimeMetricsLane(
       RAIL_W + 15,
       titleY,
     );
-    ctx.fillStyle = TASK_STROKE;
+    ctx.fillStyle = aliveTasksAvailable ? TASK_STROKE : EMPTY_TEXT;
     ctx.textAlign = "right";
-    ctx.fillText(taskLabel(atEdge.aliveTasks, series.maxAliveTasks), Math.max(0, drawW - 4), titleY);
+    ctx.fillText(
+      aliveTasksAvailable
+        ? taskLabel(atEdge.aliveTasks!, series.maxAliveTasks)
+        : "alive tasks: unavailable",
+      Math.max(0, drawW - 4),
+      titleY,
+    );
     return;
   }
 
@@ -183,22 +197,60 @@ export function drawRuntimeMetricsLane(
   ctx.lineTo(drawW, qy(qLast));
   ctx.stroke();
 
-  // ── Alive tasks: step line on its own scale ─────────────────────────────
-  const maxT = Math.max(1, series.maxAliveTasks);
-  const ty = (v: number): number => queueScaleY(v, maxT, chartTop, chartH);
-  ctx.strokeStyle = TASK_STROKE;
-  ctx.lineWidth = 1.25;
-  ctx.beginPath();
-  let tLast = seed.aliveTasks;
-  ctx.moveTo(0, ty(tLast));
-  for (const s of inView) {
-    const x = xOf(s.t);
-    ctx.lineTo(x, ty(tLast));
-    tLast = s.aliveTasks;
-    ctx.lineTo(x, ty(tLast));
+  // ── Task spawns: runtime-specific histogram behind alive-task total ─────
+  const spawnHistogram = buildSpawnHistogram(
+    spawnTimes,
+    viewStart,
+    viewEnd,
+    drawW,
+  );
+  if (spawnHistogram !== null) {
+    ctx.fillStyle = SPAWN_FILL;
+    for (let i = 0; i < spawnHistogram.counts.length; i++) {
+      const count = spawnHistogram.counts[i]!;
+      if (count === 0) continue;
+      const x = i * spawnHistogram.binWidthPx;
+      const y = queueScaleY(count, spawnHistogram.maxSpawns, chartTop, chartH);
+      const barTop = Math.min(y, baseY - 2);
+      ctx.fillRect(
+        x + 0.5,
+        barTop,
+        Math.max(1, spawnHistogram.binWidthPx - 1),
+        baseY - barTop,
+      );
+    }
+    ctx.fillStyle = TASK_STROKE;
+    ctx.font = "9px monospace";
+    ctx.textAlign = "right";
+    ctx.fillText(
+      `spawn peak:${formatSpawnRate(
+        (spawnHistogram.maxSpawns * 1_000_000_000) /
+          spawnHistogram.binDurationNs,
+      )}`,
+      Math.max(0, drawW - 4),
+      titleY,
+    );
   }
-  ctx.lineTo(drawW, ty(tLast));
-  ctx.stroke();
+
+  // ── Alive tasks: step line on its own scale ─────────────────────────────
+  if (aliveTasksAvailable && seed.aliveTasks !== null) {
+    const maxT = Math.max(1, series.maxAliveTasks);
+    const ty = (v: number): number => queueScaleY(v, maxT, chartTop, chartH);
+    ctx.strokeStyle = TASK_STROKE;
+    ctx.lineWidth = 1.25;
+    ctx.beginPath();
+    let tLast = seed.aliveTasks;
+    ctx.moveTo(0, ty(tLast));
+    for (const s of inView) {
+      if (s.aliveTasks === null) continue;
+      const x = xOf(s.t);
+      ctx.lineTo(x, ty(tLast));
+      tLast = s.aliveTasks;
+      ctx.lineTo(x, ty(tLast));
+    }
+    ctx.lineTo(drawW, ty(tLast));
+    ctx.stroke();
+  }
 
   // ── Readouts: one label per series, colour-keyed to its stroke ───────────
   // Current value first (the number a backlog investigation wants), then the
@@ -208,9 +260,15 @@ export function drawRuntimeMetricsLane(
   ctx.fillStyle = GLOBAL_STROKE;
   ctx.textAlign = "left";
   ctx.fillText(queueLabel(atEdge.globalQueue, series.maxGlobalQueue), RAIL_W + 4, baselineY);
-  ctx.fillStyle = TASK_STROKE;
+  ctx.fillStyle = aliveTasksAvailable ? TASK_STROKE : EMPTY_TEXT;
   ctx.textAlign = "right";
-  ctx.fillText(taskLabel(atEdge.aliveTasks, series.maxAliveTasks), Math.max(0, drawW - 4), baselineY);
+  ctx.fillText(
+    aliveTasksAvailable
+      ? taskLabel(atEdge.aliveTasks!, series.maxAliveTasks)
+      : "alive tasks: unavailable",
+    Math.max(0, drawW - 4),
+    baselineY,
+  );
 }
 
 // The readouts pair a POINT reading with the trace peak. "at <right edge of the
@@ -248,7 +306,7 @@ function taskLabel(current: number, max: number): string {
 function levelAt(
   series: RuntimeSeries,
   t: number,
-): { globalQueue: number; aliveTasks: number } {
+): { globalQueue: number; aliveTasks: number | null } {
   const samples = series.samples;
   let lo = 0;
   let hi = samples.length - 1;

--- a/dial9-viewer/ui/src/components/overlay/data.ts
+++ b/dial9-viewer/ui/src/components/overlay/data.ts
@@ -20,6 +20,7 @@ import {
   sharedWorkerSpans,
 } from "../../lib/trace/derived.js";
 import { metricsRuntimeNames } from "../../lib/trace/runtime-metrics-model.js";
+import { deriveRuntimeTaskSpawns } from "../../lib/trace/runtime-task-spawns.js";
 import type {
   BlockInPlaceGap,
   ParsedTrace,
@@ -51,6 +52,8 @@ export interface OverlayData {
   queueSamples: { t: number; global: number }[];
   /** Active-task-count timeline, sorted by t (tooltip Active Tasks). */
   activeTaskSamples: { t: number; count: number }[];
+  /** Runtime group name -> sorted task-spawn timestamps. */
+  runtimeTaskSpawns: ReadonlyMap<string, readonly number[]>;
   blockInPlaceGaps: readonly BlockInPlaceGap[];
   hasCpuTime: boolean;
   hasSchedWait: boolean;
@@ -81,6 +84,11 @@ export function deriveOverlayData(trace: ParsedTrace): OverlayData {
     trace.taskTerminateTimes,
   );
   const activeTaskSamples = activeTaskSeries(trace, timeline);
+  const runtimeTaskSpawns = deriveRuntimeTaskSpawns(
+    trace.taskSpawnTimes,
+    runtimeGroups,
+    workerSpans,
+  );
 
   return {
     workerIds,
@@ -92,6 +100,7 @@ export function deriveOverlayData(trace: ParsedTrace): OverlayData {
     workerQueueSamples: spanResult.workerQueueSamples,
     queueSamples: spanResult.queueSamples,
     activeTaskSamples,
+    runtimeTaskSpawns: runtimeTaskSpawns.byRuntime,
     blockInPlaceGaps: trace.blockInPlaceGaps,
     hasCpuTime: trace.hasCpuTime,
     hasSchedWait: trace.hasSchedWait,

--- a/dial9-viewer/ui/src/components/overlay/index.ts
+++ b/dial9-viewer/ui/src/components/overlay/index.ts
@@ -21,7 +21,12 @@ import type { ViewerStore } from "../../store/store.js";
 import type { StoreState, TimePanelLayout } from "../../types/state.js";
 import type { TemplateResult } from "lit-html";
 import { createCanvasSizer, type CanvasSizer } from "../../lib/canvas/dpr.js";
-import { laneRowLayout, timePanelLayout, workerAtLaneY } from "../../lib/canvas/layout.js";
+import {
+  laneRowLayout,
+  metricsLaneAtLaneY,
+  timePanelLayout,
+  workerAtLaneY,
+} from "../../lib/canvas/layout.js";
 import { LANE_ROW_H, RUNTIME_HEADER_H } from "../canvas/lanes/render.js";
 import { lanesScrollbarWidth } from "../../lib/canvas/track-layout.js";
 import { assembleLaneHover } from "../canvas/lanes/index.js";
@@ -29,7 +34,14 @@ import type { LaneHoverInput } from "../canvas/lanes/hover.js";
 import { deriveOverlayData, type OverlayData } from "./data.js";
 import { drawCrosshair, type CrosshairContext } from "./crosshair.js";
 import { computeAtCursorReadout, coverageAt } from "./readout.js";
-import { buildLaneTooltip, createTooltip, type TooltipHandle } from "./tooltip.js";
+import {
+  buildLaneTooltip,
+  createTooltip,
+  spawnHistogramTooltipRows,
+  tooltipRowsTemplate,
+  type TooltipHandle,
+} from "./tooltip.js";
+import { spawnHistogramBinAtTimes } from "../../lib/canvas/spawn-histogram.js";
 
 const OVERLAY_CLASS = "d9-crosshair-overlay";
 
@@ -94,16 +106,20 @@ function columnGeometry(
 /** Worker id under `clientY` in the lanes box, or null when off the lanes / over
  *  a runtime header. Fixed-height rows + box scrollTop, resolved through the same
  *  shared row layout the renderer + click use so hover never drifts from them. */
-function workerAtClientY(
+function laneTargetAtClientY(
   box: HTMLElement,
   clientY: number,
   data: OverlayData,
   collapsedRuntimes: Readonly<Record<string, boolean>>,
   collapsedRuntimeMetrics: Readonly<Record<string, boolean>>,
-): number | null {
-  if (data.workerIds.length === 0) return null;
+): { workerId: number | null; runtimeMetrics: string | null } {
+  if (data.workerIds.length === 0) {
+    return { workerId: null, runtimeMetrics: null };
+  }
   const rect = box.getBoundingClientRect();
-  if (clientY < rect.top || clientY >= rect.bottom || rect.height <= 0) return null;
+  if (clientY < rect.top || clientY >= rect.bottom || rect.height <= 0) {
+    return { workerId: null, runtimeMetrics: null };
+  }
   const localY = clientY - rect.top + box.scrollTop;
   const rowLayout = laneRowLayout(
     data.runtimeGroups,
@@ -112,7 +128,14 @@ function workerAtClientY(
     collapsedRuntimes,
     { runtimes: data.metricsRuntimes, collapsed: collapsedRuntimeMetrics },
   );
-  return workerAtLaneY(rowLayout, localY);
+  const runtimeMetrics = metricsLaneAtLaneY(rowLayout, localY);
+  return {
+    workerId: workerAtLaneY(rowLayout, localY),
+    runtimeMetrics:
+      runtimeMetrics !== null && collapsedRuntimeMetrics[runtimeMetrics] !== true
+        ? runtimeMetrics
+        : null,
+  };
 }
 
 /**
@@ -296,15 +319,16 @@ export function mountOverlay(
 
     const ns = geom.layout.panelXToNs(mouseX);
     const lanesBox = trackColumn.querySelector<HTMLElement>(".d9-lanes-viewport");
-    const workerId = lanesBox
-      ? workerAtClientY(
+    const laneTarget = lanesBox
+      ? laneTargetAtClientY(
           lanesBox,
           e.clientY,
           data,
           state.uiPrefs.collapsedRuntimes,
           state.uiPrefs.collapsedRuntimeMetrics,
         )
-      : null;
+      : { workerId: null, runtimeMetrics: null };
+    const workerId = laneTarget.workerId;
 
     const readout = computeAtCursorReadout(
       data,
@@ -324,6 +348,34 @@ export function mountOverlay(
         ns,
       };
       hidePending = false;
+    } else if (laneTarget.runtimeMetrics !== null) {
+      const runtimeName = laneTarget.runtimeMetrics;
+      const bin = spawnHistogramBinAtTimes(
+        data.runtimeTaskSpawns.get(runtimeName) ?? [],
+        viewStart,
+        viewEnd,
+        drawW,
+        ns,
+      );
+      const content =
+        bin === null
+          ? null
+          : tooltipRowsTemplate(
+              spawnHistogramTooltipRows(
+                bin,
+                (t) => formatTimestamp(state, t),
+                runtimeName,
+              ),
+            );
+      pendingTooltip =
+        content === null
+          ? null
+          : {
+              kind: "track",
+              cursor: { clientX: e.clientX, clientY: e.clientY },
+              content,
+            };
+      hidePending = content === null;
     } else {
       const content = trackTooltipAtTarget(e.target, state, ns, trackTooltipAt);
       pendingTooltip = content === null
@@ -376,6 +428,7 @@ export {
   laneTooltipModel,
   buildLaneTooltip,
   createTooltip,
+  spawnHistogramTooltipRows,
   tooltipRowsTemplate,
 } from "./tooltip.js";
 export type { TooltipHandle, TooltipRow, TooltipSegment } from "./tooltip.js";

--- a/dial9-viewer/ui/src/components/overlay/tooltip.ts
+++ b/dial9-viewer/ui/src/components/overlay/tooltip.ts
@@ -15,6 +15,7 @@
 
 import { html, render, type TemplateResult } from "lit-html";
 import { formatHumanDuration } from "../../lib/trace/index.js";
+import { formatSpawnRate, type SpawnHistogramBin } from "../../lib/canvas/spawn-histogram.js";
 import type { LaneHoverData } from "../canvas/lanes/index.js";
 
 // Placement (pure, cached-dimension - avoids measure-after-write).
@@ -70,6 +71,29 @@ export interface TooltipSegment {
 
 /** A tooltip line: one or more segments joined by " · " on render. */
 export type TooltipRow = TooltipSegment[];
+
+/** Shared hover content for a nonempty task-spawn histogram bin. */
+export function spawnHistogramTooltipRows(
+  bin: SpawnHistogramBin,
+  formatTs: (ns: number) => string,
+  runtimeName?: string,
+): TooltipRow[] {
+  return [
+    ...(runtimeName === undefined
+      ? []
+      : [[{ label: "Runtime:", value: runtimeName }] satisfies TooltipRow]),
+    [{ label: "Tasks spawned:", value: String(bin.count) }],
+    [{ label: "Spawn rate:", value: formatSpawnRate(bin.ratePerSecond) }],
+    [{ label: "Window:", value: `${formatTs(bin.startNs)} – ${formatTs(bin.endNs)}` }],
+    [
+      {
+        label: "Duration:",
+        value: formatHumanDuration(bin.durationNs),
+        hint: "(click bar to list tasks)",
+      },
+    ],
+  ];
+}
 
 /** Formatting hooks the model needs (kept out so the model stays Node-pure). */
 export interface TooltipFormatOpts {

--- a/dial9-viewer/ui/src/lib/canvas/spawn-histogram.ts
+++ b/dial9-viewer/ui/src/lib/canvas/spawn-histogram.ts
@@ -1,0 +1,206 @@
+/** Target histogram resolution: one time bucket for roughly every 8 CSS px. */
+export const SPAWN_BIN_TARGET_PX = 8;
+
+/** Spawn counts in viewport-adaptive, fixed-pixel-width time buckets. */
+export interface SpawnHistogramModel {
+  /** Spawn count per bucket, left-to-right across the viewport. */
+  counts: readonly number[];
+  /** Peak count across the visible buckets, >= 1. */
+  maxSpawns: number;
+  /** Width of one bucket in CSS px. */
+  binWidthPx: number;
+  /** Duration represented by one bucket in trace nanoseconds. */
+  binDurationNs: number;
+}
+
+/** One nonempty spawn-histogram bin at a cursor time. */
+export interface SpawnHistogramBin {
+  index: number;
+  count: number;
+  /** Left edge of the displayed time quantum. */
+  startNs: number;
+  /** Right edge of the displayed time quantum. */
+  endNs: number;
+  /** Inclusive end used by the existing spawned-task range selection. */
+  selectionEndNs: number;
+  durationNs: number;
+  ratePerSecond: number;
+}
+
+/** Binary search: index of the first number >= target. */
+function lowerBound(arr: readonly number[], target: number): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid]! < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/** Binary search: index of the first number > target. */
+function upperBound(arr: readonly number[], target: number): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid]! <= target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+function geometry(
+  viewStart: number,
+  viewEnd: number,
+  drawW: number,
+): { numBins: number; binWidthPx: number; binDurationNs: number } | null {
+  const viewDur = viewEnd - viewStart;
+  if (viewDur <= 0 || drawW <= 0) return null;
+  const numBins = Math.max(1, Math.ceil(drawW / SPAWN_BIN_TARGET_PX));
+  return {
+    numBins,
+    binWidthPx: drawW / numBins,
+    binDurationNs: viewDur / numBins,
+  };
+}
+
+/**
+ * Count sorted task-spawn timestamps into viewport-adaptive time buckets. The
+ * independent scale preserves burst shape without flattening a task-total line.
+ */
+export function buildSpawnHistogram(
+  spawnTimes: readonly number[],
+  viewStart: number,
+  viewEnd: number,
+  drawW: number,
+): SpawnHistogramModel | null {
+  if (spawnTimes.length === 0) return null;
+  const geom = geometry(viewStart, viewEnd, drawW);
+  if (geom === null) return null;
+
+  const counts = new Array<number>(geom.numBins).fill(0);
+  let maxSpawns = 0;
+  const from = lowerBound(spawnTimes, viewStart);
+  for (let i = from; i < spawnTimes.length; i++) {
+    const t = spawnTimes[i]!;
+    if (t > viewEnd) break;
+    const bin = Math.min(
+      geom.numBins - 1,
+      Math.floor(((t - viewStart) / (viewEnd - viewStart)) * geom.numBins),
+    );
+    const count = counts[bin]! + 1;
+    counts[bin] = count;
+    if (count > maxSpawns) maxSpawns = count;
+  }
+  if (maxSpawns === 0) return null;
+  return {
+    counts,
+    maxSpawns,
+    binWidthPx: geom.binWidthPx,
+    binDurationNs: geom.binDurationNs,
+  };
+}
+
+/**
+ * Resolve a cursor timestamp directly against sorted spawn times. Histogram
+ * bins are half-open, except the final bin includes viewEnd.
+ */
+export function spawnHistogramBinAtTimes(
+  spawnTimes: readonly number[],
+  viewStart: number,
+  viewEnd: number,
+  drawW: number,
+  ns: number,
+): SpawnHistogramBin | null {
+  const geom = geometry(viewStart, viewEnd, drawW);
+  if (
+    geom === null ||
+    spawnTimes.length === 0 ||
+    ns < viewStart ||
+    ns > viewEnd
+  ) {
+    return null;
+  }
+  const lastIndex = geom.numBins - 1;
+  const index =
+    ns === viewEnd
+      ? lastIndex
+      : Math.min(
+          lastIndex,
+          Math.floor(((ns - viewStart) / (viewEnd - viewStart)) * geom.numBins),
+        );
+  const startNs = viewStart + index * geom.binDurationNs;
+  const endNs =
+    index === lastIndex
+      ? viewEnd
+      : Math.min(viewEnd, viewStart + (index + 1) * geom.binDurationNs);
+  const from = lowerBound(spawnTimes, startNs);
+  const to =
+    index === lastIndex
+      ? upperBound(spawnTimes, endNs)
+      : lowerBound(spawnTimes, endNs);
+  const count = to - from;
+  if (count === 0) return null;
+  return {
+    index,
+    count,
+    startNs,
+    endNs,
+    selectionEndNs:
+      index === lastIndex ? endNs : Math.max(startNs, Math.ceil(endNs) - 1),
+    durationNs: endNs - startNs,
+    ratePerSecond: (count * 1_000_000_000) / (endNs - startNs),
+  };
+}
+
+/** Resolve a cursor against an already-built histogram model. */
+export function spawnHistogramBinAt(
+  histogram: SpawnHistogramModel | null,
+  viewStart: number,
+  viewEnd: number,
+  ns: number,
+): SpawnHistogramBin | null {
+  if (
+    histogram === null ||
+    histogram.counts.length === 0 ||
+    viewEnd <= viewStart ||
+    ns < viewStart ||
+    ns > viewEnd
+  ) {
+    return null;
+  }
+  const lastIndex = histogram.counts.length - 1;
+  const index =
+    ns === viewEnd
+      ? lastIndex
+      : Math.min(
+          lastIndex,
+          Math.floor(((ns - viewStart) / (viewEnd - viewStart)) * histogram.counts.length),
+        );
+  const count = histogram.counts[index]!;
+  if (count === 0) return null;
+  const startNs = viewStart + index * histogram.binDurationNs;
+  const endNs =
+    index === lastIndex
+      ? viewEnd
+      : Math.min(viewEnd, viewStart + (index + 1) * histogram.binDurationNs);
+  return {
+    index,
+    count,
+    startNs,
+    endNs,
+    selectionEndNs:
+      index === lastIndex ? endNs : Math.max(startNs, Math.ceil(endNs) - 1),
+    durationNs: endNs - startNs,
+    ratePerSecond: (count * 1_000_000_000) / (endNs - startNs),
+  };
+}
+
+/** Human-readable task-spawn rate with an explicit normalized unit. */
+export function formatSpawnRate(ratePerSecond: number): string {
+  if (!Number.isFinite(ratePerSecond) || ratePerSecond <= 0) return "0 tasks/s";
+  if (ratePerSecond < 1) return `${ratePerSecond.toFixed(2)} tasks/s`;
+  return `${Math.round(ratePerSecond)} tasks/s`;
+}

--- a/dial9-viewer/ui/src/lib/canvas/spawn-histogram.ts
+++ b/dial9-viewer/ui/src/lib/canvas/spawn-histogram.ts
@@ -1,12 +1,16 @@
 /** Target histogram resolution: one time bucket for roughly every 8 CSS px. */
 export const SPAWN_BIN_TARGET_PX = 8;
 
+const ONE_SECOND_NS = 1_000_000_000;
+
 /** Spawn counts in viewport-adaptive, fixed-pixel-width time buckets. */
 export interface SpawnHistogramModel {
   /** Spawn count per bucket, left-to-right across the viewport. */
   counts: readonly number[];
   /** Peak count across the visible buckets, >= 1. */
   maxSpawns: number;
+  /** Peak count in any actual one-second window across visible spawns. */
+  peakSpawnsPerSecond: number;
   /** Width of one bucket in CSS px. */
   binWidthPx: number;
   /** Duration represented by one bucket in trace nanoseconds. */
@@ -83,9 +87,11 @@ export function buildSpawnHistogram(
   const counts = new Array<number>(geom.numBins).fill(0);
   let maxSpawns = 0;
   const from = lowerBound(spawnTimes, viewStart);
-  for (let i = from; i < spawnTimes.length; i++) {
+  const to = upperBound(spawnTimes, viewEnd);
+  let peakSpawnsPerSecond = 0;
+  let windowStart = from;
+  for (let i = from; i < to; i++) {
     const t = spawnTimes[i]!;
-    if (t > viewEnd) break;
     const bin = Math.min(
       geom.numBins - 1,
       Math.floor(((t - viewStart) / (viewEnd - viewStart)) * geom.numBins),
@@ -93,11 +99,17 @@ export function buildSpawnHistogram(
     const count = counts[bin]! + 1;
     counts[bin] = count;
     if (count > maxSpawns) maxSpawns = count;
+
+    while (spawnTimes[windowStart]! <= t - ONE_SECOND_NS) {
+      windowStart++;
+    }
+    peakSpawnsPerSecond = Math.max(peakSpawnsPerSecond, i - windowStart + 1);
   }
   if (maxSpawns === 0) return null;
   return {
     counts,
     maxSpawns,
+    peakSpawnsPerSecond,
     binWidthPx: geom.binWidthPx,
     binDurationNs: geom.binDurationNs,
   };

--- a/dial9-viewer/ui/src/lib/trace/runtime-metrics-model.test.ts
+++ b/dial9-viewer/ui/src/lib/trace/runtime-metrics-model.test.ts
@@ -29,12 +29,26 @@ describe("computeRuntimeMetrics", () => {
 
     const main = m.byRuntime.get("")!;
     expect(main.samples.length).toBe(2);
+    expect(main.aliveTasksAvailable).toBe(true);
     expect(main.maxAliveTasks).toBe(194);
     expect(main.maxGlobalQueue).toBe(5);
 
     const io = m.byRuntime.get("io")!;
     expect(io.maxAliveTasks).toBe(4);
     expect(io.maxGlobalQueue).toBe(6);
+  });
+
+  it("marks alive-task counts unavailable when the old schema omitted them", () => {
+    const m = computeRuntimeMetrics(
+      traceWith([
+        { t: 10, runtimeName: "", globalQueue: 5, aliveTasks: null },
+        { t: 20, runtimeName: "", globalQueue: 2, aliveTasks: null },
+      ]),
+    );
+    const main = m.byRuntime.get("")!;
+    expect(main.aliveTasksAvailable).toBe(false);
+    expect(main.maxAliveTasks).toBe(0);
+    expect(main.maxGlobalQueue).toBe(5);
   });
 
   it("sums the global queue per cycle timestamp across runtimes", () => {

--- a/dial9-viewer/ui/src/lib/trace/runtime-metrics-model.ts
+++ b/dial9-viewer/ui/src/lib/trace/runtime-metrics-model.ts
@@ -15,6 +15,8 @@ import { sumGlobalQueueByCycle } from "./analysis.js";
 export interface RuntimeSeries {
   /** Samples for this runtime, in wire (time) order. */
   samples: RuntimeMetricsSample[];
+  /** False when this old trace's runtime-metrics schema omitted alive_tasks. */
+  aliveTasksAvailable: boolean;
   /** Peak alive-task count across the trace. */
   maxAliveTasks: number;
   /** Peak global-queue depth across the trace (the chart's y autoscale). */
@@ -53,13 +55,18 @@ export function computeRuntimeMetrics(trace: ParsedTrace | null): RuntimeMetrics
     if (series === undefined) {
       series = {
         samples: [],
+        aliveTasksAvailable: true,
         maxAliveTasks: 0,
         maxGlobalQueue: 0,
       };
       byRuntime.set(s.runtimeName, series);
     }
     series.samples.push(s);
-    if (s.aliveTasks > series.maxAliveTasks) series.maxAliveTasks = s.aliveTasks;
+    if (s.aliveTasks === null) {
+      series.aliveTasksAvailable = false;
+    } else if (s.aliveTasks > series.maxAliveTasks) {
+      series.maxAliveTasks = s.aliveTasks;
+    }
     if (s.globalQueue > series.maxGlobalQueue) series.maxGlobalQueue = s.globalQueue;
   }
 

--- a/dial9-viewer/ui/src/lib/trace/runtime-task-spawns.test.ts
+++ b/dial9-viewer/ui/src/lib/trace/runtime-task-spawns.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { deriveRuntimeTaskSpawns } from "./runtime-task-spawns.js";
+import type { RuntimeGroup, WorkerLane } from "../../types/trace.js";
+
+function lane(
+  polls: readonly { start: number; end: number; taskId: number }[],
+): WorkerLane {
+  return {
+    polls: polls.map((poll) => ({
+      ...poll,
+      spawnLocId: null,
+      spawnLoc: null,
+    })),
+    parks: [],
+    actives: [],
+    cpuSampleTimes: [],
+  };
+}
+
+describe("deriveRuntimeTaskSpawns", () => {
+  it("attributes each spawn to the runtime owning its earliest observed poll", () => {
+    const groups: RuntimeGroup[] = [
+      { name: "main", inferred: true, workerIds: [0, 1] },
+      { name: "io", inferred: false, workerIds: [2] },
+    ];
+    const result = deriveRuntimeTaskSpawns(
+      new Map([
+        [1, 90],
+        [2, 40],
+        [3, 10],
+        [4, 5], // never polled, so no defensible runtime attribution
+      ]),
+      groups,
+      {
+        0: lane([{ start: 100, end: 110, taskId: 1 }]),
+        1: lane([{ start: 50, end: 60, taskId: 2 }]),
+        2: lane([
+          { start: 20, end: 30, taskId: 3 },
+          { start: 200, end: 210, taskId: 1 },
+        ]),
+      },
+    );
+
+    expect(result.taskRuntime).toEqual(
+      new Map([
+        [1, "main"],
+        [2, "main"],
+        [3, "io"],
+      ]),
+    );
+    expect(result.byRuntime.get("main")).toEqual([40, 90]);
+    expect(result.byRuntime.get("io")).toEqual([10]);
+  });
+});

--- a/dial9-viewer/ui/src/lib/trace/runtime-task-spawns.ts
+++ b/dial9-viewer/ui/src/lib/trace/runtime-task-spawns.ts
@@ -1,0 +1,55 @@
+import type { LaneSpans } from "./columnar-worker-spans.js";
+import type { RuntimeGroup } from "../../types/trace.js";
+
+export interface RuntimeTaskSpawns {
+  /** Runtime group name -> sorted task-spawn timestamps. */
+  byRuntime: ReadonlyMap<string, readonly number[]>;
+  /** Task id -> runtime group name, inferred from its earliest observed poll. */
+  taskRuntime: ReadonlyMap<number, string>;
+}
+
+/**
+ * Attribute task spawns to the runtime that owns each task's earliest observed
+ * poll. TaskSpawnEvent predates per-event runtime identity, while poll worker
+ * ownership is unambiguous and works for existing traces.
+ */
+export function deriveRuntimeTaskSpawns(
+  taskSpawnTimes: ReadonlyMap<number, number>,
+  groups: readonly RuntimeGroup[],
+  workerSpans: Readonly<Record<number, LaneSpans>>,
+): RuntimeTaskSpawns {
+  const workerRuntime = new Map<number, string>();
+  for (const group of groups) {
+    for (const workerId of group.workerIds) workerRuntime.set(workerId, group.name);
+  }
+
+  const firstPoll = new Map<number, { t: number; runtime: string }>();
+  for (const [workerId, runtime] of workerRuntime) {
+    const polls = workerSpans[workerId]?.polls;
+    if (polls === undefined) continue;
+    for (let i = 0; i < polls.length; i++) {
+      const poll = polls.at(i);
+      if (poll?.taskId == null) continue;
+      const previous = firstPoll.get(poll.taskId);
+      if (previous === undefined || poll.start < previous.t) {
+        firstPoll.set(poll.taskId, { t: poll.start, runtime });
+      }
+    }
+  }
+
+  const taskRuntime = new Map<number, string>();
+  const byRuntime = new Map<string, number[]>();
+  for (const [taskId, spawnTime] of taskSpawnTimes) {
+    const placement = firstPoll.get(taskId);
+    if (placement === undefined) continue;
+    taskRuntime.set(taskId, placement.runtime);
+    let times = byRuntime.get(placement.runtime);
+    if (times === undefined) {
+      times = [];
+      byRuntime.set(placement.runtime, times);
+    }
+    times.push(spawnTime);
+  }
+  for (const times of byRuntime.values()) times.sort((a, b) => a - b);
+  return { byRuntime, taskRuntime };
+}

--- a/dial9-viewer/ui/src/pages/viewer/inspector-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/inspector-model.test.ts
@@ -289,6 +289,7 @@ describe("buildSpawnedTasksView", () => {
     const v = buildSpawnedTasksView(result, "1.0ms")!;
     expect(v.total).toBe(7);
     expect(v.rangeLabel).toBe("1.0ms");
+    expect(v.runtimeName).toBeNull();
     expect(v.groups[0]!.head).toHaveLength(5);
     expect(v.groups[0]!.head[0]!.hex).toBe("0x1");
     expect(v.groups[0]!.moreCount).toBe(2);

--- a/dial9-viewer/ui/src/pages/viewer/inspector-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/inspector-model.ts
@@ -635,6 +635,7 @@ export interface SpawnedGroupView {
 export interface SpawnedTasksView {
   total: number;
   rangeLabel: string;
+  runtimeName: string | null;
   groups: SpawnedGroupView[];
 }
 
@@ -650,6 +651,7 @@ export const SPAWNED_TASK_HEAD = 5;
 export function buildSpawnedTasksView(
   result: {
     total: number;
+    runtimeName?: string | null;
     groups: readonly {
       loc: string;
       tasks: readonly { taskId: number; firstPoll: number }[];
@@ -666,7 +668,12 @@ export function buildSpawnedTasksView(
     })),
     moreCount: Math.max(0, g.tasks.length - SPAWNED_TASK_HEAD),
   }));
-  return { total: result.total, rangeLabel, groups };
+  return {
+    total: result.total,
+    rangeLabel,
+    runtimeName: result.runtimeName ?? null,
+    groups,
+  };
 }
 
 // ── Tab availability ──────────────────────────────────────────────────────

--- a/dial9-viewer/ui/src/pages/viewer/inspector.ts
+++ b/dial9-viewer/ui/src/pages/viewer/inspector.ts
@@ -1012,7 +1012,8 @@ export function mountInspector(
     }
     if (sel.spawnedTasksRange !== null) {
       const range = sel.spawnedTasksRange;
-      const result = computeSpawnedTasks(data().queueData, range);
+      const runtimeName = sel.spawnedTasksRuntime ?? null;
+      const result = computeSpawnedTasks(data().queueData, range, runtimeName);
       const rangeLabel = formatHumanDuration(range.endNs - range.startNs);
       const view = buildSpawnedTasksView(result, rangeLabel);
       if (view === null) {
@@ -1023,7 +1024,9 @@ export function mountInspector(
       return html`
         <div class="d9-spawned">
           <div class="d9-spawned-head">
-            ${view.total} task${view.total > 1 ? "s" : ""} spawned in ${view.rangeLabel}
+            ${view.total} task${view.total > 1 ? "s" : ""} spawned
+            ${view.runtimeName === null ? "" : html` on ${view.runtimeName}`}
+            in ${view.rangeLabel}
           </div>
           ${view.groups.map(
             (g) => html`
@@ -1188,6 +1191,7 @@ export function mountInspector(
       taskDump: null,
       sidebarRange: null,
       spawnedTasksRange: null,
+      spawnedTasksRuntime: null,
       hoveredWakerTaskId: null,
     });
   }
@@ -1272,6 +1276,7 @@ export function mountInspector(
         taskDump: null,
         sidebarRange: null,
         spawnedTasksRange: null,
+        spawnedTasksRuntime: null,
       });
     },
   });

--- a/dial9-viewer/ui/src/pages/viewer/lane-interaction.ts
+++ b/dial9-viewer/ui/src/pages/viewer/lane-interaction.ts
@@ -40,6 +40,7 @@ import { toggleRuntimeCollapsed, toggleRuntimeMetricsCollapsed } from "./track-m
 import { mountSelectionOverlay } from "./selection-overlay.js";
 import type { ViewerStore } from "../../store/store.js";
 import type { StoreState } from "../../types/state.js";
+import { spawnHistogramBinAtTimes } from "../../lib/canvas/spawn-histogram.js";
 
 /** Cursor-extension step as a fraction of the visible duration (5%). */
 const KB_STEP_FRACTION = 0.05;
@@ -299,14 +300,38 @@ export function mountLaneInteraction(
       toggleRuntimeCollapsed(store, headerName);
       return;
     }
-    // A click on a runtime's SUMMARY lane folds/unfolds its chart - likewise
-    // never a worker select and never a selection clear.
+    const ns = geom.layout.panelXToNs(mouseXCol);
+    // A nonempty spawn bin in a runtime summary lane opens that runtime's
+    // spawned-task list. Empty space retains the lane's fold/unfold behavior.
     const metricsName = metricsLaneAtClientY(e.clientY, data);
     if (metricsName !== null) {
+      const state = store.getState();
+      if (state.uiPrefs.collapsedRuntimeMetrics[metricsName] !== true) {
+        const bin = spawnHistogramBinAtTimes(
+          data.runtimeTaskSpawns.byRuntime.get(metricsName) ?? [],
+          state.viewport.viewStart,
+          state.viewport.viewEnd,
+          geom.drawW,
+          ns,
+        );
+        if (bin !== null) {
+          store.update("selection", {
+            spawnedTasksRange: {
+              startNs: bin.startNs,
+              endNs: bin.selectionEndNs,
+            },
+            spawnedTasksRuntime: metricsName,
+            pinnedEvent: null,
+            pollDetail: null,
+            taskDump: null,
+            sidebarRange: null,
+          });
+          return;
+        }
+      }
       toggleRuntimeMetricsCollapsed(store, metricsName);
       return;
     }
-    const ns = geom.layout.panelXToNs(mouseXCol);
     const workerId = workerAtClientY(e.clientY, data);
     if (workerId === null) {
       store.update("selection", {

--- a/dial9-viewer/ui/src/pages/viewer/main.ts
+++ b/dial9-viewer/ui/src/pages/viewer/main.ts
@@ -22,7 +22,11 @@ import { mountLoadChrome } from "./load-chrome.js";
 import { mountInspector } from "./inspector.js";
 import { createRegionAnalysis } from "./region-analysis.js";
 import { mountLanes } from "../../components/canvas/lanes/index.js";
-import { mountOverlay, tooltipRowsTemplate } from "../../components/overlay/index.js";
+import {
+  mountOverlay,
+  spawnHistogramTooltipRows,
+  tooltipRowsTemplate,
+} from "../../components/overlay/index.js";
 import { deriveAxisInputs, fmtAxisTick } from "./axis.js";
 import {
   cpuIntervalAt,
@@ -215,6 +219,16 @@ function boot(): void {
     store,
     (state, ns) => fmtAxisTick(deriveAxisInputs(state), ns, false),
     (trackId, state, ns) => {
+      if (trackId === "queue") {
+        const bin = shell.queueTrack.spawnBinAt(ns);
+        return bin === null
+          ? null
+          : tooltipRowsTemplate(
+              spawnHistogramTooltipRows(bin, (t) =>
+                fmtAxisTick(deriveAxisInputs(state), t, false),
+              ),
+            );
+      }
       if (trackId !== "cpu" || state.trace.trace === null) return null;
       const series = cpuSeriesFor(state.trace.trace);
       const interval = cpuIntervalAt(series.intervals, ns);

--- a/dial9-viewer/ui/src/pages/viewer/queue-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-model.test.ts
@@ -169,6 +169,7 @@ describe("buildQueueRenderModel", () => {
     expect(m.spawnHistogram).toEqual({
       counts: [3, 1, 2],
       maxSpawns: 3,
+      peakSpawnsPerSecond: 6,
       binWidthPx: 8,
       binDurationNs: 40,
     });
@@ -195,15 +196,50 @@ describe("buildQueueRenderModel", () => {
     expect(m.spawnHistogram).toEqual({
       counts: [3],
       maxSpawns: 3,
+      peakSpawnsPerSecond: 3,
       binWidthPx: 4,
       binDurationNs: 10,
     });
+  });
+
+  it("computes peak spawn rate with an actual sliding one-second window", () => {
+    const m = buildQueueRenderModel({
+      data: queueData({
+        taskSpawnTimes: [
+          10_000_000,
+          11_000_000,
+          12_000_000,
+          13_000_000,
+          1_010_000_000,
+        ],
+      }),
+      viewStart: 0,
+      viewEnd: 2_000_000_000,
+      drawW: 800,
+    });
+    expect(m.spawnHistogram).toMatchObject({
+      maxSpawns: 4,
+      peakSpawnsPerSecond: 4,
+    });
+  });
+
+  it("excludes spawns exactly one second apart from the same rate window", () => {
+    const m = buildQueueRenderModel({
+      data: queueData({
+        taskSpawnTimes: [0, 999_999_999, 1_000_000_000, 1_999_999_999],
+      }),
+      viewStart: 0,
+      viewEnd: 2_000_000_000,
+      drawW: 100,
+    });
+    expect(m.spawnHistogram?.peakSpawnsPerSecond).toBe(2);
   });
 
   it("resolves exact nonempty spawn bins with boundary-safe selection ranges", () => {
     const histogram = {
       counts: [2, 0, 3],
       maxSpawns: 3,
+      peakSpawnsPerSecond: 5,
       binWidthPx: 8,
       binDurationNs: 40,
     };

--- a/dial9-viewer/ui/src/pages/viewer/queue-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-model.test.ts
@@ -149,6 +149,49 @@ describe("buildQueueRenderModel", () => {
     expect(m.activeTask!.points[0]).toEqual({ x: 25, count: 8 });
   });
 
+  it("bins task spawns at viewport-adaptive fixed-pixel resolution", () => {
+    const m = buildQueueRenderModel({
+      data: queueData({
+        taskSpawnTimes: [0, 1, 39, 40, 80, 120, 121],
+      }),
+      viewStart: 0,
+      viewEnd: 120,
+      drawW: 24,
+    });
+    expect(m.spawnHistogram).toEqual({
+      counts: [3, 1, 2],
+      maxSpawns: 3,
+      binWidthPx: 8,
+      binDurationNs: 40,
+    });
+    expect(m.hasData).toBe(true);
+  });
+
+  it("omits the spawn histogram when no spawn falls inside the viewport", () => {
+    const m = buildQueueRenderModel({
+      data: queueData({ taskSpawnTimes: [-10, 110] }),
+      viewStart: 0,
+      viewEnd: 100,
+      drawW: 24,
+    });
+    expect(m.spawnHistogram).toBeNull();
+  });
+
+  it("uses one spawn bucket for canvases narrower than the target bin width", () => {
+    const m = buildQueueRenderModel({
+      data: queueData({ taskSpawnTimes: [1, 2, 3] }),
+      viewStart: 0,
+      viewEnd: 10,
+      drawW: 4,
+    });
+    expect(m.spawnHistogram).toEqual({
+      counts: [3],
+      maxSpawns: 3,
+      binWidthPx: 4,
+      binDurationNs: 10,
+    });
+  });
+
   it("carries the first sampled task count backward instead of inventing zero", () => {
     const m = buildQueueRenderModel({
       data: queueData({
@@ -354,7 +397,31 @@ describe("computeQueueData / deriveQueueWindow", () => {
 
     const data = computeQueueData(trace);
     expect(data.activeTaskSamples).toEqual([{ t: 100, count: 43 }]);
+    expect(data.taskSpawnTimes).toEqual([110]);
     expect(data.taskFirstPoll.get(1)).toBe(110);
+  });
+
+  it("sorts task spawn timestamps for histogram windowing", () => {
+    const trace = {
+      events: [],
+      maxTs: 1000,
+      blockInPlaceGaps: [],
+      runtimeWorkers: new Map(),
+      runtimeMetrics: [],
+      legacyActiveTaskSamples: [],
+      taskSpawnTimes: new Map([
+        [1, 300],
+        [2, 100],
+        [3, 200],
+      ]),
+      taskTerminateTimes: new Map(),
+      taskSpawnLocs: new Map(),
+      spawnLocations: new Map(),
+      hasTaskTracking: true,
+      hasLocalQueueDepth: false,
+    } as unknown as ParsedTrace;
+
+    expect(computeQueueData(trace).taskSpawnTimes).toEqual([100, 200, 300]);
   });
 
   it("resolves complete for an empty segments slice, oversized when a segment is", () => {

--- a/dial9-viewer/ui/src/pages/viewer/queue-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-model.test.ts
@@ -14,8 +14,10 @@ import {
   computeQueueData,
   computeSpawnedTasks,
   deriveQueueWindow,
+  formatSpawnRate,
   queueBaselineY,
   queueScaleY,
+  spawnHistogramBinAt,
   EMPTY_QUEUE_DATA,
   type QueueData,
 } from "./queue-model.js";
@@ -26,7 +28,12 @@ import type { ParsedTrace } from "../../types/trace.js";
 function queueData(over: Partial<QueueData> = {}): QueueData {
   // EMPTY_QUEUE_DATA is the no-trace default, where queue depth is
   // unavailable. These fixtures stand in for a real trace, so opt it back on.
-  return { ...EMPTY_QUEUE_DATA, hasLocalQueueDepth: true, ...over };
+  return {
+    ...EMPTY_QUEUE_DATA,
+    hasLocalQueueDepth: true,
+    activeTaskMode: "absolute",
+    ...over,
+  };
 }
 
 describe("queueScaleY (#282: 0 must render a visible baseline)", () => {
@@ -145,6 +152,7 @@ describe("buildQueueRenderModel", () => {
     expect(m.activeTask).not.toBeNull();
     expect(m.activeTask!.startCount).toBe(3);
     expect(m.activeTask!.maxTasks).toBe(8); // peak in-view, not the 99 past it
+    expect(m.activeTask!.mode).toBe("absolute");
     expect(m.activeTask!.points).toHaveLength(2);
     expect(m.activeTask!.points[0]).toEqual({ x: 25, count: 8 });
   });
@@ -190,6 +198,37 @@ describe("buildQueueRenderModel", () => {
       binWidthPx: 4,
       binDurationNs: 10,
     });
+  });
+
+  it("resolves exact nonempty spawn bins with boundary-safe selection ranges", () => {
+    const histogram = {
+      counts: [2, 0, 3],
+      maxSpawns: 3,
+      binWidthPx: 8,
+      binDurationNs: 40,
+    };
+    expect(spawnHistogramBinAt(histogram, 0, 120, 39.9)).toMatchObject({
+      index: 0,
+      count: 2,
+      startNs: 0,
+      endNs: 40,
+      selectionEndNs: 39,
+      durationNs: 40,
+      ratePerSecond: 50_000_000,
+    });
+    expect(spawnHistogramBinAt(histogram, 0, 120, 40)).toBeNull();
+    expect(spawnHistogramBinAt(histogram, 0, 120, 120)).toMatchObject({
+      index: 2,
+      count: 3,
+      startNs: 80,
+      endNs: 120,
+      selectionEndNs: 120,
+    });
+  });
+
+  it("formats spawn rates with an explicit tasks/s unit", () => {
+    expect(formatSpawnRate(336.2)).toBe("336 tasks/s");
+    expect(formatSpawnRate(0.25)).toBe("0.25 tasks/s");
   });
 
   it("carries the first sampled task count backward instead of inventing zero", () => {
@@ -328,6 +367,13 @@ describe("computeSpawnedTasks", () => {
       ["locA", "src/a.rs:1"],
       ["locB", "src/b.rs:2"],
     ]),
+    taskRuntime: new Map([
+      [0x1, "main"],
+      [0x2, "io"],
+      [0x3, "main"],
+      [0x4, "main"],
+      [0x5, "io"],
+    ]),
   });
 
   it("finds tasks first-polled in range, grouped by loc, sorted by count desc", () => {
@@ -350,6 +396,20 @@ describe("computeSpawnedTasks", () => {
 
   it("returns null when no task was first-polled in range", () => {
     expect(computeSpawnedTasks(data, { startNs: 500, endNs: 800 })).toBeNull();
+  });
+
+  it("filters a runtime histogram selection to that runtime's tasks", () => {
+    const result = computeSpawnedTasks(
+      data,
+      { startNs: 100, endNs: 200 },
+      "main",
+    );
+    expect(result?.runtimeName).toBe("main");
+    expect(result?.total).toBe(2);
+    expect(result?.groups.flatMap((group) => group.tasks.map((task) => task.taskId))).toEqual([
+      0x1,
+      0x4,
+    ]);
   });
 });
 
@@ -397,8 +457,39 @@ describe("computeQueueData / deriveQueueWindow", () => {
 
     const data = computeQueueData(trace);
     expect(data.activeTaskSamples).toEqual([{ t: 100, count: 43 }]);
+    expect(data.activeTaskMode).toBe("absolute");
     expect(data.taskSpawnTimes).toEqual([110]);
     expect(data.taskFirstPoll.get(1)).toBe(110);
+  });
+
+  it("falls back to a relative lifecycle line when old runtime samples omit alive_tasks", () => {
+    const trace = {
+      events: [],
+      maxTs: 1000,
+      blockInPlaceGaps: [],
+      runtimeWorkers: new Map(),
+      runtimeMetrics: [
+        { t: 100, runtimeName: "", globalQueue: 0, aliveTasks: null },
+      ],
+      legacyActiveTaskSamples: [],
+      taskSpawnTimes: new Map([
+        [1, 110],
+        [2, 200],
+      ]),
+      taskTerminateTimes: new Map([[1, 300]]),
+      taskSpawnLocs: new Map(),
+      spawnLocations: new Map(),
+      hasTaskTracking: true,
+      hasLocalQueueDepth: false,
+    } as unknown as ParsedTrace;
+
+    const data = computeQueueData(trace);
+    expect(data.activeTaskSamples).toEqual([
+      { t: 110, count: 1 },
+      { t: 200, count: 2 },
+      { t: 300, count: 1 },
+    ]);
+    expect(data.activeTaskMode).toBe("relative");
   });
 
   it("sorts task spawn timestamps for histogram windowing", () => {

--- a/dial9-viewer/ui/src/pages/viewer/queue-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-model.ts
@@ -9,10 +9,11 @@
 // distance above the axis. The underlying numbers are unchanged - only the
 // y-mapping does.
 //
-// The three series (global injection queue, max per-worker local queue,
-// active-task count) share ONE explicit zero baseline even though the
+// The three line/area series (global injection queue, max per-worker local
+// queue, active-task count) share ONE explicit zero baseline even though the
 // active-task line keeps its own right-axis magnitude scale, so all three read
-// against the same floor.
+// against the same floor. Task spawns render as an independently scaled,
+// viewport-adaptive histogram behind those series.
 
 import type { ParsedTrace, TimeRange } from "../../types/trace.js";
 import type { StoreState } from "../../types/state.js";
@@ -63,6 +64,8 @@ export interface QueueData {
   mergedLocalSamples: readonly MergedLocalSample[];
   /** Active-task-count timeline, sorted by t. */
   activeTaskSamples: readonly { t: number; count: number }[];
+  /** Task-spawn timestamps, sorted ascending. */
+  taskSpawnTimes: readonly number[];
   /** task id -> first-poll time, the spawn proxy. */
   taskFirstPoll: ReadonlyMap<number, number>;
   /** task id -> spawn-location id (null when unknown). */
@@ -80,6 +83,7 @@ export const EMPTY_QUEUE_DATA: QueueData = {
   queueSamples: [],
   mergedLocalSamples: [],
   activeTaskSamples: [],
+  taskSpawnTimes: [],
   taskFirstPoll: new Map(),
   taskSpawnLocs: new Map(),
   spawnLocations: new Map(),
@@ -104,6 +108,7 @@ export function computeQueueData(trace: ParsedTrace | null): QueueData {
     trace.taskTerminateTimes,
   );
   const activeTaskSamples = activeTaskSeries(trace, timeline);
+  const taskSpawnTimes = [...trace.taskSpawnTimes.values()].sort((a, b) => a - b);
   // The global-queue series comes from per-runtime RuntimeMetrics (summed per
   // cycle) when the trace has them; otherwise fall back to the legacy
   // pre-summed QueueSample series that buildWorkerSpans extracts.
@@ -129,6 +134,7 @@ export function computeQueueData(trace: ParsedTrace | null): QueueData {
     queueSamples,
     mergedLocalSamples: merged,
     activeTaskSamples,
+    taskSpawnTimes,
     taskFirstPoll: timeline.taskFirstPoll,
     taskSpawnLocs: trace.taskSpawnLocs,
     spawnLocations: trace.spawnLocations,
@@ -169,6 +175,18 @@ export interface QueueActiveTaskModel {
   maxTasks: number;
 }
 
+/** Spawn counts in viewport-adaptive, fixed-pixel-width time buckets. */
+export interface QueueSpawnHistogramModel {
+  /** Spawn count per bucket, left-to-right across the viewport. */
+  counts: readonly number[];
+  /** Peak count across the visible buckets, >= 1. */
+  maxSpawns: number;
+  /** Width of one bucket in CSS px. */
+  binWidthPx: number;
+  /** Duration represented by one bucket in trace nanoseconds. */
+  binDurationNs: number;
+}
+
 /**
  * The bucketed queue render model for one frame. `global[i]` / `local[i]` are
  * the plotted (carry-forward-applied) step values at pixel column i. `maxQ` is
@@ -185,6 +203,8 @@ export interface QueueRenderModel {
   local: readonly number[];
   /** Shared magnitude for the global + local series (>= 1). */
   maxQ: number;
+  /** Spawn histogram, or null when no task spawns fall inside the viewport. */
+  spawnHistogram: QueueSpawnHistogramModel | null;
   /** The active-task overlay, or null when the trace has no task timeline. */
   activeTask: QueueActiveTaskModel | null;
   /** True when any series has data in view (else the "no data" path). */
@@ -325,6 +345,7 @@ export function buildQueueRenderModel(inputs: QueueRenderInputs): QueueRenderMod
       global,
       local: data.hasLocalQueueDepth ? local : [],
       maxQ: 1,
+      spawnHistogram: null,
       activeTask: null,
       hasData: false,
     };
@@ -397,6 +418,9 @@ export function buildQueueRenderModel(inputs: QueueRenderInputs): QueueRenderMod
     local[i] = lastL;
   }
 
+  const spawnHistogram = buildSpawnHistogram(data, viewStart, viewEnd, viewDur, drawW);
+  if (spawnHistogram !== null) hasData = true;
+
   const activeTask = buildActiveTaskModel(data, viewStart, viewEnd, viewDur, drawW);
   if (activeTask !== null) hasData = true;
 
@@ -405,8 +429,61 @@ export function buildQueueRenderModel(inputs: QueueRenderInputs): QueueRenderMod
     global,
     local: data.hasLocalQueueDepth ? local : [],
     maxQ,
+    spawnHistogram,
     activeTask,
     hasData,
+  };
+}
+
+/** Target histogram resolution: one time bucket for roughly every 8 CSS px. */
+const SPAWN_BIN_TARGET_PX = 8;
+
+/** Binary search: index of the first number >= target. */
+function lowerBoundNumber(arr: readonly number[], target: number): number {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid]! < target) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+/**
+ * Count real task-spawn events into viewport-adaptive time buckets. The
+ * independent scale preserves burst shape without letting a large spawn spike
+ * flatten the active-task total.
+ */
+function buildSpawnHistogram(
+  data: QueueData,
+  viewStart: number,
+  viewEnd: number,
+  viewDur: number,
+  drawW: number,
+): QueueSpawnHistogramModel | null {
+  const spawnTimes = data.taskSpawnTimes;
+  if (spawnTimes.length === 0) return null;
+
+  const numBins = Math.max(1, Math.ceil(drawW / SPAWN_BIN_TARGET_PX));
+  const counts = new Array<number>(numBins).fill(0);
+  let maxSpawns = 0;
+  const from = lowerBoundNumber(spawnTimes, viewStart);
+  for (let i = from; i < spawnTimes.length; i++) {
+    const t = spawnTimes[i]!;
+    if (t > viewEnd) break;
+    const bin = Math.min(numBins - 1, Math.floor(((t - viewStart) / viewDur) * numBins));
+    const count = counts[bin]! + 1;
+    counts[bin] = count;
+    if (count > maxSpawns) maxSpawns = count;
+  }
+  if (maxSpawns === 0) return null;
+
+  return {
+    counts,
+    maxSpawns,
+    binWidthPx: drawW / numBins,
+    binDurationNs: viewDur / numBins,
   };
 }
 
@@ -512,22 +589,22 @@ export function computeSpawnedTasks(
 /** One queue-legend entry: a swatch encoding + its meaning (matches the draw). */
 export interface QueueLegendEntry {
   /** Which series this explains, so a caller can drop the ones it will not draw. */
-  key: "global" | "local" | "activeTask";
+  key: "global" | "local" | "spawns" | "activeTask";
   /** Swatch fill (CSS color). */
   swatch: string;
   label: string;
   /** Shape hint so the swatch reads as an area/line, matching the render. */
-  shape: "area" | "line";
+  shape: "area" | "bars" | "line";
 }
 
 /**
  * The queue track legend: every series the track draws is explained, with
- * swatch encodings that MATCH the in-track rendering. Ordered global -> local
- * -> active-task, the draw order.
+ * swatch encodings that MATCH the in-track rendering.
  */
 export const QUEUE_LEGEND: readonly QueueLegendEntry[] = [
   { key: "global", swatch: "#4fc3f7", label: "Global queue", shape: "area" },
   { key: "local", swatch: "#ff8a65", label: "Max local (q:NN)", shape: "line" },
+  { key: "spawns", swatch: "#81c784", label: "Task spawns / bucket", shape: "bars" },
   { key: "activeTask", swatch: "#81c784", label: "Active tasks", shape: "line" },
 ];
 

--- a/dial9-viewer/ui/src/pages/viewer/queue-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-model.ts
@@ -22,10 +22,19 @@ import {
   buildActiveTaskTimeline,
 } from "../../lib/trace/index.js";
 import {
+  deriveRuntimeGroups,
   deriveRuntimeMetrics,
   deriveWorkerIds,
   sharedWorkerSpans,
 } from "../../lib/trace/derived.js";
+import { deriveRuntimeTaskSpawns } from "../../lib/trace/runtime-task-spawns.js";
+import {
+  buildSpawnHistogram,
+  formatSpawnRate,
+  spawnHistogramBinAt,
+  type SpawnHistogramBin,
+  type SpawnHistogramModel,
+} from "../../lib/canvas/spawn-histogram.js";
 
 // ── Windowing descriptor ─────────────────────────────────────────────────
 
@@ -46,6 +55,9 @@ export interface MergedLocalSample {
   local: number;
 }
 
+/** Whether the active-task line is an absolute total or lifecycle-relative. */
+export type ActiveTaskMode = "absolute" | "relative" | "none";
+
 /**
  * Everything the queue track needs for one render pass + the drag-select,
  * lifted out of the store so the render logic stays Node-testable. Built once
@@ -64,10 +76,17 @@ export interface QueueData {
   mergedLocalSamples: readonly MergedLocalSample[];
   /** Active-task-count timeline, sorted by t. */
   activeTaskSamples: readonly { t: number; count: number }[];
+  /**
+   * Absolute for sampled process-wide totals; relative when reconstructed from
+   * spawn/terminate deltas because the trace has no initial task-count sample.
+   */
+  activeTaskMode: ActiveTaskMode;
   /** Task-spawn timestamps, sorted ascending. */
   taskSpawnTimes: readonly number[];
   /** task id -> first-poll time, the spawn proxy. */
   taskFirstPoll: ReadonlyMap<number, number>;
+  /** task id -> runtime group name, inferred from the task's first poll. */
+  taskRuntime: ReadonlyMap<number, string>;
   /** task id -> spawn-location id (null when unknown). */
   taskSpawnLocs: ReadonlyMap<number, string | null>;
   /** spawn-location id -> human-readable location. */
@@ -83,8 +102,10 @@ export const EMPTY_QUEUE_DATA: QueueData = {
   queueSamples: [],
   mergedLocalSamples: [],
   activeTaskSamples: [],
+  activeTaskMode: "none",
   taskSpawnTimes: [],
   taskFirstPoll: new Map(),
+  taskRuntime: new Map(),
   taskSpawnLocs: new Map(),
   spawnLocations: new Map(),
   hasTaskTracking: false,
@@ -108,7 +129,23 @@ export function computeQueueData(trace: ParsedTrace | null): QueueData {
     trace.taskTerminateTimes,
   );
   const activeTaskSamples = activeTaskSeries(trace, timeline);
+  const runtimeMetricsSamples = trace.runtimeMetrics ?? [];
+  const hasRuntimeActiveTasks =
+    runtimeMetricsSamples.length > 0 &&
+    runtimeMetricsSamples.every((sample) => sample.aliveTasks !== null);
+  const hasLegacyActiveTasks = (trace.legacyActiveTaskSamples?.length ?? 0) > 0;
+  const activeTaskMode: ActiveTaskMode =
+    activeTaskSamples.length === 0
+      ? "none"
+      : hasRuntimeActiveTasks || hasLegacyActiveTasks
+        ? "absolute"
+        : "relative";
   const taskSpawnTimes = [...trace.taskSpawnTimes.values()].sort((a, b) => a - b);
+  const runtimeTaskSpawns = deriveRuntimeTaskSpawns(
+    trace.taskSpawnTimes,
+    deriveRuntimeGroups(trace),
+    spanResult.workerSpans,
+  );
   // The global-queue series comes from per-runtime RuntimeMetrics (summed per
   // cycle) when the trace has them; otherwise fall back to the legacy
   // pre-summed QueueSample series that buildWorkerSpans extracts.
@@ -134,8 +171,10 @@ export function computeQueueData(trace: ParsedTrace | null): QueueData {
     queueSamples,
     mergedLocalSamples: merged,
     activeTaskSamples,
+    activeTaskMode,
     taskSpawnTimes,
     taskFirstPoll: timeline.taskFirstPoll,
+    taskRuntime: runtimeTaskSpawns.taskRuntime,
     taskSpawnLocs: trace.taskSpawnLocs,
     spawnLocations: trace.spawnLocations,
     hasTaskTracking: trace.hasTaskTracking,
@@ -173,19 +212,13 @@ export interface QueueActiveTaskModel {
   startCount: number;
   /** Right-axis magnitude, >= 1. */
   maxTasks: number;
+  /** Whether these values are absolute totals or trace-relative deltas. */
+  mode: Exclude<ActiveTaskMode, "none">;
 }
 
-/** Spawn counts in viewport-adaptive, fixed-pixel-width time buckets. */
-export interface QueueSpawnHistogramModel {
-  /** Spawn count per bucket, left-to-right across the viewport. */
-  counts: readonly number[];
-  /** Peak count across the visible buckets, >= 1. */
-  maxSpawns: number;
-  /** Width of one bucket in CSS px. */
-  binWidthPx: number;
-  /** Duration represented by one bucket in trace nanoseconds. */
-  binDurationNs: number;
-}
+export type QueueSpawnHistogramModel = SpawnHistogramModel;
+export type QueueSpawnBin = SpawnHistogramBin;
+export { formatSpawnRate, spawnHistogramBinAt };
 
 /**
  * The bucketed queue render model for one frame. `global[i]` / `local[i]` are
@@ -418,7 +451,12 @@ export function buildQueueRenderModel(inputs: QueueRenderInputs): QueueRenderMod
     local[i] = lastL;
   }
 
-  const spawnHistogram = buildSpawnHistogram(data, viewStart, viewEnd, viewDur, drawW);
+  const spawnHistogram = buildSpawnHistogram(
+    data.taskSpawnTimes,
+    viewStart,
+    viewEnd,
+    drawW,
+  );
   if (spawnHistogram !== null) hasData = true;
 
   const activeTask = buildActiveTaskModel(data, viewStart, viewEnd, viewDur, drawW);
@@ -432,58 +470,6 @@ export function buildQueueRenderModel(inputs: QueueRenderInputs): QueueRenderMod
     spawnHistogram,
     activeTask,
     hasData,
-  };
-}
-
-/** Target histogram resolution: one time bucket for roughly every 8 CSS px. */
-const SPAWN_BIN_TARGET_PX = 8;
-
-/** Binary search: index of the first number >= target. */
-function lowerBoundNumber(arr: readonly number[], target: number): number {
-  let lo = 0;
-  let hi = arr.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >> 1;
-    if (arr[mid]! < target) lo = mid + 1;
-    else hi = mid;
-  }
-  return lo;
-}
-
-/**
- * Count real task-spawn events into viewport-adaptive time buckets. The
- * independent scale preserves burst shape without letting a large spawn spike
- * flatten the active-task total.
- */
-function buildSpawnHistogram(
-  data: QueueData,
-  viewStart: number,
-  viewEnd: number,
-  viewDur: number,
-  drawW: number,
-): QueueSpawnHistogramModel | null {
-  const spawnTimes = data.taskSpawnTimes;
-  if (spawnTimes.length === 0) return null;
-
-  const numBins = Math.max(1, Math.ceil(drawW / SPAWN_BIN_TARGET_PX));
-  const counts = new Array<number>(numBins).fill(0);
-  let maxSpawns = 0;
-  const from = lowerBoundNumber(spawnTimes, viewStart);
-  for (let i = from; i < spawnTimes.length; i++) {
-    const t = spawnTimes[i]!;
-    if (t > viewEnd) break;
-    const bin = Math.min(numBins - 1, Math.floor(((t - viewStart) / viewDur) * numBins));
-    const count = counts[bin]! + 1;
-    counts[bin] = count;
-    if (count > maxSpawns) maxSpawns = count;
-  }
-  if (maxSpawns === 0) return null;
-
-  return {
-    counts,
-    maxSpawns,
-    binWidthPx: drawW / numBins,
-    binDurationNs: viewDur / numBins,
   };
 }
 
@@ -523,7 +509,8 @@ function buildActiveTaskModel(
     const x = ((s.t - viewStart) / viewDur) * drawW;
     points.push({ x, count: s.count });
   }
-  return { points, startCount, maxTasks };
+  if (data.activeTaskMode === "none") return null;
+  return { points, startCount, maxTasks, mode: data.activeTaskMode };
 }
 
 // ── Drag-select: tasks spawned in a time range ────────────────────────────
@@ -545,6 +532,8 @@ export interface SpawnedTaskGroup {
  */
 export interface SpawnedTasksResult {
   range: TimeRange;
+  /** Runtime group filter, or null for process-wide results. */
+  runtimeName: string | null;
   /** Total tasks found in range. */
   total: number;
   /** Groups sorted by task count desc. */
@@ -559,12 +548,16 @@ export interface SpawnedTasksResult {
 export function computeSpawnedTasks(
   data: QueueData,
   range: TimeRange,
+  runtimeName: string | null = null,
 ): SpawnedTasksResult | null {
   const { startNs, endNs } = range;
   const groups = new Map<string, { taskId: number; firstPoll: number }[]>();
   let total = 0;
   for (const [taskId, t] of data.taskFirstPoll) {
     if (t < startNs || t > endNs) continue;
+    if (runtimeName !== null && data.taskRuntime.get(taskId) !== runtimeName) {
+      continue;
+    }
     const locId = data.taskSpawnLocs.get(taskId);
     const raw = locId != null ? data.spawnLocations.get(locId) : null;
     // An empty/missing location groups as unknown.
@@ -581,7 +574,7 @@ export function computeSpawnedTasks(
   const sorted = [...groups.entries()]
     .sort((a, b) => b[1].length - a[1].length)
     .map(([loc, tasks]) => ({ loc, tasks }));
-  return { range, total, groups: sorted };
+  return { range, runtimeName, total, groups: sorted };
 }
 
 // ── Legend ─────────────────────────────────────────────────────────────────

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
@@ -10,7 +10,11 @@
 
 import { describe, it, expect } from "vitest";
 import { createViewerStore } from "./store.js";
-import { createQueueTrack, drawQueueCanvas } from "./queue-track.js";
+import {
+  createQueueTrack,
+  drawQueueCanvas,
+} from "./queue-track.js";
+import { spawnHistogramTooltipRows } from "../../components/overlay/tooltip.js";
 import { ZERO_BASELINE_PX, queueBaselineY, type QueueRenderModel, type QueueWindow } from "./queue-model.js";
 import type { ParsedTrace } from "../../types/trace.js";
 
@@ -107,7 +111,12 @@ describe("drawQueueCanvas (zero-global renders a visible baseline)", () => {
         binWidthPx: 10,
         binDurationNs: 1_000_000,
       },
-      activeTask: { points: [{ x: 10, count: 4 }], startCount: 1, maxTasks: 4 },
+      activeTask: {
+        points: [{ x: 10, count: 4 }],
+        startCount: 1,
+        maxTasks: 4,
+        mode: "absolute",
+      },
       hasData: true,
     };
     const { ctx, rec } = recordingCtx();
@@ -116,7 +125,7 @@ describe("drawQueueCanvas (zero-global renders a visible baseline)", () => {
     expect(texts).toContain("2"); // maxQ label
     expect(texts).toContain("0"); // zero-baseline label
     expect(texts).toContain("tasks:4"); // active-task right-axis label
-    expect(texts).toContain("spawns:3/1.00ms"); // spawn histogram peak + quantum
+    expect(texts).toContain("spawn peak:3000 tasks/s"); // normalized peak rate
     expect(rec.fillRects.filter((r) => r.style === "rgba(129,199,132,0.16)")).toHaveLength(2);
   });
 
@@ -172,6 +181,24 @@ describe("createQueueTrack (dispatch through the selection slice)", () => {
     track.dispose();
   });
 
+  it("commitRange clears competing inspector selections so Stack opens", () => {
+    const { store } = newStore();
+    const track = createQueueTrack(store);
+    store.update("selection", {
+      pinnedEvent: { timestamp: 9 } as never,
+      sidebarRange: { startNs: 1, endNs: 2 },
+    });
+
+    track.commitRange({ startNs: 100, endNs: 500 });
+    expect(store.getState().selection.pinnedEvent).toBeNull();
+    expect(store.getState().selection.sidebarRange).toBeNull();
+    expect(store.getState().selection.spawnedTasksRange).toEqual({
+      startNs: 100,
+      endNs: 500,
+    });
+    track.dispose();
+  });
+
   it("does not re-dispatch when the range is unchanged (no store thrash)", () => {
     const { store, pending } = newStore();
     const track = createQueueTrack(store);
@@ -213,5 +240,34 @@ describe("createQueueTrack (dispatch through the selection slice)", () => {
     store.update("trace", { trace });
     expect(track.spawnedTasks({ startNs: 0, endNs: 1000 })).toBeNull();
     track.dispose();
+  });
+});
+
+describe("spawnHistogramTooltipRows", () => {
+  it("shows exact count, normalized rate, window, duration, and click hint", () => {
+    const rows = spawnHistogramTooltipRows(
+      {
+        index: 2,
+        count: 133,
+        startNs: 1_000_000,
+        endNs: 396_400_000,
+        selectionEndNs: 396_399_999,
+        durationNs: 395_400_000,
+        ratePerSecond: 336.37,
+      },
+      (ns) => `${ns}ns`,
+    );
+    expect(rows).toEqual([
+      [{ label: "Tasks spawned:", value: "133" }],
+      [{ label: "Spawn rate:", value: "336 tasks/s" }],
+      [{ label: "Window:", value: "1000000ns – 396400000ns" }],
+      [
+        {
+          label: "Duration:",
+          value: "395.40ms",
+          hint: "(click bar to list tasks)",
+        },
+      ],
+    ]);
   });
 });

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
@@ -214,6 +214,21 @@ describe("createQueueTrack (dispatch through the selection slice)", () => {
     track.dispose();
   });
 
+  it("clears a runtime filter when the process-wide range is unchanged", () => {
+    const { store } = newStore();
+    const track = createQueueTrack(store);
+    const range = { startNs: 100, endNs: 500 };
+    store.update("selection", {
+      spawnedTasksRange: range,
+      spawnedTasksRuntime: "io",
+    });
+
+    track.commitRange(range);
+    expect(store.getState().selection.spawnedTasksRange).toEqual(range);
+    expect(store.getState().selection.spawnedTasksRuntime).toBeNull();
+    track.dispose();
+  });
+
   it("commitRange(null) clears the range", () => {
     const { store } = newStore();
     const track = createQueueTrack(store);

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
@@ -108,6 +108,7 @@ describe("drawQueueCanvas (zero-global renders a visible baseline)", () => {
       spawnHistogram: {
         counts: [0, 3, 1],
         maxSpawns: 3,
+        peakSpawnsPerSecond: 4,
         binWidthPx: 10,
         binDurationNs: 1_000_000,
       },
@@ -125,7 +126,7 @@ describe("drawQueueCanvas (zero-global renders a visible baseline)", () => {
     expect(texts).toContain("2"); // maxQ label
     expect(texts).toContain("0"); // zero-baseline label
     expect(texts).toContain("tasks:4"); // active-task right-axis label
-    expect(texts).toContain("spawn peak:3000 tasks/s"); // normalized peak rate
+    expect(texts).toContain("spawn peak:4 tasks/s"); // true sliding-window peak
     expect(rec.fillRects.filter((r) => r.style === "rgba(129,199,132,0.16)")).toHaveLength(2);
   });
 

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
@@ -37,7 +37,7 @@ function recordingCtx(): { ctx: CanvasRenderingContext2D; rec: Rec } {
     textAlign: "" as CanvasTextAlign,
     clearRect() {},
     fillRect(x: number, y: number, w: number, h: number) {
-      rec.fillRects.push({ x, y, w, h, style: String(this.fillStyle) });
+      rec.fillRects.push({ x, y, w, h, style: String(ctx.fillStyle) });
     },
     strokeRect() {},
     beginPath() {},

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
@@ -19,7 +19,7 @@ const COMPLETE: QueueWindow = { truncatedAt: null, oversized: false };
 /** A recording 2D context: captures path vertices, fills, strokes, labels. */
 interface Rec {
   pathYs: number[];
-  fillRects: { x: number; y: number; w: number; h: number }[];
+  fillRects: { x: number; y: number; w: number; h: number; style: string }[];
   strokes: number;
   labels: { text: string; x: number; y: number }[];
 }
@@ -33,7 +33,7 @@ function recordingCtx(): { ctx: CanvasRenderingContext2D; rec: Rec } {
     textAlign: "" as CanvasTextAlign,
     clearRect() {},
     fillRect(x: number, y: number, w: number, h: number) {
-      rec.fillRects.push({ x, y, w, h });
+      rec.fillRects.push({ x, y, w, h, style: String(this.fillStyle) });
     },
     strokeRect() {},
     beginPath() {},
@@ -68,6 +68,7 @@ describe("drawQueueCanvas (zero-global renders a visible baseline)", () => {
       global: zeros(4),
       local: zeros(4),
       maxQ: 1,
+      spawnHistogram: null,
       activeTask: null,
       hasData: true,
     };
@@ -100,6 +101,12 @@ describe("drawQueueCanvas (zero-global renders a visible baseline)", () => {
       global: [1, 2, 2],
       local: [0, 1, 1],
       maxQ: 2,
+      spawnHistogram: {
+        counts: [0, 3, 1],
+        maxSpawns: 3,
+        binWidthPx: 10,
+        binDurationNs: 1_000_000,
+      },
       activeTask: { points: [{ x: 10, count: 4 }], startCount: 1, maxTasks: 4 },
       hasData: true,
     };
@@ -109,6 +116,8 @@ describe("drawQueueCanvas (zero-global renders a visible baseline)", () => {
     expect(texts).toContain("2"); // maxQ label
     expect(texts).toContain("0"); // zero-baseline label
     expect(texts).toContain("tasks:4"); // active-task right-axis label
+    expect(texts).toContain("spawns:3/1.00ms"); // spawn histogram peak + quantum
+    expect(rec.fillRects.filter((r) => r.style === "rgba(129,199,132,0.16)")).toHaveLength(2);
   });
 
   it("shows the empty message and no strokes when there is no data", () => {
@@ -117,6 +126,7 @@ describe("drawQueueCanvas (zero-global renders a visible baseline)", () => {
       global: zeros(4),
       local: zeros(4),
       maxQ: 1,
+      spawnHistogram: null,
       activeTask: null,
       hasData: false,
     };
@@ -132,6 +142,7 @@ describe("drawQueueCanvas (zero-global renders a visible baseline)", () => {
       global: [0, 0],
       local: [0, 0],
       maxQ: 1,
+      spawnHistogram: null,
       activeTask: null,
       hasData: true,
     };

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.ts
@@ -344,9 +344,10 @@ export function createQueueTrack(store: ViewerStore): QueueTrackController {
   }
 
   function commitRange(range: TimeRange | null): void {
-    const cur = state().selection.spawnedTasksRange;
+    const selection = state().selection;
+    const cur = selection.spawnedTasksRange;
     if (range === null) {
-      if (cur !== null || state().selection.spawnedTasksRuntime != null) {
+      if (cur !== null || selection.spawnedTasksRuntime != null) {
         store.update("selection", {
           spawnedTasksRange: null,
           spawnedTasksRuntime: null,
@@ -354,7 +355,15 @@ export function createQueueTrack(store: ViewerStore): QueueTrackController {
       }
       return;
     }
-    if (cur !== null && cur.startNs === range.startNs && cur.endNs === range.endNs) return;
+    const rangeUnchanged =
+      cur !== null && cur.startNs === range.startNs && cur.endNs === range.endNs;
+    const inspectorSelectionClear =
+      selection.spawnedTasksRuntime == null &&
+      selection.pollDetail == null &&
+      selection.pinnedEvent == null &&
+      selection.taskDump == null &&
+      selection.sidebarRange == null;
+    if (rangeUnchanged && inspectorSelectionClear) return;
     store.update("selection", {
       spawnedTasksRange: range,
       spawnedTasksRuntime: null,

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.ts
@@ -574,10 +574,7 @@ export function drawQueueCanvas(
     ctx.font = "10px monospace";
     ctx.textAlign = "right";
     ctx.fillText(
-      `spawn peak:${formatSpawnRate(
-        (spawnHistogram.maxSpawns * 1_000_000_000) /
-          spawnHistogram.binDurationNs,
-      )}`,
+      `spawn peak:${formatSpawnRate(spawnHistogram.peakSpawnsPerSecond)}`,
       Math.max(0, drawW - 4),
       Math.min(baselineY - 1, chartTop + 18),
     );

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.ts
@@ -32,14 +32,16 @@ import {
   computeQueueData,
   computeSpawnedTasks,
   deriveQueueWindow,
+  formatSpawnRate,
   queueBaselineY,
   queueScaleY,
+  spawnHistogramBinAt,
   type QueueData,
   type QueueRenderModel,
+  type QueueSpawnBin,
   type QueueWindow,
   type SpawnedTasksResult,
 } from "./queue-model.js";
-import { formatHumanDuration } from "../../lib/trace/index.js";
 
 /** Height reserved for the legend strip above the queue canvas. */
 const LEGEND_H = 18;
@@ -78,6 +80,10 @@ export interface QueueTrackController {
     viewEnd: number,
   ): void;
   queueSeries(): QueueData;
+  /** The nonempty spawn-histogram bin under a trace timestamp. */
+  spawnBinAt(ns: number): QueueSpawnBin | null;
+  /** Select the spawn bin under a timestamp and open its task list. */
+  selectSpawnBin(ns: number): boolean;
   /**
    * The spawned-tasks derivation for a range: tasks first polled in range,
    * grouped by spawn location. Exposed so the inspector reuses the logic and
@@ -205,7 +211,12 @@ export function createQueueTrack(store: ViewerStore): QueueTrackController {
     const entries = QUEUE_LEGEND.filter(
       (e) =>
         (e.key !== "local" || data.hasLocalQueueDepth) &&
-        (e.key !== "spawns" || data.taskSpawnTimes.length > 0),
+        (e.key !== "spawns" || data.taskSpawnTimes.length > 0) &&
+        (e.key !== "activeTask" || data.activeTaskMode !== "none"),
+    ).map((e) =>
+      e.key === "activeTask" && data.activeTaskMode === "relative"
+        ? { ...e, label: "Active tasks Δ (relative)" }
+        : e,
     );
     return html`
       <ul class="d9-queue-legend" aria-label="Queue depth legend">
@@ -242,8 +253,9 @@ export function createQueueTrack(store: ViewerStore): QueueTrackController {
 
   function onCanvasMouseDown(ev: MouseEvent): void {
     const s = state();
-    // Only meaningful when the trace carries the active-task timeline.
-    if (s.trace.trace === null || !queueData().hasTaskTracking) return;
+    // A drag or click selects task-spawn time, independent of whether the old
+    // trace carries an absolute active-task count.
+    if (s.trace.trace === null || queueData().taskSpawnTimes.length === 0) return;
     if (s.viewport.viewEnd <= s.viewport.viewStart) return;
     const canvas = ev.currentTarget as HTMLCanvasElement;
     const startNs = xToNs(canvas, ev.clientX, s.viewport.viewStart, s.viewport.viewEnd);
@@ -296,6 +308,7 @@ export function createQueueTrack(store: ViewerStore): QueueTrackController {
   function onWindowMouseUp(): void {
     if (drag === null) return;
     const moved = drag.moved;
+    const clickNs = drag.endNs;
     const selStart = Math.min(drag.startNs, drag.endNs);
     const selEnd = Math.max(drag.startNs, drag.endNs);
     drag = null;
@@ -309,8 +322,8 @@ export function createQueueTrack(store: ViewerStore): QueueTrackController {
       // Dispatch the range the inspector renders the spawned-task list from. A
       // plain click (no move) leaves the current range untouched.
       commitRange({ startNs: selStart, endNs: selEnd });
-    } else if (sizer !== null && lastPaint !== null) {
-      // Repaint clean (drop any band drawn before the 3px threshold).
+    } else if (!selectSpawnBin(clickNs) && sizer !== null && lastPaint !== null) {
+      // Repaint clean when the click missed a nonempty bar.
       const ctx = sizer.ensure(lastPaint.drawW, lastPaint.canvasH, lastPaint.dpr);
       drawQueueCanvas(ctx, lastPaint.model, lastPaint.window, lastPaint.drawW, lastPaint.canvasH);
     }
@@ -333,15 +346,44 @@ export function createQueueTrack(store: ViewerStore): QueueTrackController {
   function commitRange(range: TimeRange | null): void {
     const cur = state().selection.spawnedTasksRange;
     if (range === null) {
-      if (cur !== null) store.update("selection", { spawnedTasksRange: null });
+      if (cur !== null || state().selection.spawnedTasksRuntime != null) {
+        store.update("selection", {
+          spawnedTasksRange: null,
+          spawnedTasksRuntime: null,
+        });
+      }
       return;
     }
     if (cur !== null && cur.startNs === range.startNs && cur.endNs === range.endNs) return;
-    store.update("selection", { spawnedTasksRange: range, taskDump: null });
+    store.update("selection", {
+      spawnedTasksRange: range,
+      spawnedTasksRuntime: null,
+      pollDetail: null,
+      pinnedEvent: null,
+      taskDump: null,
+      sidebarRange: null,
+    });
   }
 
   function queueSeries(): QueueData {
     return queueData();
+  }
+
+  function spawnBinAt(ns: number): QueueSpawnBin | null {
+    if (lastPaint === null) return null;
+    return spawnHistogramBinAt(
+      lastPaint.model.spawnHistogram,
+      lastPaint.viewStart,
+      lastPaint.viewEnd,
+      ns,
+    );
+  }
+
+  function selectSpawnBin(ns: number): boolean {
+    const bin = spawnBinAt(ns);
+    if (bin === null) return false;
+    commitRange({ startNs: bin.startNs, endNs: bin.selectionEndNs });
+    return true;
   }
 
   function spawnedTasks(range: TimeRange): SpawnedTasksResult | null {
@@ -362,7 +404,16 @@ export function createQueueTrack(store: ViewerStore): QueueTrackController {
     sizerCanvas = null;
   }
 
-  return { rowTemplate, paint, queueSeries, spawnedTasks, commitRange, dispose };
+  return {
+    rowTemplate,
+    paint,
+    queueSeries,
+    spawnBinAt,
+    selectSpawnBin,
+    spawnedTasks,
+    commitRange,
+    dispose,
+  };
 }
 
 // ── Draw-area x mapping + selection band (module-local) ────────────────────
@@ -498,7 +549,11 @@ export function drawQueueCanvas(
     ctx.fillStyle = ACTIVE_LABEL;
     ctx.font = "10px monospace";
     ctx.textAlign = "right";
-    ctx.fillText(`tasks:${at.maxTasks}`, Math.max(0, drawW - 4), chartTop + 8);
+    ctx.fillText(
+      `${at.mode === "relative" ? "tasks Δ" : "tasks"}:${at.maxTasks}`,
+      Math.max(0, drawW - 4),
+      chartTop + 8,
+    );
 
     ctx.beginPath();
     let y = queueScaleY(at.startCount, at.maxTasks, chartTop, chartH);
@@ -519,7 +574,10 @@ export function drawQueueCanvas(
     ctx.font = "10px monospace";
     ctx.textAlign = "right";
     ctx.fillText(
-      `spawns:${spawnHistogram.maxSpawns}/${formatHumanDuration(spawnHistogram.binDurationNs)}`,
+      `spawn peak:${formatSpawnRate(
+        (spawnHistogram.maxSpawns * 1_000_000_000) /
+          spawnHistogram.binDurationNs,
+      )}`,
       Math.max(0, drawW - 4),
       Math.min(baselineY - 1, chartTop + 18),
     );

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.ts
@@ -5,8 +5,8 @@
 //
 // The global + max-local + active-task series render against ONE explicit zero
 // baseline (queueScaleY) so a 0-valued global queue shows a VISIBLE flat line
-// instead of a stroke fused to the axis; the numbers are unchanged, only the
-// y-mapping and the labeling/legend.
+// instead of a stroke fused to the axis. A translucent, independently scaled
+// spawn histogram sits behind the lines to preserve short-lived task bursts.
 //
 // Hover info rides the overlay's at-cursor store contract (transient.atCursor),
 // not a corner div, so hovering this track already populates the inspector
@@ -39,6 +39,7 @@ import {
   type QueueWindow,
   type SpawnedTasksResult,
 } from "./queue-model.js";
+import { formatHumanDuration } from "../../lib/trace/index.js";
 
 /** Height reserved for the legend strip above the queue canvas. */
 const LEGEND_H = 18;
@@ -49,6 +50,7 @@ const GLOBAL_FILL = "rgba(79,195,247,0.3)";
 const GLOBAL_STROKE = "#4fc3f7";
 const LOCAL_STROKE = "#ff8a65";
 const ACTIVE_STROKE = "#81c784";
+const SPAWN_FILL = "rgba(129,199,132,0.16)";
 const AXIS_LABEL = "#666";
 const ACTIVE_LABEL = "#81c784";
 const EMPTY_TEXT = "#555";
@@ -198,10 +200,13 @@ export function createQueueTrack(store: ViewerStore): QueueTrackController {
 
   /** The in-track legend, swatch encodings matching the draw. */
   function legendTemplate(): TemplateResult {
-    // Drop the local series when the trace has no per-worker depth.
-    const entries = queueData().hasLocalQueueDepth
-      ? QUEUE_LEGEND
-      : QUEUE_LEGEND.filter((e) => e.key !== "local");
+    const data = queueData();
+    // Drop encodings whose source is absent from this trace.
+    const entries = QUEUE_LEGEND.filter(
+      (e) =>
+        (e.key !== "local" || data.hasLocalQueueDepth) &&
+        (e.key !== "spawns" || data.taskSpawnTimes.length > 0),
+    );
     return html`
       <ul class="d9-queue-legend" aria-label="Queue depth legend">
         ${repeat(
@@ -387,9 +392,10 @@ function overlayBandRange(
 /**
  * Draw the queue chart into `ctx` (already DPR-scaled + sized to drawW x
  * canvasH) in order - background, global filled step-area, max-local step line,
- * active-task step line on its own scale, y-axis labels - every series mapped
- * through queueScaleY, which reserves a visible zero baseline so a 0-valued
- * global renders a flat line, not nothing. Then the window markers on top.
+ * translucent spawn histogram, active-task step line on its own scale, and
+ * y-axis labels. The line/area series use queueScaleY, which reserves a visible
+ * zero baseline so a 0-valued global renders a flat line, not nothing. Then the
+ * window markers on top.
  * Draw-area-relative coordinates (the canvas already omits LABEL_W; the DOM
  * label gutter supplies the shared offset).
  */
@@ -421,6 +427,7 @@ export function drawQueueCanvas(
   const maxQ = model.maxQ;
   const baselineY = queueBaselineY(chartTop, chartH);
 
+  const spawnHistogram = model.spawnHistogram;
   // ── Global queue as a filled step area with a visible zero baseline ──
   // The fill polygon's bottom edge is the baseline (queueScaleY(0)), NOT the
   // true canvas bottom, so a 0-valued global is a thin sliver + a stroke ON the
@@ -458,6 +465,26 @@ export function drawQueueCanvas(
     ctx.stroke();
   }
 
+  // ── Task spawns as a translucent, independently scaled histogram ────────
+  // Fixed-pixel-width bins adapt their time quantum as the viewport zooms.
+  // Draw after the queue series so the bars stay visible, but before the
+  // active-task total so that line remains the foreground signal.
+  if (spawnHistogram !== null) {
+    ctx.fillStyle = SPAWN_FILL;
+    for (let i = 0; i < spawnHistogram.counts.length; i++) {
+      const count = spawnHistogram.counts[i]!;
+      if (count === 0) continue;
+      const x = i * spawnHistogram.binWidthPx;
+      const y = queueScaleY(count, spawnHistogram.maxSpawns, chartTop, chartH);
+      ctx.fillRect(
+        x + 0.5,
+        y,
+        Math.max(1, spawnHistogram.binWidthPx - 1),
+        baselineY - y,
+      );
+    }
+  }
+
   // ── Y-axis labels (max at top, 0 at the visible baseline) ───────────────
   ctx.fillStyle = AXIS_LABEL;
   ctx.font = "10px monospace";
@@ -485,6 +512,17 @@ export function drawQueueCanvas(
     ctx.strokeStyle = ACTIVE_STROKE;
     ctx.lineWidth = 1.5;
     ctx.stroke();
+  }
+
+  if (spawnHistogram !== null) {
+    ctx.fillStyle = ACTIVE_LABEL;
+    ctx.font = "10px monospace";
+    ctx.textAlign = "right";
+    ctx.fillText(
+      `spawns:${spawnHistogram.maxSpawns}/${formatHumanDuration(spawnHistogram.binDurationNs)}`,
+      Math.max(0, drawW - 4),
+      Math.min(baselineY - 1, chartTop + 18),
+    );
   }
 
   // ── Surface a truncated / oversized window (never as complete) ─────

--- a/dial9-viewer/ui/src/pages/viewer/region-analysis.ts
+++ b/dial9-viewer/ui/src/pages/viewer/region-analysis.ts
@@ -735,6 +735,7 @@ export function createRegionAnalysis(
       pollDetail: null,
       taskDump: null,
       spawnedTasksRange: null,
+      spawnedTasksRuntime: null,
     });
   }
 

--- a/dial9-viewer/ui/src/pages/viewer/shell.ts
+++ b/dial9-viewer/ui/src/pages/viewer/shell.ts
@@ -248,6 +248,8 @@ export interface MountedShell {
   toastRegion: HTMLElement;
   /** The track column element (canvas host for sizing). */
   trackColumn: HTMLElement;
+  /** Queue-track hover and spawned-task selection helpers. */
+  queueTrack: QueueTrackController;
   /**
    * The issues rail. Exposed so the entry can supply its lane-reveal action
    * after mounting the lanes, which happens after the shell constructs this.
@@ -379,6 +381,7 @@ export function mountShell(
   return {
     toastRegion,
     trackColumn,
+    queueTrack,
     // Exposed so the entry can hand the rail its lane-reveal action once the
     // lanes are mounted (they mount after the shell).
     rail,

--- a/dial9-viewer/ui/src/pages/viewer/store.ts
+++ b/dial9-viewer/ui/src/pages/viewer/store.ts
@@ -44,6 +44,7 @@ export function initialViewerState(): StoreState {
       sidebarRange: null,
       hoveredWakerTaskId: null,
       spawnedTasksRange: null,
+      spawnedTasksRuntime: null,
     },
     // POI / issues-rail controls. Defaults: filter = "sched" and worst-first ON
     // (sort by the duration column, desc). No POI is current until the user

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
@@ -371,6 +371,7 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
       pollDetail: null,
       sidebarRange: null,
       spawnedTasksRange: null,
+      spawnedTasksRuntime: null,
     });
   }
 

--- a/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.test.ts
@@ -572,6 +572,7 @@ describe("viewer deep-link reconstruction", () => {
       sidebarRange: null,
       hoveredWakerTaskId: null,
       spawnedTasksRange: null,
+      spawnedTasksRuntime: null,
     });
     expect(state.poi).toEqual({
       filter: "long-poll",

--- a/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.ts
+++ b/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.ts
@@ -221,6 +221,7 @@ export function createViewerReconstruction(
       sidebarRange: null,
       hoveredWakerTaskId: null,
       spawnedTasksRange: null,
+      spawnedTasksRuntime: null,
       ...resolved,
     });
   }
@@ -236,6 +237,7 @@ export function createViewerReconstruction(
       sidebarRange: null,
       hoveredWakerTaskId: null,
       spawnedTasksRange: null,
+      spawnedTasksRuntime: null,
     });
   }
 

--- a/dial9-viewer/ui/src/styles/viewer.css
+++ b/dial9-viewer/ui/src/styles/viewer.css
@@ -896,6 +896,14 @@ body {
 /* Line encodings (max-local, active-task) read as a 2px rule, not a box, so
    the swatch matches what the track draws (swatches match rendering). */
 .d9-queue-legend-swatch.shape-line { height: 2px; }
+.d9-queue-legend-swatch.shape-bars {
+    background: repeating-linear-gradient(
+        90deg,
+        currentColor 0 2px,
+        transparent 2px 4px
+    ) !important;
+    opacity: 0.55;
+}
 .d9-queue-legend-text { white-space: nowrap; }
 .d9-queue-canvas { flex: 1; min-width: 0; }
 

--- a/dial9-viewer/ui/src/types/state.d.ts
+++ b/dial9-viewer/ui/src/types/state.d.ts
@@ -172,6 +172,11 @@ export interface SelectionSlice {
    * range is active.
    */
   spawnedTasksRange: TimeRange | null;
+  /**
+   * Runtime group filter for a range selected from a runtime-metrics spawn
+   * histogram. Null/absent means the process-wide queue histogram.
+   */
+  spawnedTasksRuntime?: string | null;
 }
 
 // ── poi slice (points-of-interest / issues rail) ────────────────────────

--- a/dial9-viewer/ui/src/types/trace_analysis.d.ts
+++ b/dial9-viewer/ui/src/types/trace_analysis.d.ts
@@ -126,7 +126,10 @@ declare module "*/trace_analysis.js" {
     runtimeMetrics: readonly RuntimeMetricsSample[]
   ): { t: number; global: number }[];
 
-  /** Sum per-runtime alive-task counts into a process-wide timeline. */
+  /**
+   * Sum per-runtime alive-task counts into a process-wide timeline. Empty when
+   * any sample lacks the field, because that would make the sum incomplete.
+   */
   export function sumActiveTasksByCycle(
     runtimeMetrics: readonly RuntimeMetricsSample[]
   ): { t: number; count: number }[];

--- a/dial9-viewer/ui/src/types/trace_parser.d.ts
+++ b/dial9-viewer/ui/src/types/trace_parser.d.ts
@@ -188,8 +188,11 @@ declare module "*/trace_parser.js" {
     runtimeName: string;
     /** Tasks pending in this runtime's global (injection) queue. */
     globalQueue: number;
-    /** Tasks alive (spawned, not yet completed) in this runtime. */
-    aliveTasks: number;
+    /**
+     * Tasks alive (spawned, not yet completed) in this runtime. Null for old
+     * RuntimeMetricsEvent schemas that predate this field.
+     */
+    aliveTasks: number | null;
   }
 
   /** Process-wide active-task sample decoded from the superseded QueueSampleEvent. */

--- a/dial9-viewer/ui/tests/core/trace_analysis.test.ts
+++ b/dial9-viewer/ui/tests/core/trace_analysis.test.ts
@@ -364,6 +364,14 @@ describe("sumActiveTasksByCycle", () => {
   it("is empty for no samples", () => {
     expect(sumActiveTasksByCycle([])).toEqual([]);
   });
+
+  it("is empty when an old schema lacks alive_tasks", () => {
+    expect(
+      sumActiveTasksByCycle([
+        { t: 10, runtimeName: "", globalQueue: 5, aliveTasks: null },
+      ]),
+    ).toEqual([]);
+  });
 });
 
 describe("globalQueueSeries", () => {
@@ -442,6 +450,20 @@ describe("activeTaskSeries", () => {
       ),
     ).toBe(lifecycle.activeTaskSamples);
     expect(activeTaskSeries({}, lifecycle)).toBe(lifecycle.activeTaskSamples);
+  });
+
+  it("falls back to lifecycle deltas when RuntimeMetrics lacks alive_tasks", () => {
+    expect(
+      activeTaskSeries(
+        {
+          runtimeMetrics: [
+            { t: 10, runtimeName: "", globalQueue: 5, aliveTasks: null },
+          ],
+          legacyActiveTaskSamples: [],
+        },
+        lifecycle,
+      ),
+    ).toBe(lifecycle.activeTaskSamples);
   });
 });
 

--- a/dial9-viewer/ui/tests/core/trace_parser_active_tasks.test.ts
+++ b/dial9-viewer/ui/tests/core/trace_parser_active_tasks.test.ts
@@ -2,11 +2,27 @@ import { createRequire } from "node:module";
 import { describe, expect, it } from "vitest";
 
 const require = createRequire(import.meta.url);
-const { decodeLegacyActiveTaskSample } = require("../../trace_parser.js") as {
+const {
+  decodeLegacyActiveTaskSample,
+  decodeRuntimeMetricsSample,
+} = require("../../trace_parser.js") as {
   decodeLegacyActiveTaskSample: (
     timestamp: number,
     fields: { active_tasks?: number | string | bigint | null },
   ) => { t: number; count: number } | null;
+  decodeRuntimeMetricsSample: (
+    timestamp: number,
+    fields: {
+      runtime_name?: string | null;
+      global_queue_depth: number | string | bigint;
+      alive_tasks?: number | string | bigint | null;
+    },
+  ) => {
+    t: number;
+    runtimeName: string;
+    globalQueue: number;
+    aliveTasks: number | null;
+  };
 };
 
 describe("legacy QueueSample active-task decoding", () => {
@@ -20,5 +36,35 @@ describe("legacy QueueSample active-task decoding", () => {
   it("does not invent zero for traces whose schema predates active_tasks", () => {
     expect(decodeLegacyActiveTaskSample(123, {})).toBeNull();
     expect(decodeLegacyActiveTaskSample(123, { active_tasks: null })).toBeNull();
+  });
+});
+
+describe("RuntimeMetrics active-task decoding", () => {
+  it("preserves a present alive_tasks field", () => {
+    expect(
+      decodeRuntimeMetricsSample(123, {
+        runtime_name: "io",
+        global_queue_depth: "7",
+        alive_tasks: "42",
+      }),
+    ).toEqual({
+      t: 123,
+      runtimeName: "io",
+      globalQueue: 7,
+      aliveTasks: 42,
+    });
+  });
+
+  it("does not invent zero for old RuntimeMetrics schemas", () => {
+    expect(
+      decodeRuntimeMetricsSample(123, {
+        global_queue_depth: 7,
+      }),
+    ).toEqual({
+      t: 123,
+      runtimeName: "",
+      globalQueue: 7,
+      aliveTasks: null,
+    });
   });
 });

--- a/dial9-viewer/ui/trace_analysis.js
+++ b/dial9-viewer/ui/trace_analysis.js
@@ -662,6 +662,10 @@
    * @returns {Array<{t: number, count: number}>} sorted by t
    */
   function sumActiveTasksByCycle(runtimeMetrics) {
+    // A single missing runtime contribution makes every process-wide sum
+    // incomplete. Return no sampled series so callers can use lifecycle data
+    // instead of rendering a plausible but false zero/partial total.
+    if (runtimeMetrics.some((s) => s.aliveTasks == null)) return [];
     const byTs = new Map();
     for (const s of runtimeMetrics) {
       byTs.set(s.t, (byTs.get(s.t) ?? 0) + s.aliveTasks);
@@ -713,7 +717,8 @@
   function activeTaskSeries(trace, taskTimeline) {
     const runtimeMetrics = trace.runtimeMetrics;
     if (runtimeMetrics && runtimeMetrics.length > 0) {
-      return sumActiveTasksByCycle(runtimeMetrics);
+      const sampled = sumActiveTasksByCycle(runtimeMetrics);
+      if (sampled.length > 0) return sampled;
     }
     const legacySamples = trace.legacyActiveTaskSamples;
     if (legacySamples && legacySamples.length > 0) {

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -39,6 +39,22 @@
     }
 
     /**
+     * Decode one per-runtime scheduler-metrics sample. `alive_tasks` is absent
+     * from older on-wire RuntimeMetricsEvent schemas; preserve that absence so
+     * analysis can fall back instead of inventing a zero-valued task series.
+     */
+    function decodeRuntimeMetricsSample(timestamp, fields) {
+        return {
+            t: timestamp,
+            runtimeName:
+                fields.runtime_name != null ? String(fields.runtime_name) : "",
+            globalQueue: num(fields.global_queue_depth),
+            aliveTasks:
+                fields.alive_tasks != null ? num(fields.alive_tasks) : null,
+        };
+    }
+
+    /**
      * Intern a callchain frame address to its "0x…" hex string, deduped per
      * parse. Callchains across millions of samples/dumps/allocs share very few
      * distinct addresses (same code paths), so caching the hex string collapses
@@ -1370,17 +1386,7 @@
             case "RuntimeMetricsEvent":
                 // Per-runtime scheduler metrics. Low-volume, so recorded in a
                 // side-channel array rather than the columnar event store.
-                // `runtime_name` is empty for the unnamed default runtime.
-                // `global_queue_depth`/`alive_tasks` were added together, so old
-                // traces (which have neither) never reach this case — they emit
-                // QueueSampleEvent instead.
-                runtimeMetrics.push({
-                    t: ts,
-                    runtimeName:
-                        v.runtime_name != null ? String(v.runtime_name) : "",
-                    globalQueue: num(v.global_queue_depth),
-                    aliveTasks: num(v.alive_tasks),
-                });
+                runtimeMetrics.push(decodeRuntimeMetricsSample(ts, v));
                 break;
             case "TaskSpawnEvent": {
                 const taskId = num(v.task_id);
@@ -2552,6 +2558,7 @@
             // Exported for focused backwards-compatibility tests. Not part of
             // the browser API.
             decodeLegacyActiveTaskSample,
+            decodeRuntimeMetricsSample,
             // Exported for unit tests: the single-event span schema compiler
             // and its runtime timing resolution. Not part of the browser API.
             compileSingleEventSpanSchema,


### PR DESCRIPTION
## Summary

- render viewport-adaptive task-spawn histograms behind the process-wide active-task line
- render the same translucent histogram in each runtime metrics row, attributing a task to the runtime that owns its earliest observed poll
- compute the headline peak spawn rate with a sliding, actual one-second window instead of extrapolating a short render quantum
- show a hover tooltip with the exact task count, time window, duration, per-quantum rate, and runtime
- open the existing spawned-task Stack view when a nonempty process or runtime histogram bin is clicked; runtime-row clicks filter the list to that runtime
- preserve missing `alive_tasks` data in old trace schemas and fall back to a clearly relative lifecycle-derived task line instead of rendering a false zero total

This makes short-lived task churn visible even when tasks start and finish between sampled active-task totals.

## Compatibility

`TaskSpawnEvent` does not carry runtime identity, so runtime attribution uses the task's earliest observed poll worker. Tasks with no observed poll are retained in the process-wide histogram but are omitted from runtime-specific histograms because there is no defensible runtime assignment.

## Testing

- full Vitest suite: 159 files passed, 1 skipped; 2,229 tests passed, 11 skipped
- `npm run check:types`
- `npm run check:boundary`
- Vite production build
- `cargo build -p dial9-viewer`
- loaded the demo trace in the local viewer and verified that the IO runtime reports `spawn peak:4 tasks/s`

Local preview:

```bash
cargo run -p dial9-viewer -- serve --port 3003 --local --dev
```

Open `http://127.0.0.1:3003/viewer.html?trace=demo-trace.bin&inspector-width=200`.
