### PR TITLE
feat(viewer): fit Browse labels to service and host names

### DIFF
--- a/dial9-viewer/ui/index.html
+++ b/dial9-viewer/ui/index.html
@@ -118,6 +118,7 @@
                 </div>
                 <div id="heatmap-body">
                     <div id="heatmap-labels"></div>
+                    <div id="heatmap-label-resizer" title="Drag to resize host labels"></div>
                     <div id="heatmap-plot">
                         <canvas id="heatmap-canvas"></canvas>
                         <div id="heatmap-sel"></div>

--- a/dial9-viewer/ui/src/pages/browser/browse-view.ts
+++ b/dial9-viewer/ui/src/pages/browser/browse-view.ts
@@ -19,6 +19,7 @@ import { assertInScheduledRender } from "../../store/store.js";
 import { ROW_H } from "./actions.js";
 import type { PageCtx } from "./ctx.js";
 import { clamp, crossesDayBoundary, fmtTick, timeToX } from "./format.js";
+import { contentFitLabelWidth } from "./heatmap-label-resize.js";
 import type { HeatmapRow, TimeDomain } from "./state.js";
 import { renderStatus } from "./status-render.js";
 
@@ -61,6 +62,7 @@ export function mountBrowseView({ store, els }: PageCtx): void {
   // guessed "service / host" split.
   function rebuildLabels(rows: readonly HeatmapRow[]): void {
     els.heatmapLabels.textContent = "";
+    const labels: string[] = [];
     for (const row of rows) {
       const boots = bootTransitions(row.segments);
       const div = document.createElement("div");
@@ -69,11 +71,13 @@ export function mountBrowseView({ store, els }: PageCtx): void {
         // Raw display: `host` carries the group's raw directory path
         // (segments.ts unknownGroupPath); no service/host split exists.
         div.append(document.createTextNode(row.host));
+        labels.push(row.host);
       } else {
         const svc = document.createElement("span");
         svc.className = "svc";
         svc.textContent = row.service;
         div.append(svc, document.createTextNode(` / ${row.host}`));
+        labels.push(row.label);
       }
       if (boots.length) {
         div.append(document.createTextNode(" "));
@@ -88,6 +92,15 @@ export function mountBrowseView({ store, els }: PageCtx): void {
       div.title = row.segments[0]?.layout === "unknown" ? row.host : row.label;
       els.heatmapLabels.appendChild(div);
     }
+    const firstRow = els.heatmapLabels.querySelector<HTMLDivElement>(".row");
+    const context = document.createElement("canvas").getContext("2d");
+    if (!firstRow || !context) return;
+    context.font = getComputedStyle(firstRow).font;
+    const width = contentFitLabelWidth(
+      labels.map((label) => context.measureText(label).width),
+      els.heatmapBody.clientWidth,
+    );
+    document.documentElement.style.setProperty("--heatmap-label-w", `${width}px`);
   }
 
   function drawCanvas(rows: readonly HeatmapRow[], domain: TimeDomain, tz: boolean): void {
@@ -200,8 +213,7 @@ export function mountBrowseView({ store, els }: PageCtx): void {
     drawAxis(W, domain, tz);
   }
 
-  // 2 to 8 TZ-aware ticks, aligned to the canvas left edge via
-  // --heatmap-label-w. When the visible span crosses a calendar-day
+  // 2 to 8 TZ-aware ticks, aligned to the canvas left edge. When the visible span crosses a calendar-day
   // boundary, ticks carry the date ("YYYY-MM-DD HH:MM:SS") - time-only
   // ticks across a multi-day span were ambiguous. Tick COUNT is unchanged
   // in both modes.
@@ -214,7 +226,7 @@ export function mountBrowseView({ store, els }: PageCtx): void {
       const frac = i / n;
       const tick = document.createElement("div");
       tick.className = "tick";
-      tick.style.left = LABEL_W() + frac * W + "px";
+      tick.style.left = (els.heatmapPlot.offsetLeft || LABEL_W()) + frac * W + "px";
       tick.textContent = fmtTick(tMin + frac * (tMax - tMin), tz, withDate);
       els.heatmapAxis.appendChild(tick);
     }

--- a/dial9-viewer/ui/src/pages/browser/dom.ts
+++ b/dial9-viewer/ui/src/pages/browser/dom.ts
@@ -55,7 +55,9 @@ export interface BrowserEls {
   browseStatus: HTMLDivElement;
   // Heatmap
   heatmapView: HTMLDivElement;
+  heatmapBody: HTMLDivElement;
   heatmapLabels: HTMLDivElement;
+  heatmapLabelResizer: HTMLDivElement;
   heatmapPlot: HTMLDivElement;
   heatmapCanvas: HTMLCanvasElement;
   heatmapSel: HTMLDivElement;
@@ -122,7 +124,9 @@ export function queryEls(): BrowserEls {
     browseWarning: byId("browse-warning"),
     browseStatus: byId("browse-status"),
     heatmapView: byId("heatmap-view"),
+    heatmapBody: byId("heatmap-body"),
     heatmapLabels: byId("heatmap-labels"),
+    heatmapLabelResizer: byId("heatmap-label-resizer"),
     heatmapPlot: byId("heatmap-plot"),
     heatmapCanvas: byIdOf("heatmap-canvas", HTMLCanvasElement),
     heatmapSel: byId("heatmap-sel"),

--- a/dial9-viewer/ui/src/pages/browser/heatmap-label-resize.test.ts
+++ b/dial9-viewer/ui/src/pages/browser/heatmap-label-resize.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  clampLabelWidth,
+  contentFitLabelWidth,
+  MAX_LABEL_WIDTH,
+  MIN_LABEL_WIDTH,
+} from "./heatmap-label-resize.js";
+
+describe("clampLabelWidth", () => {
+  it("keeps the host column within its defined bounds", () => {
+    expect(clampLabelWidth(1, 2_000)).toBe(MIN_LABEL_WIDTH);
+    expect(clampLabelWidth(2_000, 2_000)).toBe(MAX_LABEL_WIDTH);
+  });
+
+  it("leaves enough horizontal space for the heatmap", () => {
+    expect(clampLabelWidth(600, 700)).toBe(500);
+  });
+});
+
+describe("contentFitLabelWidth", () => {
+  it("fits the longest label, including row padding", () => {
+    expect(contentFitLabelWidth([100, 500], 2_000)).toBe(516);
+  });
+
+  it("uses the same minimum and maximum bounds as manual resizing", () => {
+    expect(contentFitLabelWidth([10], 2_000)).toBe(MIN_LABEL_WIDTH);
+    expect(contentFitLabelWidth([1_000], 2_000)).toBe(MAX_LABEL_WIDTH);
+  });
+});

--- a/dial9-viewer/ui/src/pages/browser/heatmap-label-resize.ts
+++ b/dial9-viewer/ui/src/pages/browser/heatmap-label-resize.ts
@@ -1,0 +1,60 @@
+// Resizable service/host label column for the Browse heatmap. The CSS
+// variable remains the single source of truth for the label width.
+
+import type { PageCtx } from "./ctx.js";
+
+export const MIN_LABEL_WIDTH = 220;
+export const MAX_LABEL_WIDTH = 640;
+const MIN_PLOT_WIDTH = 200;
+const LABEL_HORIZONTAL_PADDING = 16;
+
+export function clampLabelWidth(width: number, availableWidth: number): number {
+  const maximum = Math.max(
+    MIN_LABEL_WIDTH,
+    Math.min(MAX_LABEL_WIDTH, availableWidth - MIN_PLOT_WIDTH),
+  );
+  return Math.min(maximum, Math.max(MIN_LABEL_WIDTH, width));
+}
+
+export function contentFitLabelWidth(
+  labelTextWidths: readonly number[],
+  availableWidth: number,
+): number {
+  const widest = Math.max(0, ...labelTextWidths);
+  return clampLabelWidth(widest + LABEL_HORIZONTAL_PADDING, availableWidth);
+}
+
+export function mountHeatmapLabelResize({ els }: PageCtx): void {
+  let startX = 0;
+  let startWidth = 0;
+  let resizing = false;
+
+  function repaint(): void {
+    // The heatmap interaction owns the debounced resize repaint path.
+    window.dispatchEvent(new Event("resize"));
+  }
+
+  els.heatmapLabelResizer.addEventListener("mousedown", (e) => {
+    if (e.button !== 0) return;
+    resizing = true;
+    startX = e.clientX;
+    startWidth = els.heatmapLabels.getBoundingClientRect().width;
+    e.preventDefault();
+  });
+
+  window.addEventListener("mousemove", (e) => {
+    if (!resizing) return;
+    const width = clampLabelWidth(
+      startWidth + e.clientX - startX,
+      els.heatmapBody.clientWidth,
+    );
+    document.documentElement.style.setProperty("--heatmap-label-w", `${width}px`);
+    repaint();
+  });
+
+  window.addEventListener("mouseup", () => {
+    if (!resizing) return;
+    resizing = false;
+    repaint();
+  });
+}

--- a/dial9-viewer/ui/src/pages/browser/main.ts
+++ b/dial9-viewer/ui/src/pages/browser/main.ts
@@ -19,6 +19,7 @@ import { dateToPickerStr } from "./format.js";
 import { mountHeader } from "./header.js";
 import { mountHeatmapInteraction } from "./heatmap-interact.js";
 import { mountHeatmapKeys } from "./heatmap-keys.js";
+import { mountHeatmapLabelResize } from "./heatmap-label-resize.js";
 import { mountBrowserPageKeys } from "./page-keys.js";
 import { mountRawView } from "./raw-view.js";
 import { mountSearchControls } from "./search-controls.js";
@@ -74,6 +75,7 @@ function boot(): void {
   mountBrowseView(ctx);
   mountSelectionOverlay(ctx);
   mountHeatmapInteraction(ctx);
+  mountHeatmapLabelResize(ctx);
   // Unified keyboard model: `?` help, `/` search focus, Enter submits,
   // heatmap keyboard window selection.
   mountBrowserPageKeys(ctx);

--- a/dial9-viewer/ui/src/styles/browser.css
+++ b/dial9-viewer/ui/src/styles/browser.css
@@ -3,7 +3,7 @@
 :root {
     /* Width of the heatmap host-label column. Read from JS (see LABEL_W)
        so the timeline axis ticks line up with the canvas left edge. */
-    --heatmap-label-w: 220px;
+    --heatmap-label-w: 400px;
 }
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body {
@@ -160,8 +160,14 @@ button.active { background: #6c63ff; border-color: #6c63ff; color: #fff; }
     background-image: repeating-linear-gradient(-45deg,
         rgba(120,120,160,0.35) 0 1px, transparent 1px 6px);
 }
-#heatmap-body { flex: 1; overflow: auto; display: flex; min-height: 0; }
+#heatmap-body { flex: 1; overflow: auto; display: flex; min-height: 0; position: relative; }
 #heatmap-labels { flex-shrink: 0; width: var(--heatmap-label-w); border-right: 2px solid #3a3a5e; }
+#heatmap-label-resizer {
+    position: absolute; top: 0; bottom: 0;
+    left: calc(var(--heatmap-label-w) - 4px); width: 8px;
+    cursor: col-resize; z-index: 1;
+}
+#heatmap-label-resizer:hover { background: rgba(126, 200, 227, 0.2); }
 #heatmap-labels .row {
     height: 26px; line-height: 26px; padding: 0 8px;
     font-size: 0.78em; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;


### PR DESCRIPTION
  ## Browse labels that fit real service and host names

  The Browse heatmap previously used a fixed-width label column. Long service and host names were often truncated,
  making it difficult to distinguish similar hosts and select the one you wanted.

  Browse now sizes the label column to fit the longest returned service/host label, within a practical range of 220–
  640px while preserving room for the timeline. Readers can also drag the column edge to choose the balance they
  prefer: more room to read labels, or more room for the heatmap.

  This makes hosts easier to scan and select without sacrificing the time-based view.
