### PR TITLE
fix!: seal ext traits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,6 +462,7 @@ jobs:
             --baseline-rev origin/main \
             -p dial9-trace-format-derive \
             -p dial9-trace-format \
+            -p dial9-core \
             -p dial9-perf-self-profile \
             -p dial9-macro \
             -p dial9-utils \

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -378,12 +378,12 @@ impl<M: BufferMode> RecorderBuilder<M> {
 
 // TODO(tokio-as-source): now that tokio attaches to a built `Recorder`, this
 // trait has a single implementor. Fold it into inherent `RecorderBuilder`
-// methods once the `RecorderPerfExt` blanket impl can be reworked.
+// methods.
 /// A builder that can register [`Source`]s.
 ///
-/// Implemented by [`RecorderBuilder`]; the `.with_*()` perf-source sugar is
-/// built on top of it.
-pub trait RecorderSourceExt: Sized {
+/// Implemented by [`RecorderBuilder`], the `.with_*()` perf-source
+/// sugar is built on top of it.
+pub trait RecorderSourceExt: recorder_source_ext_sealed::Sealed + Sized {
     /// Register a [`Source`] with the underlying recording recorder.
     fn source(self, source: impl Source + 'static) -> Self;
 
@@ -415,6 +415,13 @@ pub trait RecorderSourceExt: Sized {
             config, callback,
         ))
     }
+}
+
+mod recorder_source_ext_sealed {
+    use super::{BufferMode, RecorderBuilder};
+
+    pub trait Sealed {}
+    impl<M: BufferMode> Sealed for RecorderBuilder<M> {}
 }
 
 impl<M: BufferMode> RecorderSourceExt for RecorderBuilder<M> {

--- a/dial9-core/src/recorder.rs
+++ b/dial9-core/src/recorder.rs
@@ -374,36 +374,31 @@ impl<M: BufferMode> RecorderBuilder<M> {
         self.enabled = false;
         self
     }
-}
-
-// TODO(tokio-as-source): now that tokio attaches to a built `Recorder`, this
-// trait has a single implementor. Fold it into inherent `RecorderBuilder`
-// methods.
-/// A builder that can register [`Source`]s.
-///
-/// Implemented by [`RecorderBuilder`], the `.with_*()` perf-source
-/// sugar is built on top of it.
-pub trait RecorderSourceExt: recorder_source_ext_sealed::Sealed + Sized {
-    /// Register a [`Source`] with the underlying recording recorder.
-    fn source(self, source: impl Source + 'static) -> Self;
 
     /// Register a hook run once, with the live [`Dial9Handle`], when the recorder
     /// starts recording.
-    fn on_recording_start(self, hook: impl FnOnce(&Dial9Handle) + Send + 'static) -> Self;
+    pub fn on_recording_start(mut self, hook: impl FnOnce(&Dial9Handle) + Send + 'static) -> Self {
+        self.recording_start_hooks.push(Box::new(hook));
+        self
+    }
 
     /// Register a hook run on each of dial9's own threads (the flush thread and,
     /// with `pipeline`, the background worker) before it starts, returning a
     /// teardown run when it stops. Defaults to a no-op.
-    fn on_recording_thread_start<F, T>(self, hook: F) -> Self
+    pub fn on_recording_thread_start<F, T>(mut self, hook: F) -> Self
     where
         F: Fn() -> T + Send + Sync + 'static,
-        T: FnOnce() + Send + 'static;
+        T: FnOnce() + Send + 'static,
+    {
+        self.thread_init = Arc::new(move || Box::new(hook()) as Box<dyn FnOnce() + Send>);
+        self
+    }
 
     /// Register a callback that dial9 invokes on the flush thread at the config's
     /// interval to emit custom events. Sugar for [`source`](Self::source) with a
     /// [`CustomEventsSource`](crate::custom_events::CustomEventsSource). Not
     /// tokio-coupled — works on the plain recorder and the tokio builder.
-    fn with_custom_events<F>(
+    pub fn with_custom_events<F>(
         self,
         config: crate::custom_events::CustomEventsConfig,
         callback: F,
@@ -414,34 +409,6 @@ pub trait RecorderSourceExt: recorder_source_ext_sealed::Sealed + Sized {
         self.source(crate::custom_events::CustomEventsSource::new(
             config, callback,
         ))
-    }
-}
-
-mod recorder_source_ext_sealed {
-    use super::{BufferMode, RecorderBuilder};
-
-    pub trait Sealed {}
-    impl<M: BufferMode> Sealed for RecorderBuilder<M> {}
-}
-
-impl<M: BufferMode> RecorderSourceExt for RecorderBuilder<M> {
-    fn source(mut self, source: impl Source + 'static) -> Self {
-        self.sources.push(Box::new(source));
-        self
-    }
-
-    fn on_recording_start(mut self, hook: impl FnOnce(&Dial9Handle) + Send + 'static) -> Self {
-        self.recording_start_hooks.push(Box::new(hook));
-        self
-    }
-
-    fn on_recording_thread_start<F, T>(mut self, hook: F) -> Self
-    where
-        F: Fn() -> T + Send + Sync + 'static,
-        T: FnOnce() + Send + 'static,
-    {
-        self.thread_init = Arc::new(move || Box::new(hook()) as Box<dyn FnOnce() + Send>);
-        self
     }
 }
 
@@ -899,8 +866,8 @@ mod tests {
             let stopped = StdArc::new(AtomicUsize::new(0));
             let (s, t) = (StdArc::clone(&started), StdArc::clone(&stopped));
 
-            let recorder =
-                RecorderSourceExt::on_recording_thread_start(recorder(writer), move || {
+            let recorder = recorder(writer)
+                .on_recording_thread_start(move || {
                     s.fetch_add(1, Ordering::SeqCst);
                     let t = StdArc::clone(&t);
                     move || {

--- a/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
+++ b/dial9-tokio-telemetry/src/telemetry/recorder/recorder_tokio.rs
@@ -69,7 +69,7 @@ use std::io;
 /// sample symbolization) run at build-time wiring, then segments are compressed
 /// and written back. If there are no stages and no upload target, no worker
 /// starts. These methods customize that behavior.
-pub trait RecorderPipelineExt<M: BufferMode>: Sized {
+pub trait RecorderPipelineExt<M: BufferMode>: sealed::Sealed + Sized {
     /// Replace the default pipeline with your own processors, run verbatim.
     ///
     /// Nothing is added for you, so chain
@@ -92,6 +92,14 @@ pub trait RecorderPipelineExt<M: BufferMode>: Sized {
     /// client (custom credentials, endpoint, or a test double).
     #[cfg(feature = "worker-s3")]
     fn with_s3_uploader_client(self, config: S3Config, client: aws_sdk_s3::Client) -> Self;
+}
+
+mod sealed {
+    use dial9_core::buffer::BufferMode;
+    use dial9_core::recorder::RecorderBuilder;
+
+    pub trait Sealed {}
+    impl<M: BufferMode> Sealed for RecorderBuilder<M> {}
 }
 
 impl<M: BufferMode> RecorderPipelineExt<M> for RecorderBuilder<M> {
@@ -124,23 +132,12 @@ impl<M: BufferMode> RecorderPipelineExt<M> for RecorderBuilder<M> {
 /// This is separate from [`RecorderPipelineExt`] to keep that existing public
 /// trait unchanged.
 #[cfg(feature = "worker-s3")]
-pub trait RecorderS3ClientExt<M: BufferMode>:
-    recorder_s3_client_ext_sealed::Sealed + Sized
-{
+pub trait RecorderS3ClientExt<M: BufferMode>: sealed::Sealed + Sized {
     /// Like [`RecorderPipelineExt::with_s3_uploader`], but constructs the S3
     /// client asynchronously on the pipeline worker's Tokio runtime.
     fn with_s3_uploader_client_future<F>(self, config: S3Config, client_future: F) -> Self
     where
         F: std::future::Future<Output = aws_sdk_s3::Client> + Send + 'static;
-}
-
-#[cfg(feature = "worker-s3")]
-mod recorder_s3_client_ext_sealed {
-    use dial9_core::buffer::BufferMode;
-    use dial9_core::recorder::RecorderBuilder;
-
-    pub trait Sealed {}
-    impl<M: BufferMode> Sealed for RecorderBuilder<M> {}
 }
 
 #[cfg(feature = "worker-s3")]

--- a/dial9-tokio-telemetry/tests/custom_events.rs
+++ b/dial9-tokio-telemetry/tests/custom_events.rs
@@ -1,7 +1,6 @@
 mod common;
 
 use common::{CAPTURE_BUFFER_SIZE, capture_processor};
-use dial9_core::recorder::RecorderSourceExt;
 use dial9_tokio_telemetry::telemetry::{
     CustomEventsConfig, MemoryBuffer, RecorderPipelineExt, TokioAttachOptions, recorder,
 };

--- a/dial9/README.md
+++ b/dial9/README.md
@@ -650,7 +650,7 @@ periodic snapshots without passing a [`Dial9Handle`] through your code:
 ```rust,no_run
 use dial9::core::CustomEventsConfig;
 use dial9::format::TraceEvent;
-use dial9::{RecorderSourceExt, recorder};
+use dial9::recorder;
 
 #[derive(TraceEvent)]
 struct CacheEvent {

--- a/dial9/src/lib.rs
+++ b/dial9/src/lib.rs
@@ -5,7 +5,7 @@
 pub use dial9_core::buffer::{Disk, DiskBuffer, Memory, MemoryBuffer};
 pub use dial9_core::handle::{Dial9Handle, InstallGlobalHandleError};
 pub use dial9_core::recorder::{
-    RecorderBuilder, RecorderSourceExt, recorder, recorder_disabled, recorder_or_disabled,
+    RecorderBuilder, recorder, recorder_disabled, recorder_or_disabled,
 };
 pub use dial9_core::recording::Recorder;
 

--- a/dial9/tests/recorder_attach.rs
+++ b/dial9/tests/recorder_attach.rs
@@ -3,8 +3,7 @@
 #![cfg(feature = "tokio")]
 
 use dial9::{
-    AttachedRuntime, Dial9HandleTokioExt, DiskBuffer, Recorder, RecorderSourceExt,
-    TokioAttachOptions, recorder,
+    AttachedRuntime, Dial9HandleTokioExt, DiskBuffer, Recorder, TokioAttachOptions, recorder,
 };
 use dial9_trace_format::decoder::Decoder;
 use std::{collections::BTreeMap, time::Duration};

--- a/docs/migration-0.3-to-0.5.md
+++ b/docs/migration-0.3-to-0.5.md
@@ -420,7 +420,6 @@ Instead of threading a handle around, register a callback that runs on dial9's f
 
 ```rust
 use dial9::core::CustomEventsConfig;
-use dial9::RecorderSourceExt;
 
 let recorder = dial9::recorder(writer)
     .with_custom_events(CustomEventsConfig::default(), move |ctx| {

--- a/perf-self-profile/src/recorder_ext.rs
+++ b/perf-self-profile/src/recorder_ext.rs
@@ -5,7 +5,7 @@
 //! propagate the failure instead.
 
 use dial9_core::buffer::BufferMode;
-use dial9_core::recorder::{RecorderBuilder, RecorderSourceExt};
+use dial9_core::recorder::RecorderBuilder;
 
 #[cfg(any(feature = "cpu-profiling", feature = "memory-profiling"))]
 use dial9_core::rate_limited;

--- a/perf-self-profile/src/recorder_ext.rs
+++ b/perf-self-profile/src/recorder_ext.rs
@@ -4,15 +4,15 @@
 //! failure or unsupported platform. Use `.source(CpuProfiler::start(cfg)?)` to
 //! propagate the failure instead.
 
-use dial9_core::recorder::RecorderSourceExt;
+use dial9_core::buffer::BufferMode;
+use dial9_core::recorder::{RecorderBuilder, RecorderSourceExt};
 
 #[cfg(any(feature = "cpu-profiling", feature = "memory-profiling"))]
 use dial9_core::rate_limited;
 
-/// `.with_*` convenience for this crate's profiling `Source`s, available on any
-/// [`RecorderSourceExt`]. The core [`RecorderBuilder`](dial9_core::recorder::RecorderBuilder)
-/// and runtime wrappers that forward to it.
-pub trait RecorderPerfExt: Sized {
+/// `.with_*` convenience for this crate's profiling `Source`s on the core
+/// [`RecorderBuilder`].
+pub trait RecorderPerfExt: recorder_perf_ext_sealed::Sealed + Sized {
     /// Register the process-wide CPU profiler. Warns and skips on start failure.
     #[cfg(feature = "cpu-profiling")]
     fn with_cpu_profiling(self, config: crate::CpuProfilingConfig) -> Self;
@@ -36,7 +36,15 @@ pub trait RecorderPerfExt: Sized {
     fn with_memory_profiling(self, config: crate::memory_profiling::MemoryProfilingConfig) -> Self;
 }
 
-impl<T: RecorderSourceExt> RecorderPerfExt for T {
+mod recorder_perf_ext_sealed {
+    use dial9_core::buffer::BufferMode;
+    use dial9_core::recorder::RecorderBuilder;
+
+    pub trait Sealed {}
+    impl<M: BufferMode> Sealed for RecorderBuilder<M> {}
+}
+
+impl<M: BufferMode> RecorderPerfExt for RecorderBuilder<M> {
     #[cfg(feature = "cpu-profiling")]
     fn with_cpu_profiling(self, config: crate::CpuProfilingConfig) -> Self {
         match crate::CpuProfiler::start(config) {


### PR DESCRIPTION
Fixes #875.

Seals all ext traits that were missing a seal:

0030033cc8bc9b0c1f437c6037c597c69a4b8957: seal `RecorderSourceExt`, `RecorderPipelineExt` and `RecorderPerfExt` so they can gain methods without breaking. `RecorderPerfExt` swaps its blanket impl for a
direct one on `RecorderBuilder<M>`.
`Dial9EntryExt` and `Instrument` stay unsealed since their blanket impls already block downstream impls via coherence, so new methods there just need default bodies.

14c92b040b0e954de24899dfcf4544c56820c4c8 fold `RecorderSourceExt` into inherent `RecorderBuilder` methods and delete it. With this change users can drop having to import `RecorderSourceExt`. 

We could deprecate the trait first since this PR is breaking either way (semver-checks flags `trait_added_supertrait` on the seal changes regardless). 
But if we'd rather keep 0.5 for now and have a deprecation cycle for this one we can do that.

19781e208e97ef45a506336d3dfb1c83914f0eb9 adds dial9-core to CI's semver-checks list