### PR TITLE
feat(viewer): improve the timeline label column

### DIFF
--- a/dial9-viewer/ui/README.md
+++ b/dial9-viewer/ui/README.md
@@ -241,6 +241,7 @@ list escaping. Previously emitted comma/pre-encoded list values remain readable.
 | `runtime-metrics-collapsed` | `v1:` + TAB-joined names | Runtimes whose summary lane is folded to its one-line strip. |
 | `inspector-width` | positive CSS pixels | Inspector width. |
 | `rail-width` | positive CSS pixels | Issues/Tasks rail width. |
+| `label-width` | positive CSS pixels | Shared time-track label gutter width. |
 | `task-cols` | `v1:` + TAB-joined `<id\|loc\|polls\|total\|longest\|lifetime>,<px>` entries | Tasks-table column widths. |
 | `issue-cols` | `v1:` + TAB-joined `<dot\|worker\|kind\|time\|duration>,<px>` entries | Issues-table column widths. |
 | `lanes-height` | positive CSS pixels | Worker-lanes viewport height. |

--- a/dial9-viewer/ui/src/components/canvas/lanes/index.ts
+++ b/dial9-viewer/ui/src/components/canvas/lanes/index.ts
@@ -35,7 +35,6 @@ import {
 } from "./render.js";
 import { ensureLanesLegend, mountLanesLegend } from "./legend.js";
 import { renderLaneLabels } from "./labels.js";
-import { LABEL_W } from "../../../lib/canvas/layout.js";
 
 const LANES_TRACK_ID: TrackId = "lanes";
 
