### PR TITLE
feat(viewer): show the spawn location in the task-detail gutter

### DIFF
--- a/dial9-viewer/ui/src/lib/trace/index.ts
+++ b/dial9-viewer/ui/src/lib/trace/index.ts
@@ -43,6 +43,7 @@ export {
   canStreamDecode,
   deduplicateSamples,
   deriveBlockInPlaceGaps,
+  docsRsUrl,
   fetchTraceBytes,
   formatFrame,
   loadTrace,

--- a/dial9-viewer/ui/src/lib/trace/load.ts
+++ b/dial9-viewer/ui/src/lib/trace/load.ts
@@ -27,6 +27,7 @@ import {
   canStreamDecode,
   deduplicateSamples,
   deriveBlockInPlaceGaps,
+  docsRsUrl,
   fetchTraces,
   formatFrame,
   parseTrace,
@@ -56,6 +57,7 @@ export {
   canStreamDecode,
   deduplicateSamples,
   deriveBlockInPlaceGaps,
+  docsRsUrl,
   formatFrame,
   symbolizeChain,
 };

--- a/dial9-viewer/ui/src/lib/url/copy-link.ts
+++ b/dial9-viewer/ui/src/lib/url/copy-link.ts
@@ -22,11 +22,14 @@ export interface CopyLinkHandle {
 }
 
 /**
- * Default clipboard write: the async Clipboard API, falling back to a
- * transient textarea + execCommand("copy") for non-secure contexts
- * (plain-http LAN hosts; the API exists only in secure contexts).
+ * Clipboard write: the async Clipboard API, falling back to a transient
+ * textarea + execCommand("copy") for non-secure contexts (plain-http LAN
+ * hosts; the API exists only in secure contexts).
+ *
+ * Rejects when the write genuinely failed, so callers can say so instead of
+ * flashing a success the user's clipboard does not back up.
  */
-async function defaultCopy(text: string): Promise<void> {
+export async function copyText(text: string): Promise<void> {
   if (navigator.clipboard !== undefined) {
     await navigator.clipboard.writeText(text);
     return;
@@ -82,7 +85,7 @@ export function mountCopyLink(
       return;
     }
     const text = options.getText !== undefined ? options.getText() : window.location.href;
-    const copy = options.copy ?? defaultCopy;
+    const copy = options.copy ?? copyText;
     copy(text).then(
       () => {
         flash("Copied");

--- a/dial9-viewer/ui/src/lib/url/index.ts
+++ b/dial9-viewer/ui/src/lib/url/index.ts
@@ -28,5 +28,5 @@ export type {
   DebounceTimer,
 } from "./sync.js";
 
-export { mountCopyLink } from "./copy-link.js";
+export { copyText, mountCopyLink } from "./copy-link.js";
 export type { CopyLinkOptions, CopyLinkHandle } from "./copy-link.js";

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-model.test.ts
@@ -20,6 +20,7 @@ import {
   firstVisibleByEnd,
   formatTaskDetailSummary,
   hitRegionAt,
+  spawnLocLabel,
   statusTextAt,
   wakeRegionAt,
   wakerLabelFor,
@@ -173,6 +174,31 @@ describe("formatTaskDetailSummary (label parts)", () => {
     const trace = fakeTrace({ taskInstrumented: { 42: false } });
     const data = computeTaskDetailData(base, trace, 42);
     expect(formatTaskDetailSummary(data)).toBe("Task 0x2a · 2 polls");
+  });
+});
+
+// ── spawnLocLabel ─────────────────────────────────────────────────────────
+
+describe("spawnLocLabel (the gutter form)", () => {
+  it("drops directories and the trailing column", () => {
+    expect(
+      spawnLocLabel(
+        "-cargobrazil/amzn_s3_cds_client-0.1.609/src/discovery/full_ok_view_discovery.rs:237:28",
+      ),
+    ).toBe("full_ok_view_discovery.rs:237");
+  });
+
+  it("keeps a location that carries no column", () => {
+    expect(spawnLocLabel("src/foo/bar.rs:12")).toBe("bar.rs:12");
+  });
+
+  it("passes through a location with no line info at all", () => {
+    expect(spawnLocLabel("src/foo/bar.rs")).toBe("bar.rs");
+    expect(spawnLocLabel("tokio::spawn")).toBe("tokio::spawn");
+  });
+
+  it("is null for a task with no recorded location", () => {
+    expect(spawnLocLabel(null)).toBeNull();
   });
 });
 

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-model.test.ts
@@ -21,6 +21,7 @@ import {
   formatTaskDetailSummary,
   hitRegionAt,
   spawnLocLabel,
+  spawnLocLink,
   statusTextAt,
   wakeRegionAt,
   wakerLabelFor,
@@ -199,6 +200,36 @@ describe("spawnLocLabel (the gutter form)", () => {
 
   it("is null for a task with no recorded location", () => {
     expect(spawnLocLabel(null)).toBeNull();
+  });
+});
+
+describe("spawnLocLink (what the label does when clicked)", () => {
+  const REGISTRY =
+    "/home/rcoh/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/hyper-util-0.1.20/src/rt/tokio.rs:115:9";
+
+  it("links a dependency path to its exact source line on docs.rs", () => {
+    const link = spawnLocLink(REGISTRY);
+    expect(link).not.toBeNull();
+    expect(link!.label).toBe("tokio.rs:115");
+    expect(link!.full).toBe(REGISTRY);
+    // The line is the anchor and the column is dropped: a spawn location ends
+    // in `:line:col`, unlike the `:line` a stack frame carries.
+    expect(link!.href).toBe(
+      "https://docs.rs/hyper-util/0.1.20/src/hyper_util/rt/tokio.rs.html#115",
+    );
+  });
+
+  it("offers no link for first-party code, which names no published crate", () => {
+    const link = spawnLocLink("examples/metrics-service/src/main.rs:334:14");
+    expect(link).not.toBeNull();
+    expect(link!.label).toBe("main.rs:334");
+    expect(link!.href).toBeNull();
+    // The full path still travels, so the fallback has something to copy.
+    expect(link!.full).toBe("examples/metrics-service/src/main.rs:334:14");
+  });
+
+  it("is null for a task with no recorded location", () => {
+    expect(spawnLocLink(null)).toBeNull();
   });
 });
 

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
@@ -298,6 +298,22 @@ export function formatTaskDetailSummary(data: TaskDetailData): string {
   return out;
 }
 
+/**
+ * The gutter-sized form of a spawn location: directories dropped and the
+ * trailing column dropped, so `.../src/discovery/full_ok_view_discovery.rs:237:28`
+ * reads as `full_ok_view_discovery.rs:237` in a ~100px label column. The full
+ * string still rides the element's `title`, so nothing is lost.
+ *
+ * A location that does not end in `:line:col` (or `:line`) keeps whatever tail
+ * it has - only a genuinely numeric column is stripped.
+ */
+export function spawnLocLabel(location: string | null): string | null {
+  if (location == null) return null;
+  const file = location.replace(/.*\//, "");
+  const m = /^(.*?):(\d+):\d+$/.exec(file);
+  return m ? `${m[1]}:${m[2]}` : file;
+}
+
 // ── Per-frame render model (viewport-dependent) ───────────────────────────
 
 /** Band vertical placement. */

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
@@ -308,6 +308,8 @@ export function formatTaskDetailSummary(data: TaskDetailData): string {
  * A location that does not end in `:line:col` (or `:line`) keeps whatever tail
  * it has - only a genuinely numeric column is stripped.
  */
+export function spawnLocLabel(location: string): string;
+export function spawnLocLabel(location: string | null): string | null;
 export function spawnLocLabel(location: string | null): string | null {
   if (location == null) return null;
   const file = location.replace(/.*\//, "");
@@ -338,9 +340,12 @@ export interface SpawnLocLink {
 }
 
 export function spawnLocLink(location: string | null): SpawnLocLink | null {
-  const label = spawnLocLabel(location);
-  if (label === null || location === null) return null;
-  return { label, full: location, href: docsRsUrl(location) };
+  if (location === null) return null;
+  return {
+    label: spawnLocLabel(location),
+    full: location,
+    href: docsRsUrl(location),
+  };
 }
 
 // ── Per-frame render model (viewport-dependent) ───────────────────────────

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-model.ts
@@ -25,6 +25,7 @@ import {
   EVENT_TYPES,
   computePollWakes,
   computeRuntimeGroups,
+  docsRsUrl,
   formatHumanDuration,
 } from "../../lib/trace/index.js";
 import type {
@@ -312,6 +313,34 @@ export function spawnLocLabel(location: string | null): string | null {
   const file = location.replace(/.*\//, "");
   const m = /^(.*?):(\d+):\d+$/.exec(file);
   return m ? `${m[1]}:${m[2]}` : file;
+}
+
+/**
+ * What the gutter's spawn location should DO when clicked.
+ *
+ * A spawn location is a path on the machine that recorded the trace, so there is
+ * no general way to open "the file". Two cases are actually reachable:
+ *
+ *   - a dependency path carries its crate and version, so it resolves to the
+ *     exact source line on docs.rs (the same link the flamegraph offers on a
+ *     frame);
+ *   - first-party code identifies no published artifact, and the trace records
+ *     neither repository nor commit, so the honest fallback is handing the user
+ *     the path to open themselves.
+ */
+export interface SpawnLocLink {
+  /** The trimmed `file.rs:line` label. */
+  label: string;
+  /** The full recorded path: the tooltip, and what "copy" yields. */
+  full: string;
+  /** docs.rs source URL, or null when the path names no published crate. */
+  href: string | null;
+}
+
+export function spawnLocLink(location: string | null): SpawnLocLink | null {
+  const label = spawnLocLabel(location);
+  if (label === null || location === null) return null;
+  return { label, full: location, href: docsRsUrl(location) };
 }
 
 // ── Per-frame render model (viewport-dependent) ───────────────────────────

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.test.ts
@@ -18,6 +18,7 @@ import {
   type ParsedTrace,
 } from "../../lib/trace/index.js";
 import { createViewerStore } from "./store.js";
+import type { TrackSpec } from "../../lib/canvas/track-layout.js";
 import {
   createTaskDetailDerivation,
   createTaskDetailTrack,
@@ -473,5 +474,68 @@ describe("drawTaskDetailCanvas render input", () => {
     const { ctx, texts } = recordingCtx();
     drawTaskDetailCanvas(ctx, model, null, 2000, 160, COMPLETE_TASK_DETAIL_WINDOW);
     expect(texts.some((t) => t.text === "partial window")).toBe(false);
+  });
+});
+
+// ── 5. Spawn-location gutter control ──────────────────────────────────────
+
+/**
+ * Flatten a lit TemplateResult to its static HTML with a NUL standing in for
+ * each binding, so a test can assert WHERE the bindings sit.
+ */
+function markedHtml(tpl: unknown): string {
+  const t = tpl as { strings?: readonly string[]; values?: readonly unknown[] };
+  if (t.strings === undefined || t.values === undefined) return "";
+  let out = "";
+  t.strings.forEach((str, i) => {
+    out += str;
+    if (i < t.values!.length) out += "\u0000";
+  });
+  return out;
+}
+
+/** Depth-first search for the nested template carrying `needle`. */
+function findTemplate(tpl: unknown, needle: string): string | null {
+  const here = markedHtml(tpl);
+  if (here.includes(needle)) return here;
+  const values = (tpl as { values?: readonly unknown[] }).values ?? [];
+  for (const v of values) {
+    const hit = findTemplate(v, needle);
+    if (hit !== null) return hit;
+  }
+  return null;
+}
+
+function spawnLocTrace(): ParsedTrace {
+  const trace = traceWith([...pollEvents(0, 42, 1000, 1100)]);
+  // A first-party path: no published crate, so the gutter renders the COPY
+  // button rather than the docs.rs link.
+  (trace.spawnLocations as Map<string, string>).set("F", "examples/app/src/main.rs:334:14");
+  (trace.taskSpawnLocs as Map<number, string>).set(42, "F");
+  return trace;
+}
+
+describe("task-detail gutter: spawn location", () => {
+  const TRACK = { id: "task-detail", label: "task", height: 60 } as TrackSpec;
+
+  it("wraps the bound label in its own span, apart from the copy flash", () => {
+    const store = createViewerStore({ scheduler: () => {} });
+    store.update("trace", { trace: spawnLocTrace() });
+    store.update("selection", { selectedTaskId: 42 });
+    const track = createTaskDetailTrack(store);
+
+    const tpl = findTemplate(track.rowTemplate(TRACK), "d9-task-detail-spawn");
+    expect(tpl).not.toBeNull();
+
+    // The label binding sits INSIDE .d9-spawn-label. If it were a direct child
+    // of the button, the imperative copy flash would have to write the
+    // button's textContent - deleting lit's part markers with it, so every
+    // later re-render would update a detached node and the gutter would keep
+    // showing the previously selected task's path.
+    expect(tpl!).toContain('<span class="d9-spawn-label">\u0000</span');
+
+    // The flash slot is static: no binding between its tags, so writing its
+    // textContent is safe.
+    expect(tpl!).toContain('class="d9-spawn-flash" aria-live="polite"></span>');
   });
 });

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
@@ -16,9 +16,11 @@
 //     contract; this track never reaches into the lanes.
 //
 // This file owns the timeline track (per-task polls/wakes over time) + the
-// derivation. The textual detail (task id, spawn location, counts, the
-// uninstrumented badge, the idle-flamegraph link) renders in the inspector Task
-// tab from the SAME derivation, exposed via createTaskDetailDerivation.
+// derivation. Its gutter carries the task id plus the spawn location in
+// `file.rs:line` form (the full path stays on the `title`). The rest of the
+// textual detail (counts, the uninstrumented badge, the idle-flamegraph link)
+// renders in the inspector Task tab from the SAME derivation, exposed via
+// createTaskDetailDerivation.
 
 import { drawWindowMarkers } from "./resident-window.js";
 import { html, nothing, type TemplateResult } from "lit-html";
@@ -38,6 +40,7 @@ import {
   computeTaskDetailData,
   formatTaskDetailSummary,
   hitRegionAt,
+  spawnLocLabel,
   statusTextAt,
   wakeRegionAt,
   type TaskDetailData,
@@ -197,6 +200,7 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
     const data = taskDetailData();
     const identity =
       data.taskId !== null ? formatTaskDetailSummary(data) : track.label;
+    const spawnLoc = spawnLocLabel(data.spawnLocation);
     return html`
       <div
         class="d9-track d9-track--task-detail"
@@ -208,6 +212,13 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
           ${data.taskId !== null
             ? html`<span class="d9-task-detail-id" title=${identity}
                 >Task 0x${data.taskId.toString(16)}</span
+              >`
+            : nothing}
+          ${spawnLoc !== null
+            ? html`<span
+                class="d9-task-detail-spawn"
+                title=${data.spawnLocation ?? ""}
+                >${spawnLoc}</span
               >`
             : nothing}
         </div>

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
@@ -27,6 +27,7 @@ import { html, nothing, type TemplateResult } from "lit-html";
 import { createCanvasSizer } from "../../lib/canvas/index.js";
 import type { CanvasSizer } from "../../lib/canvas/index.js";
 import { formatHumanDuration } from "../../lib/trace/index.js";
+import { copyText } from "../../lib/url/index.js";
 import type { ViewerStore } from "../../store/store.js";
 import type { StoreState } from "../../types/state.js";
 import type { TrackSpec } from "../../lib/canvas/track-layout.js";
@@ -254,26 +255,52 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
         >${spawn.label}</a
       >`;
     }
+    // The label rides its own <span> and the flash rides a SEPARATE, static
+    // one. The label is a lit binding: writing the flash into the button's own
+    // textContent would delete lit's ChildPart markers with it, and every later
+    // re-render would then update a detached text node - the gutter would keep
+    // showing this task's path after the user selected another one.
     return html`<button
       type="button"
       class="d9-task-detail-spawn is-copy"
       title=${`${spawn.full}\nCopy path`}
       @click=${(e: MouseEvent) => copySpawnLoc(e, spawn.full)}
     >
-      ${spawn.label}
+      <span class="d9-spawn-label">${spawn.label}</span
+      ><span class="d9-spawn-flash" aria-live="polite"></span>
     </button>`;
   }
 
-  /** Copy the full path, flashing the label. Imperative, like the inspector's
-   *  own copy buttons - no store round-trip for an 800ms affordance. */
+  let flashTimer: number | null = null;
+
+  /** Flash `text` over the label for 800ms. Writes only the binding-free flash
+   *  span, never the button's own children. */
+  function flashSpawn(btn: HTMLButtonElement, text: string): void {
+    const slot = btn.querySelector<HTMLElement>(".d9-spawn-flash");
+    if (slot === null) return;
+    if (flashTimer !== null) window.clearTimeout(flashTimer);
+    slot.textContent = text;
+    btn.classList.add("is-flashing");
+    flashTimer = window.setTimeout(() => {
+      flashTimer = null;
+      slot.textContent = "";
+      btn.classList.remove("is-flashing");
+    }, 800);
+  }
+
+  /** Copy the full path. Imperative, like the inspector's own copy buttons - no
+   *  store round-trip for an 800ms affordance - but the flash reports what
+   *  actually happened: the clipboard is unavailable outside secure contexts
+   *  and rejects on a denied permission or an unfocused document. */
   function copySpawnLoc(e: MouseEvent, value: string): void {
     const btn = e.currentTarget as HTMLButtonElement;
-    void navigator.clipboard?.writeText(value);
-    const previous = btn.textContent;
-    btn.textContent = "copied ✓";
-    window.setTimeout(() => {
-      btn.textContent = previous;
-    }, 800);
+    copyText(value).then(
+      () => flashSpawn(btn, "copied"),
+      (err: unknown) => {
+        console.warn("task-detail: spawn-location copy failed:", err);
+        flashSpawn(btn, "copy failed");
+      },
+    );
   }
 
   // ── Canvas interaction (status, waker hover/click) ─────────────────────
@@ -401,6 +428,10 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
   }
 
   function dispose(): void {
+    if (flashTimer !== null) {
+      window.clearTimeout(flashTimer);
+      flashTimer = null;
+    }
     modelCache = null;
     lastModel = null;
     sizer = null;

--- a/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/task-detail-track.ts
@@ -40,9 +40,10 @@ import {
   computeTaskDetailData,
   formatTaskDetailSummary,
   hitRegionAt,
-  spawnLocLabel,
+  spawnLocLink,
   statusTextAt,
   wakeRegionAt,
+  type SpawnLocLink,
   type TaskDetailData,
   type TaskDetailRenderModel,
   type TaskDetailWindow,
@@ -200,7 +201,7 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
     const data = taskDetailData();
     const identity =
       data.taskId !== null ? formatTaskDetailSummary(data) : track.label;
-    const spawnLoc = spawnLocLabel(data.spawnLocation);
+    const spawn = spawnLocLink(data.spawnLocation);
     return html`
       <div
         class="d9-track d9-track--task-detail"
@@ -214,13 +215,7 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
                 >Task 0x${data.taskId.toString(16)}</span
               >`
             : nothing}
-          ${spawnLoc !== null
-            ? html`<span
-                class="d9-task-detail-spawn"
-                title=${data.spawnLocation ?? ""}
-                >${spawnLoc}</span
-              >`
-            : nothing}
+          ${spawn === null ? nothing : spawnTemplate(spawn)}
         </div>
         <div class="d9-track-canvas-wrap d9-task-detail-wrap">
           <span
@@ -240,6 +235,45 @@ export function createTaskDetailTrack(store: ViewerStore): TaskDetailTrackContro
         </div>
       </div>
     `;
+  }
+
+  /**
+   * The spawn location as an actionable control: a docs.rs source link when the
+   * path names a published crate, else a button that copies the full path. The
+   * label is trimmed to fit the gutter either way, so the tooltip carries the
+   * whole thing.
+   */
+  function spawnTemplate(spawn: SpawnLocLink): TemplateResult {
+    if (spawn.href !== null) {
+      return html`<a
+        class="d9-task-detail-spawn is-link"
+        href=${spawn.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        title=${`${spawn.full}\nOpen on docs.rs`}
+        >${spawn.label}</a
+      >`;
+    }
+    return html`<button
+      type="button"
+      class="d9-task-detail-spawn is-copy"
+      title=${`${spawn.full}\nCopy path`}
+      @click=${(e: MouseEvent) => copySpawnLoc(e, spawn.full)}
+    >
+      ${spawn.label}
+    </button>`;
+  }
+
+  /** Copy the full path, flashing the label. Imperative, like the inspector's
+   *  own copy buttons - no store round-trip for an 800ms affordance. */
+  function copySpawnLoc(e: MouseEvent, value: string): void {
+    const btn = e.currentTarget as HTMLButtonElement;
+    void navigator.clipboard?.writeText(value);
+    const previous = btn.textContent;
+    btn.textContent = "copied ✓";
+    window.setTimeout(() => {
+      btn.textContent = previous;
+    }, 800);
   }
 
   // ── Canvas interaction (status, waker hover/click) ─────────────────────

--- a/dial9-viewer/ui/src/styles/viewer.css
+++ b/dial9-viewer/ui/src/styles/viewer.css
@@ -1043,6 +1043,14 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
 }
+.d9-task-detail-spawn {
+    font-size: 0.66em;
+    color: var(--d9-fg-muted);
+    font-family: var(--d9-mono, monospace);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
 .d9-task-detail-wrap { position: relative; }
 .d9-task-detail-status {
     position: absolute;

--- a/dial9-viewer/ui/src/styles/viewer.css
+++ b/dial9-viewer/ui/src/styles/viewer.css
@@ -1067,6 +1067,17 @@ body {
     outline-offset: 1px;
 }
 .d9-task-detail-spawn.is-link { color: #7fb3ff; }
+/* The copy button's label and its transient flash are separate spans: the
+   label is a lit binding, so the flash must never be written into the button's
+   own textContent (that would delete lit's part markers with it). */
+.d9-spawn-label,
+.d9-spawn-flash {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.d9-task-detail-spawn.is-flashing .d9-spawn-label { display: none; }
+.d9-spawn-flash { color: var(--d9-accent); }
 .d9-task-detail-wrap { position: relative; }
 .d9-task-detail-status {
     position: absolute;

--- a/dial9-viewer/ui/src/styles/viewer.css
+++ b/dial9-viewer/ui/src/styles/viewer.css
@@ -1050,7 +1050,23 @@ body {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+    /* Both variants are interactive; neutralise the button's chrome so the
+       link and the copy button read as one control. */
+    background: none;
+    border: none;
+    padding: 0;
+    text-align: left;
+    cursor: pointer;
+    text-decoration: none;
+    display: block;
+    width: 100%;
 }
+.d9-task-detail-spawn:hover { color: var(--d9-fg); text-decoration: underline; }
+.d9-task-detail-spawn:focus-visible {
+    outline: 2px solid var(--d9-accent);
+    outline-offset: 1px;
+}
+.d9-task-detail-spawn.is-link { color: #7fb3ff; }
 .d9-task-detail-wrap { position: relative; }
 .d9-task-detail-status {
     position: absolute;

--- a/dial9-viewer/ui/src/types/trace_parser.d.ts
+++ b/dial9-viewer/ui/src/types/trace_parser.d.ts
@@ -476,6 +476,13 @@ declare module "*/trace_parser.js" {
   ): { text: string; docsUrl: string | null };
 
   /**
+   * The docs.rs source URL for a `file.rs:line[:col]` location, or null when the
+   * path does not identify a published crate. First-party code has no target:
+   * the trace records the path on the recording machine, not a repo or commit.
+   */
+  export function docsRsUrl(location: string | null): string | null;
+
+  /**
    * Resolve a callchain (address strings) to frames. Leaf→root in, leaf→root
    * out: an address's inlined frames are expanded in place innermost callee
    * first, so `[0]` is always the leaf.

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -2361,7 +2361,9 @@
     /**
      * Try to build a docs.rs source link from a location path containing a crate-version segment.
      * Matches any path like: .../hyper-0.14.28/src/client/connect/http.rs:474
-     * Returns URL string or null.
+     * Returns URL string or null. Exported as `docsRsUrl`: first-party code has
+     * no target, since the trace records the path on the recording machine
+     * rather than a repo or commit.
      */
     function _docsRsUrl(location) {
         if (!location) return null;
@@ -2379,17 +2381,6 @@
         let url = `https://docs.rs/${crate_}/${version}/src/${crateSrc}/${path}.html`;
         if (line) url += `#${line}`;
         return url;
-    }
-
-    /**
-     * The docs.rs source URL for a `file.rs:line[:col]` location, or null when
-     * the path does not identify a published crate (first-party code, whose
-     * repository and commit the trace does not record).
-     * @param {string|null} location
-     * @returns {string|null}
-     */
-    function docsRsUrl(location) {
-        return _docsRsUrl(location);
     }
 
     /**
@@ -2539,7 +2530,7 @@
             fetchTracesStream,
             canStreamDecode,
             formatFrame,
-            docsRsUrl,
+            docsRsUrl: _docsRsUrl,
             symbolizeChain,
             deduplicateSamples,
             deriveBlockInPlaceGaps,
@@ -2563,7 +2554,7 @@
             fetchTracesStream,
             canStreamDecode,
             formatFrame,
-            docsRsUrl,
+            docsRsUrl: _docsRsUrl,
             symbolizeChain,
             deduplicateSamples,
             deriveBlockInPlaceGaps,

--- a/dial9-viewer/ui/trace_parser.js
+++ b/dial9-viewer/ui/trace_parser.js
@@ -2365,8 +2365,12 @@
      */
     function _docsRsUrl(location) {
         if (!location) return null;
+        // A stack frame's location ends at `:line`, but a task's spawn location
+        // carries `:line:col`. Without the optional column group the column is
+        // read as the line and the real line leaks into the file path, yielding
+        // ".../tokio.rs:115.html#9" instead of ".../tokio.rs.html#115".
         const m = location.match(
-            /\/([a-z][a-z0-9_-]*)-(\d+\.\d+[^/]*)\/(.+?)(?::(\d+))?$/,
+            /\/([a-z][a-z0-9_-]*)-(\d+\.\d+[^/]*)\/(.+?)(?::(\d+))?(?::\d+)?$/,
         );
         if (!m) return null;
         const [, crate_, version, rawPath, line] = m;
@@ -2375,6 +2379,17 @@
         let url = `https://docs.rs/${crate_}/${version}/src/${crateSrc}/${path}.html`;
         if (line) url += `#${line}`;
         return url;
+    }
+
+    /**
+     * The docs.rs source URL for a `file.rs:line[:col]` location, or null when
+     * the path does not identify a published crate (first-party code, whose
+     * repository and commit the trace does not record).
+     * @param {string|null} location
+     * @returns {string|null}
+     */
+    function docsRsUrl(location) {
+        return _docsRsUrl(location);
     }
 
     /**
@@ -2524,6 +2539,7 @@
             fetchTracesStream,
             canStreamDecode,
             formatFrame,
+            docsRsUrl,
             symbolizeChain,
             deduplicateSamples,
             deriveBlockInPlaceGaps,
@@ -2547,6 +2563,7 @@
             fetchTracesStream,
             canStreamDecode,
             formatFrame,
+            docsRsUrl,
             symbolizeChain,
             deduplicateSamples,
             deriveBlockInPlaceGaps,


### PR DESCRIPTION
## Summary

When you select a task, the task-detail lane labels it `Task 0x358` and nothing else. Where that task came from was already known, but only reachable by hovering for a tooltip or switching to the inspector.

The gutter now shows the spawn location under the task id, as `file.rs:line`, and clicking it does something useful:

- **dependency code** opens that exact source line on docs.rs, the same way Cmd+click already works on flamegraph frames
- **first-party code** copies the full path, since a trace records a path on the machine that recorded it and no repository or commit to resolve it against

### Notes

Paths are trimmed to fit the ~100px label column: directories and the trailing column number are dropped, so a 100 character cargo registry path reads as `tokio.rs:115`. The full path is still on the tooltip, and the inspector's Task tab is unchanged.

Includes a fix to the shared docs.rs URL builder, which mishandled locations ending in `:line:col` and produced a broken anchor. Stack frames only ever carry `:line`, so nothing hit it until now. 