### PR TITLE
test(dial9-core): add shuttle coverage for the dump-trigger debounce gate

### DIFF
--- a/dial9-core/src/dump.rs
+++ b/dial9-core/src/dump.rs
@@ -43,7 +43,7 @@
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant, SystemTime};
 
@@ -165,7 +165,7 @@ pub(crate) struct DumpRequest {
 #[derive(Debug)]
 struct Debounce {
     window: Duration,
-    last: Mutex<Option<(Instant, DumpId)>>,
+    last: crate::primitives::sync::Mutex<Option<(Instant, DumpId)>>,
 }
 
 /// Sending half of the trigger channel.
@@ -198,7 +198,7 @@ impl DumpTrigger {
     pub fn with_debounce(mut self, window: Duration) -> Self {
         self.debounce = Some(Arc::new(Debounce {
             window,
-            last: Mutex::new(None),
+            last: crate::primitives::sync::Mutex::new(None),
         }));
         self
     }
@@ -628,5 +628,47 @@ mod tests {
 
         let parsed: DumpId = a.to_string().parse().expect("round-trip");
         assert_eq!(parsed, a);
+    }
+}
+
+#[cfg(all(test, shuttle))]
+mod shuttle_tests {
+    use super::*;
+
+    const CALLERS: usize = 4;
+
+    crate::shuttle_test! {
+        default;
+        // Multiple threads race a shared, debounced trigger; exactly one
+        // must dispatch a real request, the rest must coalesce into it.
+        fn shuttle_debounce_gate() {
+            let (trigger, mut rx) = channel();
+            let trigger = trigger.with_debounce(Duration::from_secs(60));
+
+            let handles: Vec<_> = (0..CALLERS)
+                .map(|_| {
+                    let trigger = trigger.clone();
+                    crate::primitives::thread::spawn(move || {
+                        // Dropped without awaiting: per `DumpRun`'s `Drop`
+                        // impl, dispatch (or no-op, if coalesced) happens
+                        // right here.
+                        drop(trigger.dump_current_data());
+                    })
+                })
+                .collect();
+
+            for h in handles {
+                h.join().unwrap();
+            }
+
+            let mut dispatched = 0;
+            while rx.rx.try_recv().is_ok() {
+                dispatched += 1;
+            }
+            assert_eq!(
+                dispatched, 1,
+                "exactly one trigger within the debounce window must dispatch a real request"
+            );
+        }
     }
 }

--- a/dial9-core/src/dump.rs
+++ b/dial9-core/src/dump.rs
@@ -43,13 +43,13 @@
 
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant, SystemTime};
 
 use tokio::sync::{mpsc, oneshot};
 
 use crate::pipeline::ProcessErrorKind;
+use crate::primitives::sync::Arc;
 
 /// Mint a dump trigger + receiver pair. The builder wires the receiver into
 /// the worker and stashes the trigger in the recorder so it can be reached via
@@ -629,46 +629,46 @@ mod tests {
         let parsed: DumpId = a.to_string().parse().expect("round-trip");
         assert_eq!(parsed, a);
     }
-}
 
-#[cfg(all(test, shuttle))]
-mod shuttle_tests {
-    use super::*;
+    #[cfg(shuttle)]
+    mod shuttle_tests {
+        use super::*;
 
-    const CALLERS: usize = 4;
+        const CALLERS: usize = 4;
 
-    crate::shuttle_test! {
-        default;
-        // Multiple threads race a shared, debounced trigger; exactly one
-        // must dispatch a real request, the rest must coalesce into it.
-        fn shuttle_debounce_gate() {
-            let (trigger, mut rx) = channel();
-            let trigger = trigger.with_debounce(Duration::from_secs(60));
+        crate::shuttle_test! {
+            default;
+            // Multiple threads race a shared, debounced trigger; exactly one
+            // must dispatch a real request, the rest must coalesce into it.
+            fn shuttle_debounce_gate() {
+                let (trigger, mut rx) = channel();
+                let trigger = trigger.with_debounce(Duration::from_secs(60));
 
-            let handles: Vec<_> = (0..CALLERS)
-                .map(|_| {
-                    let trigger = trigger.clone();
-                    crate::primitives::thread::spawn(move || {
-                        // Dropped without awaiting: per `DumpRun`'s `Drop`
-                        // impl, dispatch (or no-op, if coalesced) happens
-                        // right here.
-                        drop(trigger.dump_current_data());
+                let handles: Vec<_> = (0..CALLERS)
+                    .map(|_| {
+                        let trigger = trigger.clone();
+                        crate::primitives::thread::spawn(move || {
+                            // Dropped without awaiting: per `DumpRun`'s `Drop`
+                            // impl, dispatch (or no-op, if coalesced) happens
+                            // right here.
+                            drop(trigger.dump_current_data());
+                        })
                     })
-                })
-                .collect();
+                    .collect();
 
-            for h in handles {
-                h.join().unwrap();
-            }
+                for h in handles {
+                    h.join().unwrap();
+                }
 
-            let mut dispatched = 0;
-            while rx.rx.try_recv().is_ok() {
-                dispatched += 1;
+                let mut dispatched = 0;
+                while rx.rx.try_recv().is_ok() {
+                    dispatched += 1;
+                }
+                assert_eq!(
+                    dispatched, 1,
+                    "exactly one trigger within the debounce window must dispatch a real request"
+                );
             }
-            assert_eq!(
-                dispatched, 1,
-                "exactly one trigger within the debounce window must dispatch a real request"
-            );
         }
     }
 }


### PR DESCRIPTION
#764
 
## Description
- Adds shuttle coverage for DumpTrigger's debounce gate.
  - Races several threads calling dump_current_data() through a shared, debounced trigger.
   - Asserts exactly one dispatches a real request and the rest coalesce.
- Replaces Arc to go through crate::primitives::sync instead of std::sync
  - zero production impact, byte-identical outside a shuttle build
- replaces std::sync::Mutex to make it visible to shuttle