@@ -123,6 +122,7 @@ export function mountLanes(trackColumn: HTMLElement, store: ViewerStore): Mounte
     const geometry = trackGeometry(track, {
       pw,
       scrollbarW,
+      labelW: state.uiPrefs.labelWidth,
       viewStart: state.viewport.viewStart,
       viewEnd: state.viewport.viewEnd,
       dpr,
@@ -232,11 +232,12 @@ export function mountLanes(trackColumn: HTMLElement, store: ViewerStore): Mounte
     // leading track-name line (CSS makes that name sr-only). Any inset here would
     // shift every label relative to the lane it names.
     const labelH = viewportH;
-    const ctx = labelSizer.ensure(LABEL_W, labelH, dpr);
+    const labelW = store.getState().uiPrefs.labelWidth;
+    const ctx = labelSizer.ensure(labelW, labelH, dpr);
     renderLaneLabels(ctx, {
       rowLayout,
       scrollTop,
-      labelW: LABEL_W,
+      labelW,
       height: labelH,
       runtimeAccents: data.runtimeAccents,
       workerRuntime: data.workerRuntime,

--- a/dial9-viewer/ui/src/components/overlay/index.ts
+++ b/dial9-viewer/ui/src/components/overlay/index.ts
@@ -21,7 +21,7 @@ import type { ViewerStore } from "../../store/store.js";
 import type { StoreState, TimePanelLayout } from "../../types/state.js";
 import type { TemplateResult } from "lit-html";
 import { createCanvasSizer, type CanvasSizer } from "../../lib/canvas/dpr.js";
-import { LABEL_W, laneRowLayout, timePanelLayout, workerAtLaneY } from "../../lib/canvas/layout.js";
+import { laneRowLayout, timePanelLayout, workerAtLaneY } from "../../lib/canvas/layout.js";
 import { LANE_ROW_H, RUNTIME_HEADER_H } from "../canvas/lanes/render.js";
 import { lanesScrollbarWidth } from "../../lib/canvas/track-layout.js";
 import { assembleLaneHover } from "../canvas/lanes/index.js";
@@ -67,6 +67,7 @@ interface ColumnGeometry {
 /** Read the shared column geometry ONCE (the lanes use the identical inputs). */
 function columnGeometry(
   trackColumn: HTMLElement,
+  labelW: number,
   viewStart: number,
   viewEnd: number,
 ): ColumnGeometry {
@@ -84,7 +85,7 @@ function columnGeometry(
   const contentHeight =
     (hint?.offsetHeight ?? 0) + flowContent.offsetHeight;
   return {
-    layout: timePanelLayout({ pw, scrollbarW, viewStart, viewEnd }),
+    layout: timePanelLayout({ pw, scrollbarW, labelW, viewStart, viewEnd }),
     pw,
     scrollHeight: Math.max(trackColumn.clientHeight, contentHeight),
   };
@@ -187,7 +188,7 @@ export function mountOverlay(
     // ALL reads first (geometry), THEN all writes: on a hover-only frame this
     // subscriber is alone, so its reads precede every write in the frame and
     // force no layout.
-    const geom = columnGeometry(trackColumn, viewStart, viewEnd);
+    const geom = columnGeometry(trackColumn, state.uiPrefs.labelWidth, viewStart, viewEnd);
     const dpr = (typeof devicePixelRatio === "number" ? devicePixelRatio : 1) || 1;
 
     const formatTs = (ns: number): string => formatTimestamp(state, ns);
@@ -274,12 +275,17 @@ export function mountOverlay(
 
     const { viewStart, viewEnd } = state.viewport;
     // Clean reads (fresh event, layout committed): column geometry + ns.
-    const geom = columnGeometry(trackColumn, viewStart, viewEnd);
+    const geom = columnGeometry(
+      trackColumn,
+      state.uiPrefs.labelWidth,
+      viewStart,
+      viewEnd,
+    );
     const rect = trackColumn.getBoundingClientRect();
     const mouseX = e.clientX - rect.left;
     const drawW = geom.layout.drawW;
     // Outside the draw area (label gutter, past drawW, degenerate view): clear.
-    if (mouseX < LABEL_W || mouseX > LABEL_W + drawW || viewEnd <= viewStart) {
+    if (mouseX < geom.layout.labelW || mouseX > geom.layout.labelW + drawW || viewEnd <= viewStart) {
       if (state.transient.mouseNs !== null || state.transient.atCursor !== null) {
         store.update("transient", { mouseNs: null, atCursor: null });
       }

--- a/dial9-viewer/ui/src/lib/canvas/layout.test.ts
+++ b/dial9-viewer/ui/src/lib/canvas/layout.test.ts
@@ -40,11 +40,11 @@ describe("timePanelLayout", () => {
 
   it("known case: no scrollbar -> drawW = pw - LABEL_W", () => {
     const l = timePanelLayout({ pw: 1000, viewStart: 0, viewEnd: 1000 });
-    expect(l.drawW).toBe(900);
+    expect(l.drawW).toBe(1000 - LABEL_W);
     expect(l.nsToPanelX(0)).toBe(LABEL_W);
     expect(l.nsToPanelX(1000)).toBe(1000);
     // Midpoint is linear.
-    expect(l.nsToPanelX(500)).toBe(LABEL_W + 450);
+    expect(l.nsToPanelX(500)).toBe(LABEL_W + l.drawW / 2);
   });
 
   it("INVARIANT: the gutter is always LABEL_W - never caller-defined", () => {
@@ -128,7 +128,7 @@ describe("panelGeometry", () => {
     expect(g.kind).toBe("queue");
     expect(g.height).toBe(80);
     expect(g.dpr).toBe(2);
-    expect(g.time.drawW).toBe(1083);
+    expect(g.time.drawW).toBe(1200 - LABEL_W - 17);
     expect(g.time.nsToPanelX(0)).toBe(LABEL_W);
   });
 });

--- a/dial9-viewer/ui/src/lib/canvas/layout.ts
+++ b/dial9-viewer/ui/src/lib/canvas/layout.ts
@@ -25,7 +25,7 @@ export type { TimePanelLayout };
  * time-based panel. The invariant is that ALL panels use this one
  * constant, never a private gutter width.
  */
-export const LABEL_W = 100;
+export const LABEL_W = 180;
 
 /**
  * Timestamp (ns) -> draw-area-relative x (px). THE alignment invariant: every
@@ -60,6 +60,8 @@ export interface TimePanelLayoutOpts {
    * panels that don't need to match the lane right edge.
    */
   scrollbarW?: number;
+  /** Shared left label gutter width for this viewer layout. */
+  labelW?: number;
   /** Visible-range start timestamp (ns). */
   viewStart: number;
   /** Visible-range end timestamp (ns). */
@@ -78,7 +80,7 @@ export interface TimePanelLayoutOpts {
 export function timePanelLayout(opts: TimePanelLayoutOpts): TimePanelLayout {
   return makeTimePanelLayout(
     opts.pw,
-    LABEL_W,
+    opts.labelW ?? LABEL_W,
     opts.scrollbarW,
     opts.viewStart,
     opts.viewEnd,

--- a/dial9-viewer/ui/src/lib/canvas/track-layout.test.ts
+++ b/dial9-viewer/ui/src/lib/canvas/track-layout.test.ts
@@ -46,6 +46,20 @@ describe("trackGeometry - shared axis", () => {
     expect(g.time.drawW).toBe(opts.pw - LABEL_W - 15);
   });
 
+  it("uses one caller-selected gutter width for every track", () => {
+    const labelW = 240;
+    const geometries = TRACKS.map((t) =>
+      trackGeometry(t, { ...opts, labelW, scrollbarW: 15 }),
+    );
+    expect(new Set(geometries.map((g) => g.time.drawW))).toEqual(
+      new Set([opts.pw - labelW - 15]),
+    );
+    for (const g of geometries) {
+      expect(g.time.labelW).toBe(labelW);
+      expect(g.time.nsToPanelX(opts.viewStart)).toBe(labelW);
+    }
+  });
+
   it("carries the track height into the geometry box", () => {
     for (const t of TRACKS) {
       expect(trackGeometry(t, opts).height).toBe(t.height);

--- a/dial9-viewer/ui/src/lib/canvas/track-layout.ts
+++ b/dial9-viewer/ui/src/lib/canvas/track-layout.ts
@@ -92,6 +92,8 @@ export interface TrackGeometryOpts {
   pw: number;
   /** Right gutter matching the lanes vertical scrollbar (0 if none). */
   scrollbarW?: number;
+  /** Shared left label gutter width for every track in this render pass. */
+  labelW?: number;
   /** Visible-range start timestamp (ns). */
   viewStart: number;
   /** Visible-range end timestamp (ns). */
@@ -117,6 +119,7 @@ export function trackGeometry(
     kind,
     pw: opts.pw,
     ...(opts.scrollbarW !== undefined ? { scrollbarW: opts.scrollbarW } : {}),
+    ...(opts.labelW !== undefined ? { labelW: opts.labelW } : {}),
     viewStart: opts.viewStart,
     viewEnd: opts.viewEnd,
     height: track.height,

--- a/dial9-viewer/ui/src/lib/url/view-state.ts
+++ b/dial9-viewer/ui/src/lib/url/view-state.ts
@@ -134,6 +134,8 @@ export interface ViewState {
   /** Shareable layout geometry and vertical lane position. */
   inspectorWidth?: number;
   railWidth?: number;
+  /** Shared time-track label gutter width in CSS px. */
+  labelWidth?: number;
   /** Rail-table column widths (px by column key), when user-resized. */
   taskColWidths?: Record<string, number>;
   issueColWidths?: Record<string, number>;

--- a/dial9-viewer/ui/src/pages/viewer/label-gutter.ts
+++ b/dial9-viewer/ui/src/pages/viewer/label-gutter.ts
@@ -1,0 +1,15 @@
+/** Content-fit default for the shared time-track label gutter (CSS px). */
+export const DEFAULT_LABEL_WIDTH = 180;
+/** Smallest usable gutter: track controls and a metadata key still fit. */
+export const MIN_LABEL_WIDTH = 120;
+/** Do not let labels consume more than this share of the viewport. */
+export const MAX_LABEL_WIDTH_VW = 0.45;
+
+/** Clamp a gutter width to its accessible, viewport-relative bounds. */
+export function clampLabelWidth(
+  width: number,
+  viewportWidth = typeof window === "undefined" ? Infinity : window.innerWidth,
+): number {
+  const max = Math.max(MIN_LABEL_WIDTH, Math.floor(viewportWidth * MAX_LABEL_WIDTH_VW));
+  return Math.round(Math.max(MIN_LABEL_WIDTH, Math.min(max, width)));
+}

--- a/dial9-viewer/ui/src/pages/viewer/lane-interaction.ts
+++ b/dial9-viewer/ui/src/pages/viewer/lane-interaction.ts
@@ -15,7 +15,6 @@
 // samples returns openStackFor, which drives the inspector's Poll Detail.
 
 import {
-  LABEL_W,
   headerAtLaneY,
   laneRowLayout,
   metricsLaneAtLaneY,
@@ -99,8 +98,14 @@ export function mountLaneInteraction(
     const scrollbarW = lanesScrollbarWidth(trackColumn);
     const { viewStart, viewEnd } = store.getState().viewport;
     return {
-      layout: timePanelLayout({ pw, scrollbarW, viewStart, viewEnd }),
-      drawW: pw - LABEL_W - scrollbarW,
+      layout: timePanelLayout({
+        pw,
+        scrollbarW,
+        labelW: store.getState().uiPrefs.labelWidth,
+        viewStart,
+        viewEnd,
+      }),
+      drawW: pw - store.getState().uiPrefs.labelWidth - scrollbarW,
       rectLeft: rect.left,
     };
   }
@@ -108,7 +113,8 @@ export function mountLaneInteraction(
   /** Timestamp under `clientX`, clamped to the draw area (region/press edge). */
   function nsAtClientX(clientX: number, geom: ColumnGeom): number {
     const x = clientX - geom.rectLeft;
-    const clamped = Math.max(LABEL_W, Math.min(LABEL_W + geom.drawW, x));
+    const labelW = geom.layout.labelW;
+    const clamped = Math.max(labelW, Math.min(labelW + geom.drawW, x));
     return geom.layout.panelXToNs(clamped);
   }
 
@@ -275,7 +281,7 @@ export function mountLaneInteraction(
     const geom = readColumnGeom();
     const mouseXCol = e.clientX - geom.rectLeft;
     // Any lanes click clears the pinned custom-event marker.
-    if (mouseXCol < LABEL_W || mouseXCol > LABEL_W + geom.drawW) {
+    if (mouseXCol < geom.layout.labelW || mouseXCol > geom.layout.labelW + geom.drawW) {
       store.update("selection", {
         selectedTaskId: null,
         pinnedEvent: null,
@@ -341,7 +347,7 @@ export function mountLaneInteraction(
     if (!e.ctrlKey && !e.metaKey) return;
     if (store.getState().trace.trace === null) return;
     const geom = readColumnGeom();
-    const mouseXInDraw = e.clientX - geom.rectLeft - LABEL_W;
+    const mouseXInDraw = e.clientX - geom.rectLeft - geom.layout.labelW;
     const intent = wheelZoomIntent({
       ctrlKey: e.ctrlKey,
       metaKey: e.metaKey,

--- a/dial9-viewer/ui/src/pages/viewer/selection-overlay.ts
+++ b/dial9-viewer/ui/src/pages/viewer/selection-overlay.ts
@@ -143,7 +143,13 @@ export function mountSelectionOverlay(
       el.style.display = "none";
       return;
     }
-    const layout = timePanelLayout({ pw, scrollbarW, viewStart, viewEnd });
+    const layout = timePanelLayout({
+      pw,
+      scrollbarW,
+      labelW: state.uiPrefs.labelWidth,
+      viewStart,
+      viewEnd,
+    });
     const box = selectionBox(region, layout);
     el.classList.toggle(ZOOM_MODIFIER, region.mode === "zoom");
     el.style.left = `${box.left}px`;
@@ -161,7 +167,7 @@ export function mountSelectionOverlay(
   // contract and trips the dev assertion at boot. Nothing is drawable before
   // that first tick anyway
   // (no trace, no selection => the box is hidden).
-  const unsubscribe = store.subscribe(["transient", "viewport", "selection"], () => render());
+  const unsubscribe = store.subscribe(["transient", "viewport", "selection", "uiPrefs"], () => render());
 
   return {
     dispose(): void {

--- a/dial9-viewer/ui/src/pages/viewer/shell.ts
+++ b/dial9-viewer/ui/src/pages/viewer/shell.ts
@@ -97,6 +97,7 @@ function viewModel(state: StoreState): TracksViewModel {
     trackOrder: state.uiPrefs.trackOrder,
     collapsed: state.uiPrefs.collapsed,
     lanesViewportHeight: state.uiPrefs.lanesViewportHeight,
+    labelWidth: state.uiPrefs.labelWidth,
   };
 }
 

--- a/dial9-viewer/ui/src/pages/viewer/spans-track.ts
+++ b/dial9-viewer/ui/src/pages/viewer/spans-track.ts
@@ -313,9 +313,8 @@ export function createSpansTrack(store: ViewerStore): SpansTrackController {
         style="height:${track.height}px"
       >
         <div class="d9-track-label d9-spans-label" id="d9-track-label-spans">
-          ${label === null
-            ? html`<span class="d9-track-name">${track.label}</span>`
-            : spanMetaTemplate(label)}
+          <span class="d9-spans-heading">${track.label}</span>
+          ${label === null ? null : spanMetaTemplate(label)}
         </div>
         <div class="d9-track-body d9-spans-body">
           ${hasSpans ? controlsTemplate(data, s, filter) : nothing}

--- a/dial9-viewer/ui/src/pages/viewer/store.ts
+++ b/dial9-viewer/ui/src/pages/viewer/store.ts
@@ -11,6 +11,7 @@ import { createStore } from "../../store/store.js";
 import type { ViewerStore } from "../../store/store.js";
 import type { StoreState } from "../../types/state.js";
 import type { StoreOptions } from "../../store/store.js";
+import { DEFAULT_LABEL_WIDTH } from "./label-gutter.js";
 
 /** The default persistent inspector width (CSS px). */
 export const DEFAULT_INSPECTOR_WIDTH = 360;
@@ -25,6 +26,8 @@ export const DEFAULT_RAIL_WIDTH = 300;
  *  default so multi-runtime traces are not cramped to a couple of visible rows;
  *  folding a runtime (header click) reclaims the rest. */
 export const DEFAULT_LANES_HEIGHT = 360;
+
+export { DEFAULT_LABEL_WIDTH } from "./label-gutter.js";
 
 /** Build the viewer store's resting (no-trace) initial state. */
 export function initialViewerState(): StoreState {
@@ -70,6 +73,7 @@ export function initialViewerState(): StoreState {
       collapsedRuntimeMetrics: {},
       sidebarWidth: DEFAULT_INSPECTOR_WIDTH,
       railWidth: DEFAULT_RAIL_WIDTH,
+      labelWidth: DEFAULT_LABEL_WIDTH,
       taskColWidths: {},
       issueColWidths: {},
       lanesViewportHeight: DEFAULT_LANES_HEIGHT,

--- a/dial9-viewer/ui/src/pages/viewer/track-management.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/track-management.test.ts
@@ -405,6 +405,20 @@ describe("persistence: uiPrefs survives reload (headline DoD)", () => {
     expect(uiPrefs(s2).railWidth).toBe(420);
   });
 
+  it("persists + restores the shared label gutter width across a fresh store", () => {
+    vi.stubGlobal("localStorage", fakeLocalStorage());
+    const s1 = manualScheduler();
+    const dispose = mountTrackPrefsPersistence(s1.store);
+    s1.store.update("uiPrefs", { labelWidth: 240 });
+    s1.flush();
+    dispose();
+
+    const s2 = createViewerStore({ scheduler: () => {} });
+    expect(uiPrefs(s2).labelWidth).toBe(180);
+    hydrateTrackPrefs(s2);
+    expect(uiPrefs(s2).labelWidth).toBe(240);
+  });
+
   it("keeps the store default when no rail width was stored", () => {
     const ls = fakeLocalStorage();
     // A pref blob from before railWidth existed: order/collapse only.

--- a/dial9-viewer/ui/src/pages/viewer/track-management.ts
+++ b/dial9-viewer/ui/src/pages/viewer/track-management.ts
@@ -27,6 +27,8 @@ import {
   closeFieldChart,
   fieldChartTrackSpecs,
 } from "./field-chart-model.js";
+import { DEFAULT_LABEL_WIDTH } from "./store.js";
+import { clampLabelWidth } from "./label-gutter.js";
 
 /** Collapsed (label-only) track height in CSS px. */
 export const COLLAPSED_TRACK_H = 36;
@@ -151,10 +153,21 @@ export interface TrackManageActions {
   reorder(dragged: TrackId, target: TrackId): void;
   /** Close a URL-defined dynamic chart and clean every reference to its id. */
   close(id: TrackId): void;
+  setLabelWidth(width: number): void;
+  adjustLabelWidth(delta: number): void;
+  resetLabelWidth(): void;
 }
 
 /** Bind the track-management actions to a store (dispatch uiPrefs updates). */
 export function createTrackManageActions(store: ViewerStore): TrackManageActions {
+  function setLabelWidth(width: number): void {
+    const next = clampLabelWidth(width);
+    if (next !== store.getState().uiPrefs.labelWidth) {
+      store.update("uiPrefs", { labelWidth: next });
+      store.update("viewport", {});
+    }
+  }
+
   return {
     toggleCollapse(id: TrackId): void {
       if (!isManageableTrack(id)) return;
@@ -176,6 +189,14 @@ export function createTrackManageActions(store: ViewerStore): TrackManageActions
     },
     close(id: TrackId): void {
       closeFieldChart(store, id);
+    },
+    setLabelWidth,
+    adjustLabelWidth(delta: number): void {
+      const cur = store.getState().uiPrefs.labelWidth;
+      setLabelWidth(cur + delta);
+    },
+    resetLabelWidth(): void {
+      setLabelWidth(DEFAULT_LABEL_WIDTH);
     },
   };
 }
@@ -235,6 +256,7 @@ export interface TrackPrefs {
   collapsedRuntimeMetrics?: Readonly<Record<string, boolean>>;
   lanesHeight?: number;
   railWidth?: number;
+  labelWidth?: number;
   taskColWidths?: Readonly<Record<string, number>>;
   issueColWidths?: Readonly<Record<string, number>>;
 }
@@ -314,6 +336,8 @@ export function loadTrackPrefs(): TrackPrefs | null {
     const lanesHeight = typeof lh === "number" && Number.isFinite(lh) && lh > 0 ? lh : undefined;
     const rw = (obj as { railWidth?: unknown }).railWidth;
     const railWidth = typeof rw === "number" && Number.isFinite(rw) && rw > 0 ? rw : undefined;
+    const lw = (obj as { labelWidth?: unknown }).labelWidth;
+    const labelWidth = typeof lw === "number" && Number.isFinite(lw) && lw > 0 ? lw : undefined;
     const tcw = (obj as { taskColWidths?: unknown }).taskColWidths;
     const taskColWidths = tcw !== undefined ? parseWidthMap(tcw) : undefined;
     const icw = (obj as { issueColWidths?: unknown }).issueColWidths;
@@ -325,6 +349,7 @@ export function loadTrackPrefs(): TrackPrefs | null {
       ...(collapsedRuntimeMetrics !== undefined ? { collapsedRuntimeMetrics } : {}),
       ...(lanesHeight !== undefined ? { lanesHeight } : {}),
       ...(railWidth !== undefined ? { railWidth } : {}),
+      ...(labelWidth !== undefined ? { labelWidth } : {}),
       ...(taskColWidths !== undefined ? { taskColWidths } : {}),
       ...(issueColWidths !== undefined ? { issueColWidths } : {}),
     };
@@ -355,6 +380,9 @@ export function saveTrackPrefs(prefs: TrackPrefs): void {
         : {}),
       ...(prefs.lanesHeight !== undefined ? { lanesHeight: prefs.lanesHeight } : {}),
       ...(prefs.railWidth !== undefined ? { railWidth: prefs.railWidth } : {}),
+      ...(prefs.labelWidth !== undefined
+        ? { labelWidth: clampLabelWidth(prefs.labelWidth) }
+        : {}),
       ...(prefs.taskColWidths !== undefined ? { taskColWidths: prefs.taskColWidths } : {}),
       ...(prefs.issueColWidths !== undefined ? { issueColWidths: prefs.issueColWidths } : {}),
     }),
@@ -383,6 +411,9 @@ export function hydrateTrackPrefs(store: ViewerStore): void {
       : {}),
     ...(prefs.lanesHeight !== undefined ? { lanesViewportHeight: prefs.lanesHeight } : {}),
     ...(prefs.railWidth !== undefined ? { railWidth: prefs.railWidth } : {}),
+    ...(prefs.labelWidth !== undefined
+      ? { labelWidth: clampLabelWidth(prefs.labelWidth) }
+      : {}),
     ...(prefs.taskColWidths !== undefined ? { taskColWidths: prefs.taskColWidths } : {}),
     ...(prefs.issueColWidths !== undefined ? { issueColWidths: prefs.issueColWidths } : {}),
   });
@@ -404,6 +435,7 @@ export function mountTrackPrefsPersistence(store: ViewerStore): () => void {
       collapsedRuntimeMetrics,
       lanesViewportHeight,
       railWidth,
+      labelWidth,
       taskColWidths,
       issueColWidths,
     } = state.uiPrefs;
@@ -414,6 +446,7 @@ export function mountTrackPrefsPersistence(store: ViewerStore): () => void {
       collapsedRuntimeMetrics,
       lanesHeight: lanesViewportHeight,
       railWidth,
+      labelWidth,
       taskColWidths,
       issueColWidths,
     });

--- a/dial9-viewer/ui/src/pages/viewer/tracks.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/tracks.test.ts
@@ -19,6 +19,7 @@ function vm(over: Partial<TracksViewModel> = {}): TracksViewModel {
     collapsed: {},
     emptyTracks: new Set<TrackId>(),
     lanesViewportHeight: 130,
+    labelWidth: 180,
     ...over,
   };
 }

--- a/dial9-viewer/ui/src/pages/viewer/tracks.ts
+++ b/dial9-viewer/ui/src/pages/viewer/tracks.ts
@@ -15,7 +15,7 @@ import { html, type TemplateResult } from "lit-html";
 import { repeat } from "lit-html/directives/repeat.js";
 import { createCanvasSizer } from "../../lib/canvas/dpr.js";
 import type { CanvasSizer } from "../../lib/canvas/dpr.js";
-import { LABEL_W, lanesScrollbarWidth, trackGeometry } from "../../lib/canvas/track-layout.js";
+import { lanesScrollbarWidth, trackGeometry } from "../../lib/canvas/track-layout.js";
 import {
   isFieldChartTrackId,
   type TrackId,
@@ -42,6 +42,11 @@ import type { TaskDetailTrackController } from "./task-detail-track.js";
 import type { EventsTrackController } from "./events-track.js";
 import { fieldChartTrackSpecs } from "./field-chart-model.js";
 import type { FieldChartTrackController } from "./field-chart-track.js";
+import {
+  MAX_LABEL_WIDTH_VW,
+  MIN_LABEL_WIDTH,
+  clampLabelWidth,
+} from "./label-gutter.js";
 
 export interface TracksViewModel {
   /** True once a trace is loaded (tracks render empty until then). */
@@ -84,7 +89,11 @@ export interface TracksViewModel {
   /** Height (CSS px) of the worker-lanes scroll box. The lanes row sizes its
    *  viewport to this; the user drag-resizes it via the lanes bottom gutter. */
   lanesViewportHeight: number;
+  /** Shared, user-resizable DOM/canvas gutter width. */
+  labelWidth: number;
 }
+
+export { MAX_LABEL_WIDTH_VW, MIN_LABEL_WIDTH, clampLabelWidth } from "./label-gutter.js";
 
 /**
  * The tracks visible for a view model, in the user's order: apply `trackOrder`
@@ -141,7 +150,7 @@ export function tracksTemplate(
       class="d9-tracks"
       role="group"
       aria-label="Timeline tracks"
-      style="--d9-label-w:${LABEL_W}px"
+      style="--d9-label-w:${vm.labelWidth}px"
     >
       ${repeat(
         tracks,
@@ -169,6 +178,20 @@ export function tracksTemplate(
             : inner;
         },
       )}
+      <div
+        class="d9-label-resize"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize track labels"
+        aria-valuemin=${MIN_LABEL_WIDTH}
+        aria-valuemax=${Math.max(MIN_LABEL_WIDTH, Math.floor(window.innerWidth * MAX_LABEL_WIDTH_VW))}
+        aria-valuenow=${vm.labelWidth}
+        tabindex="0"
+        title="Drag to resize track labels; double-click to reset"
+        @mousedown=${(e: MouseEvent) => onLabelResizeDown(e, actions)}
+        @keydown=${(e: KeyboardEvent) => onLabelResizeKeyDown(e, actions)}
+        @dblclick=${() => actions.resetLabelWidth()}
+      ></div>
     </div>
   `;
 }
@@ -253,6 +276,48 @@ function lanesTrackRow(t: TrackSpec, viewportHeight: number): TemplateResult {
 // dragstart, cleared on dragend/drop. Transient, like the `sizers` memo below.
 let dragSourceId: TrackId | null = null;
 
+function onLabelResizeDown(e: MouseEvent, actions: TrackManageActions): void {
+  e.preventDefault();
+  const handle = e.currentTarget as HTMLElement;
+  const doc = handle.ownerDocument;
+  const win = doc.defaultView ?? window;
+  const onMove = (move: MouseEvent): void => {
+    const tracks = handle.closest<HTMLElement>(".d9-tracks");
+    if (tracks !== null) {
+      actions.setLabelWidth(
+        clampLabelWidth(move.clientX - tracks.getBoundingClientRect().left),
+      );
+    }
+  };
+  const onUp = (): void => {
+    doc.body.style.userSelect = "";
+    doc.body.style.cursor = "";
+    win.removeEventListener("mousemove", onMove);
+    win.removeEventListener("mouseup", onUp);
+  };
+  doc.body.style.userSelect = "none";
+  doc.body.style.cursor = "col-resize";
+  win.addEventListener("mousemove", onMove);
+  win.addEventListener("mouseup", onUp);
+}
+
+function onLabelResizeKeyDown(e: KeyboardEvent, actions: TrackManageActions): void {
+  const step = e.shiftKey ? 32 : 8;
+  if (e.key === "ArrowLeft") {
+    e.preventDefault();
+    actions.adjustLabelWidth(-step);
+  } else if (e.key === "ArrowRight") {
+    e.preventDefault();
+    actions.adjustLabelWidth(step);
+  } else if (e.key === "Home") {
+    e.preventDefault();
+    actions.setLabelWidth(MIN_LABEL_WIDTH);
+  } else if (e.key === "End") {
+    e.preventDefault();
+    actions.setLabelWidth(clampLabelWidth(Infinity));
+  }
+}
+
 function onGripDragStart(e: DragEvent, id: TrackId): void {
   dragSourceId = id;
   if (e.dataTransfer !== null) {
@@ -301,7 +366,8 @@ function manageWrapper(
   return html`
     <div
       class="d9-track-manage ${collapsed ? "is-collapsed" : ""}
-        ${isFieldChartTrackId(t.id) ? "is-dynamic" : ""}"
+        ${isFieldChartTrackId(t.id) ? "is-dynamic" : ""}
+        ${t.id === "spans" ? "d9-track-manage--spans" : ""}"
       data-track-manage=${t.id}
       @dragover=${(e: DragEvent) => onRowDragOver(e, t.id)}
       @drop=${(e: DragEvent) => onRowDrop(e, t.id, actions)}
@@ -450,6 +516,7 @@ export function sizeTracks(
     const geometry = trackGeometry(track, {
       pw,
       scrollbarW,
+      labelW: vm.labelWidth,
       viewStart: vm.viewStart,
       viewEnd: vm.viewEnd,
       dpr,

--- a/dial9-viewer/ui/src/pages/viewer/url-state.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/url-state.test.ts
@@ -44,6 +44,7 @@ function mkState(over: {
       collapsedRuntimeMetrics: {},
       sidebarWidth: 360,
       railWidth: 300,
+      labelWidth: 180,
       taskColWidths: {},
       issueColWidths: {},
       lanesViewportHeight: 360,
@@ -302,6 +303,7 @@ describe("viewer URL state: complete durable view", () => {
           collapsedRuntimes: { beta: true, alpha: true },
           sidebarWidth: 444,
           railWidth: 460,
+          labelWidth: 240,
           taskColWidths: { polls: 48, loc: 260 },
           issueColWidths: { kind: 120, dot: 14 },
           lanesViewportHeight: 280,
@@ -329,6 +331,7 @@ describe("viewer URL state: complete durable view", () => {
 
     expect(params.get("rail")).toBe("tasks");
     expect(params.get("rail-width")).toBe("460");
+    expect(params.get("label-width")).toBe("240");
     expect(params.get("task-cols")).toBe("v1:loc,260\tpolls,48");
     expect(params.get("issue-cols")).toBe("v1:dot,14\tkind,120");
     expect(params.get("task-sort")).toBe("lifetime,asc");
@@ -342,6 +345,7 @@ describe("viewer URL state: complete durable view", () => {
       collapsedRuntimes: ["alpha", "beta"],
       inspectorWidth: 444,
       railWidth: 460,
+      labelWidth: 240,
       taskColWidths: { loc: 260, polls: 48 },
       issueColWidths: { dot: 14, kind: 120 },
       lanesHeight: 280,

--- a/dial9-viewer/ui/src/pages/viewer/url-state.ts
+++ b/dial9-viewer/ui/src/pages/viewer/url-state.ts
@@ -23,6 +23,7 @@ import type { PointOfInterestType } from "../../types/trace.js";
 import type { ViewState } from "../../lib/url/index.js";
 import {
   DEFAULT_INSPECTOR_WIDTH,
+  DEFAULT_LABEL_WIDTH,
   DEFAULT_LANES_HEIGHT,
   DEFAULT_RAIL_WIDTH,
 } from "./store.js";
@@ -43,6 +44,7 @@ import {
   FIELD_CHART_TRACK_ID_PREFIX,
   isFieldChartTrackId,
 } from "../../lib/canvas/track-layout.js";
+import { clampLabelWidth } from "./label-gutter.js";
 
 const P_START = "start";
 const P_END = "end";
@@ -75,6 +77,7 @@ const P_RUNTIME_COLLAPSED = "runtime-collapsed";
 const P_RUNTIME_METRICS_COLLAPSED = "runtime-metrics-collapsed";
 const P_INSPECTOR_WIDTH = "inspector-width";
 const P_RAIL_WIDTH = "rail-width";
+const P_LABEL_WIDTH = "label-width";
 const P_LANES_HEIGHT = "lanes-height";
 const P_LANES_SCROLL = "lanes-scroll";
 const P_STACK_VIEW = "stack-view";
@@ -179,6 +182,7 @@ export const VIEWER_STATE_OWNERSHIP = {
     collapsedRuntimeMetrics: url(P_RUNTIME_METRICS_COLLAPSED),
     sidebarWidth: url(P_INSPECTOR_WIDTH),
     railWidth: url(P_RAIL_WIDTH),
+    labelWidth: url(P_LABEL_WIDTH),
     taskColWidths: url(P_TASK_COLS),
     issueColWidths: url(P_ISSUE_COLS),
     lanesViewportHeight: url(P_LANES_HEIGHT),
@@ -352,6 +356,9 @@ export function projectViewerState(state: ReadonlyState<StoreState>): ViewState 
   if (state.uiPrefs.railWidth !== DEFAULT_RAIL_WIDTH) {
     vs.railWidth = state.uiPrefs.railWidth;
   }
+  if (state.uiPrefs.labelWidth !== DEFAULT_LABEL_WIDTH) {
+    vs.labelWidth = state.uiPrefs.labelWidth;
+  }
   const taskColEntries = sortedWidthEntries(state.uiPrefs.taskColWidths);
   if (taskColEntries.length > 0) {
     vs.taskColWidths = Object.fromEntries(taskColEntries);
@@ -464,6 +471,7 @@ export function mirrorViewerToQuery(
   set(params, P_RUNTIME_METRICS_COLLAPSED, encodeList(vs.collapsedRuntimeMetrics));
   set(params, P_INSPECTOR_WIDTH, finiteString(vs.inspectorWidth));
   set(params, P_RAIL_WIDTH, finiteString(vs.railWidth));
+  set(params, P_LABEL_WIDTH, finiteString(vs.labelWidth));
   set(params, P_TASK_COLS, encodeWidthMap(vs.taskColWidths));
   set(params, P_ISSUE_COLS, encodeWidthMap(vs.issueColWidths));
   set(params, P_LANES_HEIGHT, finiteString(vs.lanesHeight));
@@ -602,6 +610,7 @@ export interface ViewerUrlState {
   collapsedRuntimeMetrics?: string[];
   inspectorWidth?: number;
   railWidth?: number;
+  labelWidth?: number;
   taskColWidths?: Record<string, number>;
   issueColWidths?: Record<string, number>;
   lanesHeight?: number;
@@ -667,6 +676,9 @@ export function hydrateViewerStore(
   }
   if (urlView.railWidth !== undefined) {
     uiPrefs.railWidth = urlView.railWidth;
+  }
+  if (urlView.labelWidth !== undefined) {
+    uiPrefs.labelWidth = clampLabelWidth(urlView.labelWidth);
   }
   if (urlView.taskColWidths !== undefined) {
     uiPrefs.taskColWidths = urlView.taskColWidths;
@@ -848,6 +860,8 @@ export function readViewerUrlState(search: string): ViewerUrlState {
   if (inspectorWidth !== null) out.inspectorWidth = inspectorWidth;
   const railWidth = positiveInt(p.get(P_RAIL_WIDTH));
   if (railWidth !== null) out.railWidth = railWidth;
+  const labelWidth = positiveInt(p.get(P_LABEL_WIDTH));
+  if (labelWidth !== null) out.labelWidth = labelWidth;
   const taskCols = decodeWidthMap(
     p.get(P_TASK_COLS),
     TASK_SORT_KEYS as readonly string[],

--- a/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/viewer-reconstruction.test.ts
@@ -376,6 +376,7 @@ describe("viewer deep-link reconstruction", () => {
       collapsedRuntimeMetrics: { runtime_b: true },
       sidebarWidth: 444,
       railWidth: 460,
+      labelWidth: 240,
       taskColWidths: { loc: 260, polls: 48 },
       issueColWidths: { dot: 14, kind: 120 },
       lanesViewportHeight: 280,

--- a/dial9-viewer/ui/src/store/store.test.ts
+++ b/dial9-viewer/ui/src/store/store.test.ts
@@ -63,6 +63,7 @@ function initialViewerState(): StoreState {
       collapsedRuntimeMetrics: {},
       sidebarWidth: 320,
       railWidth: 300,
+      labelWidth: 180,
       taskColWidths: {},
       issueColWidths: {},
       lanesViewportHeight: 200,

--- a/dial9-viewer/ui/src/styles/viewer.css
+++ b/dial9-viewer/ui/src/styles/viewer.css
@@ -550,7 +550,7 @@ body {
 
 /* ── Tracks ──────────────────────────────────────────────────────────── */
 
-.d9-tracks { display: flex; flex-direction: column; }
+.d9-tracks { display: flex; flex-direction: column; position: relative; }
 .d9-track {
     display: flex;
     align-items: stretch;
@@ -599,6 +599,18 @@ body {
     background: var(--d9-bg-track);
 }
 .d9-track-canvas { display: block; }
+.d9-label-resize {
+    position: absolute;
+    z-index: 8;
+    top: 0;
+    bottom: 0;
+    left: calc(var(--d9-label-w) - 3px);
+    width: 7px;
+    cursor: col-resize;
+    touch-action: none;
+}
+.d9-label-resize:hover,
+.d9-label-resize:focus-visible { background: var(--d9-accent); outline: none; }
 
 /* CPU guide + visible-window summary share a real DOM header so they cannot
    overlap. The guide swatch mirrors the canvas line's 4px/3px dash pattern. */
@@ -898,6 +910,24 @@ body {
     overflow-y: auto;
     overflow-x: hidden;
 }
+/* Spans owns an in-flow heading so focused metadata always starts on the next
+   line. Its management strip retains the collapse/reorder controls only. */
+.d9-track-manage--spans .d9-track-strip-name {
+    display: none;
+}
+.d9-track-manage--spans .d9-track-manage-strip {
+    justify-content: space-between;
+}
+.d9-spans-heading {
+    display: block;
+    min-height: 20px;
+    padding-left: 28px;
+    padding-right: 28px;
+    font-size: 0.8em;
+    line-height: 20px;
+    color: var(--d9-fg);
+    flex: none;
+}
 .d9-spans-meta-name {
     font-size: 0.78em;
     color: #ccc;
@@ -911,7 +941,7 @@ body {
     margin-top: 2px;
     line-height: 1.3;
 }
-.d9-kv-key { color: var(--d9-fg-muted); font-size: 0.72em; white-space: nowrap; }
+.d9-kv-key { color: var(--d9-fg-muted); font-size: 0.72em; white-space: nowrap; flex: none; }
 .d9-kv-val {
     color: #cdd2f0;
     font-size: 0.72em;

--- a/dial9-viewer/ui/src/types/exhaustive.test.ts
+++ b/dial9-viewer/ui/src/types/exhaustive.test.ts
@@ -190,6 +190,7 @@ const initialState: StoreState = {
     collapsedRuntimeMetrics: { main: true },
     sidebarWidth: 400,
     railWidth: 320,
+    labelWidth: 180,
     taskColWidths: { loc: 260, polls: 48 },
     issueColWidths: { dot: 14, kind: 120 },
     lanesViewportHeight: 220,

--- a/dial9-viewer/ui/src/types/state.d.ts
+++ b/dial9-viewer/ui/src/types/state.d.ts
@@ -298,6 +298,8 @@ export interface UiPrefsSlice {
   sidebarWidth: number;
   /** Issues/Tasks rail width in CSS px (drag-resizable via its right edge). */
   railWidth: number;
+  /** Shared time-track label gutter width in CSS px (drag-resizable). */
+  labelWidth: number;
   /**
    * Tasks-table column widths in CSS px, keyed by column sort key. Empty =
    * automatic (content-fit) layout. The first divider drag seeds every column


### PR DESCRIPTION
Give the timeline label column enough room for useful labels by default, while allowing readers to resize it when a trace calls for more or less space. Place selected span details below the Spans label so names and fields remain clear and easy to scan.