### PR TITLE
feat(viewer): Zoom-aware ruler & Selection measure

### DIFF
--- a/dial9-viewer/ui/flamegraph_histogram.js
+++ b/dial9-viewer/ui/flamegraph_histogram.js
@@ -13,19 +13,6 @@
 // declarations. The rendering and brush wiring live in
 // src/pages/flamegraph/minimap.ts.
 
-// Format a nanosecond duration as a short human string for axis ticks/tooltips:
-//   500000 -> "500µs", 1500000 -> "1.5ms", 50000000 -> "50ms", 2e9 -> "2s".
-// Sub-microsecond values fall back to "ns". Trailing ".0" is trimmed.
-function fmtDurationNs(ns) {
-  const n = Number(ns);
-  if (!Number.isFinite(n) || n < 0) return "";
-  const trim = (x) => String(Number(x.toFixed(1)));
-  if (n < 1e3) return n + "ns";
-  if (n < 1e6) return trim(n / 1e3) + "µs";
-  if (n < 1e9) return trim(n / 1e6) + "ms";
-  return trim(n / 1e9) + "s";
-}
-
 // Normalize + validate the backend histogram into ascending bars with numeric
 // fields. Drops malformed entries (non-finite / negative). Empty in → empty out.
 function normalizeHistogram(hist) {
@@ -127,7 +114,6 @@ function brushToBand(bars, width, x0, x1) {
 }
 
 var FlamegraphHistogram = {
-  fmtDurationNs,
   normalizeHistogram,
   sampleWeightedMedianNs,
   histogramLayout,

--- a/dial9-viewer/ui/format.js
+++ b/dial9-viewer/ui/format.js
@@ -1,19 +1,53 @@
 "use strict";
 
+// The sub-minute unit ladder, ascending. The unit is picked so the mantissa
+// lands in [1, 1000), which is what makes the unit itself carry the magnitude:
+// 100ns reads "100ns", never "0.1µs". Picoseconds are the floor - divided
+// durations (per-poll averages, rates) can land below a nanosecond.
+const HUMAN_DURATION_UNITS = [
+  { div: 1e-3, suffix: "ps" },
+  { div: 1, suffix: "ns" },
+  { div: 1e3, suffix: "µs" },
+  { div: 1e6, suffix: "ms" },
+  { div: 1e9, suffix: "s" },
+];
+
+// 3 significant digits, at most 2 decimals: 2 below 10, 1 below 100, none
+// above. `Number(...)` drops trailing zeros so a round value reads "1µs", not
+// "1.00µs".
+function humanSignificand(mantissa) {
+  const decimals = mantissa >= 100 ? 0 : mantissa >= 10 ? 1 : 2;
+  return String(Number(mantissa.toFixed(decimals)));
+}
+
 // Format a duration in nanoseconds as a human-friendly string with a sensible
-// unit. Chosen to read naturally at any scale: "500ns", "1.5µs", "123.46ms",
-// "30.00s", "5m 12.0s", "8h 0m 8s", "2d 4h 30m".
+// unit: "100ps", "500ns", "1.5µs", "123ms", "30s", "5m 12.0s", "8h 0m 8s",
+// "2d 4h 30m".
 //
-// Used in the viewer header and anywhere else we want a compact, readable
-// duration regardless of magnitude.
+// Sub-minute values carry 3 significant digits (at most 2 decimals) in the unit
+// that keeps the mantissa under 1000, so the reading is always scannable and
+// the unit tells you the scale at a glance. At a minute and above the composite
+// m/h/d form takes over, where the leading unit already reads that way.
+//
+// This is the viewer's ONE duration format: the time-lane ruler, tooltips,
+// inspector rows, flamegraph axes and the tokio-stats tables all route here.
 function formatHumanDuration(ns) {
   if (!isFinite(ns) || ns < 0) return "0ns";
-  if (ns < 1_000) return `${Math.round(ns)}ns`;
-  if (ns < 1_000_000) return `${(ns / 1_000).toFixed(1)}µs`;
-  if (ns < 1_000_000_000) return `${(ns / 1_000_000).toFixed(2)}ms`;
+  if (ns === 0) return "0ns";
 
   const totalSec = ns / 1e9;
-  if (totalSec < 60) return `${totalSec.toFixed(2)}s`;
+  if (totalSec < 60) {
+    let i = 0;
+    while (i < HUMAN_DURATION_UNITS.length - 1 && ns >= HUMAN_DURATION_UNITS[i + 1].div) i++;
+    let mantissa = humanSignificand(ns / HUMAN_DURATION_UNITS[i].div);
+    // Rounding can carry the mantissa up to 1000 (999.6ns): promote a unit
+    // rather than print a 4-digit reading.
+    if (Number(mantissa) >= 1000 && i < HUMAN_DURATION_UNITS.length - 1) {
+      i++;
+      mantissa = humanSignificand(ns / HUMAN_DURATION_UNITS[i].div);
+    }
+    return mantissa + HUMAN_DURATION_UNITS[i].suffix;
+  }
 
   const totalMin = Math.floor(totalSec / 60);
   const sec = totalSec - totalMin * 60;

--- a/dial9-viewer/ui/format.js
+++ b/dial9-viewer/ui/format.js
@@ -20,6 +20,26 @@ function humanSignificand(mantissa) {
   return String(Number(mantissa.toFixed(decimals)));
 }
 
+// The sub-minute reading, or null when it belongs to the composite branch:
+// either the value is already a minute or more, or rounding carried the
+// seconds reading onto the boundary (59.96s must not print "60s" right next to
+// a real minute printing "1m 0.0s").
+function subMinuteDuration(ns) {
+  if (ns >= 60e9) return null;
+  let i = 0;
+  while (i < HUMAN_DURATION_UNITS.length - 1 && ns >= HUMAN_DURATION_UNITS[i + 1].div) i++;
+  let mantissa = humanSignificand(ns / HUMAN_DURATION_UNITS[i].div);
+  // Rounding can carry the mantissa up to 1000 (999.6ns): promote a unit
+  // rather than print a 4-digit reading.
+  if (Number(mantissa) >= 1000 && i < HUMAN_DURATION_UNITS.length - 1) {
+    i++;
+    mantissa = humanSignificand(ns / HUMAN_DURATION_UNITS[i].div);
+  }
+  const unit = HUMAN_DURATION_UNITS[i];
+  if (unit.suffix === "s" && Number(mantissa) >= 60) return null;
+  return mantissa + unit.suffix;
+}
+
 // Format a duration in nanoseconds as a human-friendly string with a sensible
 // unit: "100ps", "500ns", "1.5µs", "123ms", "30s", "5m 12.0s", "8h 0m 8s",
 // "2d 4h 30m".
@@ -32,23 +52,14 @@ function humanSignificand(mantissa) {
 // This is the viewer's ONE duration format: the time-lane ruler, tooltips,
 // inspector rows, flamegraph axes and the tokio-stats tables all route here.
 function formatHumanDuration(ns) {
-  if (!isFinite(ns) || ns < 0) return "0ns";
-  if (ns === 0) return "0ns";
+  if (!(ns > 0) || !isFinite(ns)) return "0ns";
 
-  const totalSec = ns / 1e9;
-  if (totalSec < 60) {
-    let i = 0;
-    while (i < HUMAN_DURATION_UNITS.length - 1 && ns >= HUMAN_DURATION_UNITS[i + 1].div) i++;
-    let mantissa = humanSignificand(ns / HUMAN_DURATION_UNITS[i].div);
-    // Rounding can carry the mantissa up to 1000 (999.6ns): promote a unit
-    // rather than print a 4-digit reading.
-    if (Number(mantissa) >= 1000 && i < HUMAN_DURATION_UNITS.length - 1) {
-      i++;
-      mantissa = humanSignificand(ns / HUMAN_DURATION_UNITS[i].div);
-    }
-    return mantissa + HUMAN_DURATION_UNITS[i].suffix;
-  }
+  const reading = subMinuteDuration(ns);
+  if (reading !== null) return reading;
 
+  // A value whose seconds reading rounded up to a minute is formatted as the
+  // minute it rounded to; using the raw 59.96s here would read "0m 60.0s".
+  const totalSec = Math.max(ns, 60e9) / 1e9;
   const totalMin = Math.floor(totalSec / 60);
   const sec = totalSec - totalMin * 60;
   if (totalMin < 60) return `${totalMin}m ${sec.toFixed(1)}s`;

--- a/dial9-viewer/ui/span_explorer.js
+++ b/dial9-viewer/ui/span_explorer.js
@@ -28,8 +28,6 @@ function shouldAdoptCatalogSnapshot(mode, baselineFilesFolded, incomingFilesFold
   }
   return false;
 }
-// ── Duration formatting (reuse from flamegraph_histogram.js when available) ──
-
 // ── Span type catalog helpers ────────────────────────────────────────────────
 
 // Sort span types by a given key. Default: descending by count.

--- a/dial9-viewer/ui/span_explorer.js
+++ b/dial9-viewer/ui/span_explorer.js
@@ -30,17 +30,6 @@ function shouldAdoptCatalogSnapshot(mode, baselineFilesFolded, incomingFilesFold
 }
 // ── Duration formatting (reuse from flamegraph_histogram.js when available) ──
 
-function fmtNs(ns) {
-  if (ns == null) return "—";
-  const n = Number(ns);
-  if (!Number.isFinite(n) || n < 0) return "—";
-  if (n === 0) return "0";
-  if (n < 1e3) return n + "ns";
-  if (n < 1e6) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "µs";
-  if (n < 1e9) return (n / 1e6).toFixed(2).replace(/\.?0+$/, "") + "ms";
-  return (n / 1e9).toFixed(2).replace(/\.?0+$/, "") + "s";
-}
-
 // ── Span type catalog helpers ────────────────────────────────────────────────
 
 // Sort span types by a given key. Default: descending by count.
@@ -597,7 +586,6 @@ function exemplarRequestMatches(requestUid, requestScopeKey, currentUid, current
 var SpanExplorer = {
   setMaxFilesParam,
   shouldAdoptCatalogSnapshot,
-  fmtNs,
   sortSpanTypes,
   spanTypeLabel,
   normalizeSpanHistogram,

--- a/dial9-viewer/ui/src/lib/canvas/flamegraph_histogram.test.ts
+++ b/dial9-viewer/ui/src/lib/canvas/flamegraph_histogram.test.ts
@@ -4,23 +4,11 @@
 import { describe, it, expect } from "vitest";
 import {
   brushToBand,
-  fmtDurationNs,
   histogramLayout,
   normalizeHistogram,
   pxToNs,
   sampleWeightedMedianNs,
 } from "./flamegraph_histogram.js";
-
-describe("fmtDurationNs", () => {
-  it("formats ns/µs/ms/s and rejects negatives", () => {
-    expect(fmtDurationNs(500)).toBe("500ns");
-    expect(fmtDurationNs(500000)).toBe("500µs");
-    expect(fmtDurationNs(1500000)).toBe("1.5ms");
-    expect(fmtDurationNs(50000000)).toBe("50ms");
-    expect(fmtDurationNs(2000000000)).toBe("2s");
-    expect(fmtDurationNs(-1)).toBe("");
-  });
-});
 
 describe("normalizeHistogram", () => {
   it("sorts ascending and drops malformed entries", () => {

--- a/dial9-viewer/ui/src/lib/canvas/flamegraph_histogram.ts
+++ b/dial9-viewer/ui/src/lib/canvas/flamegraph_histogram.ts
@@ -1,15 +1,15 @@
 // Typed seam over the frozen poll-duration histogram helpers
 // (flamegraph_histogram.js): the DOM-free math behind the aggregated-mode
-// minimap - duration formatting, histogram normalization, the sample-weighted
-// median (fast/slow split seed), bar layout, and pixel <-> poll-duration-band
-// mapping. The api-mode page composes the minimap through this re-export
-// instead of importing the core module directly.
+// minimap - histogram normalization, the sample-weighted median (fast/slow
+// split seed), bar layout, and pixel <-> poll-duration-band mapping. The
+// api-mode page composes the minimap through this re-export instead of
+// importing the core module directly. Duration labels come from
+// `formatHumanDuration` (lib/trace), the viewer's one duration format.
 //
 // flamegraph_histogram.js is self-contained (no dependencies), so it needs no
 // global-seed chain like the flamegraph widget does.
 
 export {
-  fmtDurationNs,
   normalizeHistogram,
   sampleWeightedMedianNs,
   histogramLayout,

--- a/dial9-viewer/ui/src/lib/canvas/index.ts
+++ b/dial9-viewer/ui/src/lib/canvas/index.ts
@@ -81,7 +81,6 @@ export type {
 
 export {
   brushToBand,
-  fmtDurationNs,
   histogramLayout,
   normalizeHistogram,
   pxToNs,

--- a/dial9-viewer/ui/src/lib/trace/span_explorer.test.ts
+++ b/dial9-viewer/ui/src/lib/trace/span_explorer.test.ts
@@ -64,6 +64,8 @@ describe("scope and catalog helpers", () => {
     expect([fmtNs(500), fmtNs(1_500_000), fmtNs(2_000_000_000)])
       .toEqual(["500ns", "1.5ms", "2s"]);
     expect([fmtNs(null), fmtNs(-1), fmtNs(0)]).toEqual(["—", "—", "0"]);
+    // A minute or more reaches the shared composite form.
+    expect(fmtNs(90_000_000_000)).toBe("1m 30.0s");
     expect(
       spanTypeLabel({
         name: "handle_request",

--- a/dial9-viewer/ui/src/lib/trace/span_explorer.ts
+++ b/dial9-viewer/ui/src/lib/trace/span_explorer.ts
@@ -5,6 +5,22 @@
 // lib/trace is the sanctioned shared-core import boundary; the Span Explorer
 // page consumes all of this through the barrel.
 
+import { formatHumanDuration } from "../../../format.js";
+
+/**
+ * Duration for a Span Explorer table cell. The missing/invalid and zero
+ * contracts are this page's ("—" reads as no measurement, a bare "0" as a
+ * measured nothing); the number itself goes through the viewer's one duration
+ * format.
+ */
+export function fmtNs(ns: number | string | null | undefined): string {
+  if (ns == null) return "—";
+  const n = Number(ns);
+  if (!Number.isFinite(n) || n < 0) return "—";
+  if (n === 0) return "0";
+  return formatHumanDuration(n);
+}
+
 export {
   TIME_CATEGORIES,
   addAttrFilter,
@@ -19,7 +35,6 @@ export {
   exemplarRequestMatches,
   exemplarsInBand,
   flamegraphUrl,
-  fmtNs,
   fmtPercentile,
   formatAttrFilterParams,
   hasAttrFilter,

--- a/dial9-viewer/ui/src/pages/flamegraph/minimap.ts
+++ b/dial9-viewer/ui/src/pages/flamegraph/minimap.ts
@@ -12,7 +12,6 @@
 
 import {
   brushToBand,
-  fmtDurationNs,
   histogramLayout,
   normalizeHistogram,
   pxToNs,
@@ -20,7 +19,7 @@ import {
   type HistogramColumn,
   type PollHistogramBar,
 } from "../../lib/canvas/index.js";
-import { msToNs, nsToMs } from "../../lib/trace/index.js";
+import { formatHumanDuration, msToNs, nsToMs } from "../../lib/trace/index.js";
 import type { PollDurationBar } from "../../lib/trace/index.js";
 
 const MINIMAP_H = 46; // px, bar-area height
@@ -146,7 +145,7 @@ export function createPollMinimap(opts: PollMinimapOptions): PollMinimap {
       mmFastSlow.style.display = "none";
       return;
     }
-    const s = fmtDurationNs(splitNs);
+    const s = formatHumanDuration(splitNs);
     mmFastSlow.style.display = "";
     mmFastSlow.textContent = `Diff fast vs slow polls (split @ ${s})`;
     mmFastSlow.title =
@@ -264,13 +263,13 @@ export function createPollMinimap(opts: PollMinimapOptions): PollMinimap {
       if (i % stride !== 0) continue;
       const c = cols[i]!;
       const t = document.createElement("span");
-      t.textContent = fmtDurationNs(c.lo_ns);
+      t.textContent = formatHumanDuration(c.lo_ns);
       t.style.cssText = `position:absolute;left:${(c.x / width) * 100}%;white-space:nowrap;transform:translateX(-1px)`;
       axis.appendChild(t);
     }
     if (nBars > 0) {
       const last = document.createElement("span");
-      last.textContent = fmtDurationNs(cols[nBars - 1]!.hi_ns);
+      last.textContent = formatHumanDuration(cols[nBars - 1]!.hi_ns);
       last.style.cssText = "position:absolute;right:0;white-space:nowrap;color:#6a6a80";
       axis.appendChild(last);
     }
@@ -304,7 +303,7 @@ export function createPollMinimap(opts: PollMinimapOptions): PollMinimap {
         return;
       }
       tipEl.textContent =
-        `${fmtDurationNs(c.lo_ns)}–${fmtDurationNs(c.hi_ns)} · ${c.samples.toLocaleString()} samples`;
+        `${formatHumanDuration(c.lo_ns)}–${formatHumanDuration(c.hi_ns)} · ${c.samples.toLocaleString()} samples`;
       tipEl.style.display = "block";
       tipEl.style.left = `${e.clientX + 12}px`;
       tipEl.style.top = `${e.clientY - 28}px`;

--- a/dial9-viewer/ui/src/pages/span-explorer/histogram.ts
+++ b/dial9-viewer/ui/src/pages/span-explorer/histogram.ts
@@ -8,13 +8,13 @@
 import {
   durationAtPercentile,
   fmtNs,
+  formatHumanDuration,
   normalizeSpanHistogram,
   spanBrushToBand,
   spanHistogramLayout,
   spanNsToPx,
 } from "../../lib/trace/index.js";
 import type { DurationBand, HistogramBarLike } from "../../lib/trace/index.js";
-import { fmtDurationNs } from "../../lib/canvas/index.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
 /** Drawing width in viewBox units; the SVG scales to its container. */
@@ -174,7 +174,7 @@ export function renderHistogram(
   cols.forEach((c, i) => {
     if (i % stride !== 0) return;
     const t = document.createElement("span");
-    t.textContent = fmtDurationNs(c.lo_ns);
+    t.textContent = formatHumanDuration(c.lo_ns);
     t.style.cssText = `position:absolute;left:${(c.x / W) * 100}%;white-space:nowrap;transform:translateX(-1px)`;
     axis.appendChild(t);
   });

--- a/dial9-viewer/ui/src/pages/tokio-stats/format.test.ts
+++ b/dial9-viewer/ui/src/pages/tokio-stats/format.test.ts
@@ -40,6 +40,10 @@ describe("nsToDatetime / datetimeToNs", () => {
 describe("formatDuration (unit ladder s/ms/us/ns)", () => {
   it("seconds and milliseconds carry two decimals", () => {
     expect(formatDuration(1e9)).toBe("1s");
+    // At a minute and above the shared format switches to the composite form,
+    // so these table cells do too.
+    expect(formatDuration(120e9)).toBe("2m 0.0s");
+    expect(formatDuration(3600e9)).toBe("1h 0m 0s");
     expect(formatDuration(1.5e9)).toBe("1.5s");
     expect(formatDuration(1e6)).toBe("1ms");
     expect(formatDuration(1.234e6)).toBe("1.23ms");

--- a/dial9-viewer/ui/src/pages/tokio-stats/format.test.ts
+++ b/dial9-viewer/ui/src/pages/tokio-stats/format.test.ts
@@ -39,9 +39,9 @@ describe("nsToDatetime / datetimeToNs", () => {
 
 describe("formatDuration (unit ladder s/ms/us/ns)", () => {
   it("seconds and milliseconds carry two decimals", () => {
-    expect(formatDuration(1e9)).toBe("1.00s");
-    expect(formatDuration(1.5e9)).toBe("1.50s");
-    expect(formatDuration(1e6)).toBe("1.00ms");
+    expect(formatDuration(1e9)).toBe("1s");
+    expect(formatDuration(1.5e9)).toBe("1.5s");
+    expect(formatDuration(1e6)).toBe("1ms");
     expect(formatDuration(1.234e6)).toBe("1.23ms");
   });
   it("microseconds are whole numbers with the U+00B5 micro sign", () => {

--- a/dial9-viewer/ui/src/pages/tokio-stats/format.ts
+++ b/dial9-viewer/ui/src/pages/tokio-stats/format.ts
@@ -30,15 +30,10 @@ export function datetimeToNs(val: string, utc: boolean): string | null {
 }
 
 /**
- * Human duration with the unit ladder: s / ms / us (U+00B5 micro sign) / ns.
- * The threshold label and every P50/P99/Max cell render through this.
+ * Human duration for the threshold label and every P50/P99/Max cell: the
+ * viewer's one duration format, aliased so the page's call sites read locally.
  */
-export function formatDuration(ns: number): string {
-  if (ns >= 1e9) return (ns / 1e9).toFixed(2) + "s";
-  if (ns >= 1e6) return (ns / 1e6).toFixed(2) + "ms";
-  if (ns >= 1e3) return (ns / 1e3).toFixed(0) + "µs";
-  return ns + "ns";
-}
+export { formatHumanDuration as formatDuration } from "../../lib/trace/index.js";
 
 /**
  * The threshold slider's log-scale mapping: value v in [-1, 3] -> 10^v ms in ns

--- a/dial9-viewer/ui/src/pages/tokio-stats/format.ts
+++ b/dial9-viewer/ui/src/pages/tokio-stats/format.ts
@@ -33,7 +33,7 @@ export function datetimeToNs(val: string, utc: boolean): string | null {
  * Human duration for the threshold label and every P50/P99/Max cell: the
  * viewer's one duration format, aliased so the page's call sites read locally.
  */
-export { formatHumanDuration as formatDuration } from "../../lib/trace/index.js";
+export { formatHumanDuration as formatDuration } from "../../lib/trace/api_format.js";
 
 /**
  * The threshold slider's log-scale mapping: value v in [-1, 3] -> 10^v ms in ns

--- a/dial9-viewer/ui/src/pages/viewer/axis.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/axis.test.ts
@@ -280,6 +280,13 @@ describe("label formatting (fmtTs parity + amendment)", () => {
     expect(Math.abs(micros - 1500)).toBeLessThan(2);
   });
 
+  it("fmtWallClockLabel: a pre-epoch wall clock still yields digits", () => {
+    // A negative remainder used to pad its minus sign into the fraction
+    // (".0-1"); the euclidean remainder keeps the field numeric.
+    const label = fmtWallClockLabel(-1_500_000, false, false, 6);
+    expect(label).toMatch(/^\d{2}:\d{2}:\d{2}\.\d{6}$/);
+  });
+
   it("wallClockFracDigits caps at µs (float64 epoch-ns is already quantised)", () => {
     expect(wallClockFracDigits(undefined)).toBe(0);
     expect(wallClockFracDigits(1e9)).toBe(0);
@@ -387,6 +394,26 @@ describe("rulerLayout (window-relative ruler)", () => {
     const sliver = rulerLayout(viewStart, viewEnd, 120, relInputs());
     expect(sliver.chip).toBeNull();
     expect(sliver.anchor).toBeNull();
+  });
+
+  it("drops an edge label that the canvas would clip", () => {
+    // 250px: no chip (its 320px floor), so only the canvas edge protects the
+    // last tick, which lands exactly on x = drawW. The anchor covers x = 0.
+    const layout = rulerLayout(viewStart, viewEnd, 250, relInputs());
+    expect(layout.chip).toBeNull();
+    expect(layout.ticks[0]!.offsetNs).toBe(0);
+    expect(layout.ticks[0]!.text).toBeNull();
+    const last = layout.ticks[layout.ticks.length - 1]!;
+    expect(last.x).toBe(250);
+    expect(last.text).toBeNull();
+  });
+
+  it("keeps the zero label when there is no anchor to yield to", () => {
+    // Below the anchor floor the ruler is bare ticks, so nothing reserves the
+    // left edge - but a label centred at x = 0 would still be half clipped.
+    const layout = rulerLayout(viewStart, viewEnd, 120, relInputs());
+    expect(layout.anchor).toBeNull();
+    expect(layout.ticks[0]!.text).toBeNull();
   });
 
   it("drops a colliding label but keeps its tick mark", () => {

--- a/dial9-viewer/ui/src/pages/viewer/axis.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/axis.test.ts
@@ -1,13 +1,19 @@
-// Tests for the time-axis track. Two load-bearing properties are asserted
+// Tests for the time-axis track. Three load-bearing properties are asserted
 // mechanically here: (1) axis ticks align PIXEL-EXACT with every other track's
-// ns<->x mapping at three column widths, and (2) the date-qualification rule -
-// a day-crossing absolute span gains a `MM-DD ` prefix, a same-day span does
-// not.
+// ns<->x mapping at three column widths, (2) the date-qualification rule - a
+// day-crossing absolute span gains a `MM-DD ` prefix on the anchor, a same-day
+// span does not, and (3) the ruler is window-relative: tick labels are offsets
+// from the left edge whose unit follows the zoom, framed by an absolute anchor
+// and a width/step chip that yield to tick labels on a narrow panel.
 
 import { describe, it, expect } from "vitest";
 import {
   pickTickInterval,
-  tickTimestamps,
+  tickOffsets,
+  cursorPrecisionNs,
+  decimalsForStep,
+  fmtTickOffset,
+  rulerLayout,
   nsToDrawX,
   clockOffsetForTimestamp,
   wallClockNs,
@@ -15,6 +21,7 @@ import {
   isDateQualified,
   fmtDuration,
   fmtWallClockLabel,
+  wallClockFracDigits,
   fmtAxisTick,
   renderTimeAxis,
   type AxisInputs,
@@ -66,21 +73,62 @@ describe("pickTickInterval (nice-values)", () => {
     expect(pickTickInterval(0, 1e9, 50)).toBe(5e8);
   });
 
-  it("falls back to the raw interval past the largest nice value", () => {
-    // 1e12 span over 4 ticks = 2.5e11 > 1e10 (largest nice value).
-    expect(pickTickInterval(0, 1e12, 100)).toBe(1e12 / 4);
+  it("reaches clock-friendly steps above 10s", () => {
+    // 1e12 span (1000s) over 4 ticks = 2.5e11 -> the 5-minute nice value.
+    expect(pickTickInterval(0, 1e12, 100)).toBe(3e11);
+  });
+
+  it("falls back to the raw interval past the largest nice value (1h)", () => {
+    // 1e14 span over 4 ticks = 2.5e13 > 3.6e12.
+    expect(pickTickInterval(0, 1e14, 100)).toBe(1e14 / 4);
+  });
+
+  it("steps back down when snapping up would overshoot the window", () => {
+    // A 4.574s view over a narrow draw area: 4 target ticks -> 1.14s, which
+    // snaps to 5s and would leave a single tick. 1s fits twice, so it wins.
+    expect(pickTickInterval(0, 4.574e9, 275)).toBe(1e9);
+  });
+
+  it("keeps picking steps below a microsecond", () => {
+    // 1µs over 8 ticks = 125ns -> 500ns; 40ns over 8 = 5ns exactly.
+    expect(pickTickInterval(0, 1e3, 800)).toBe(500);
+    expect(pickTickInterval(0, 40, 800)).toBe(5);
   });
 });
 
-describe("tickTimestamps (firstTick loop)", () => {
-  it("emits every interval multiple in [ceil(start/int)*int, end]", () => {
-    expect(tickTimestamps(0, 1e9, 5e8)).toEqual([0, 5e8, 1e9]);
-    expect(tickTimestamps(1e8, 1e9, 5e8)).toEqual([5e8, 1e9]);
+describe("tickOffsets (window-relative)", () => {
+  it("emits every interval multiple from the left edge", () => {
+    expect(tickOffsets(1e9, 5e8)).toEqual([0, 5e8, 1e9]);
+    expect(tickOffsets(9e8, 5e8)).toEqual([0, 5e8]);
   });
 
   it("never spins on a degenerate viewport", () => {
-    expect(tickTimestamps(5, 5, 0)).toEqual([]);
-    expect(tickTimestamps(10, 0, 1e8)).toEqual([]);
+    expect(tickOffsets(0, 0)).toEqual([]);
+    expect(tickOffsets(-1, 1e8)).toEqual([]);
+  });
+});
+
+describe("cursorPrecisionNs", () => {
+  it("targets ~1px of the visible span, snapped to a nice value", () => {
+    expect(cursorPrecisionNs(0, 1e9)).toBe(1e6); // 1s view -> 1ms
+    expect(cursorPrecisionNs(0, 5e5)).toBe(500); // 500µs view -> 500ns
+  });
+
+  it("floors at 1ns on a degenerate viewport", () => {
+    expect(cursorPrecisionNs(5, 5)).toBe(1);
+  });
+});
+
+describe("decimalsForStep", () => {
+  it("counts the decimals a step needs in a given unit", () => {
+    expect(decimalsForStep(1e9, 1e9)).toBe(0);
+    expect(decimalsForStep(1e6, 1e9)).toBe(3);
+    expect(decimalsForStep(5e5, 1e9)).toBe(4);
+    expect(decimalsForStep(1, 1e9)).toBe(9);
+  });
+
+  it("is zero for a non-positive step", () => {
+    expect(decimalsForStep(0, 1e9)).toBe(0);
   });
 });
 
@@ -193,10 +241,58 @@ describe("label formatting (fmtTs parity + amendment)", () => {
     expect(fmtDuration(42)).toBe("+42ns");
   });
 
+  it("fmtDuration: decimals follow the step it must resolve", () => {
+    // A 1µs step at a 2s offset needs 6 decimals to separate two ticks; a 1s
+    // step needs none.
+    expect(fmtDuration(2.0007e9, 1e3)).toBe("+2.000700s");
+    expect(fmtDuration(2.0007e9, 1e9)).toBe("+2s");
+    expect(fmtDuration(2.0007e9, 1e5)).toBe("+2.0007s");
+  });
+
+  it("fmtDuration: unitBasisNs pins the unit so a range shares it", () => {
+    // Without a basis the window start would read "+0ns" beside a "+4.574s"
+    // end; pinning both to the end's magnitude keeps them comparable.
+    expect(fmtDuration(0, 5e6, 4.574e9)).toBe("+0.000s");
+    expect(fmtDuration(4.574e9, 5e6, 4.574e9)).toBe("+4.574s");
+  });
+
   it("fmtWallClockLabel: HH:MM:SS, MM-DD prefix when withDate", () => {
     const wall = DAY0_NS + 23 * HOUR_NS + 61 * 1e9; // 23:01:01 UTC
     expect(fmtWallClockLabel(wall, false, false)).toBe("23:01:01");
     expect(fmtWallClockLabel(wall, false, true)).toBe("01-01 23:01:01");
+  });
+
+  it("fmtWallClockLabel: fractional seconds in 3-digit groups", () => {
+    // Small wall value: exact, so the grouping itself is asserted.
+    expect(fmtWallClockLabel(1_500_000, false, false, 3)).toBe("00:00:00.001");
+    expect(fmtWallClockLabel(1_500_000, false, false, 6)).toBe("00:00:00.001500");
+  });
+
+  it("fmtWallClockLabel: a real epoch timestamp keeps µs, not ns", () => {
+    // Epoch-ns is past 2^53, so a float64 wall clock is quantised to a few
+    // hundred ns: the ms digits are solid, the last µs digit is not. This is
+    // why wallClockFracDigits caps at 6.
+    const wall = DAY0_NS + 23 * HOUR_NS + 61 * 1e9 + 1_500_000; // +1.5ms
+    expect(fmtWallClockLabel(wall, false, false, 3)).toBe("23:01:01.001");
+    const six = fmtWallClockLabel(wall, false, false, 6);
+    expect(six.startsWith("23:01:01.")).toBe(true);
+    const micros = Number(six.slice("23:01:01.".length));
+    expect(Math.abs(micros - 1500)).toBeLessThan(2);
+  });
+
+  it("wallClockFracDigits caps at µs (float64 epoch-ns is already quantised)", () => {
+    expect(wallClockFracDigits(undefined)).toBe(0);
+    expect(wallClockFracDigits(1e9)).toBe(0);
+    expect(wallClockFracDigits(1e6)).toBe(3);
+    expect(wallClockFracDigits(1e3)).toBe(6);
+    expect(wallClockFracDigits(1)).toBe(6);
+  });
+
+  it("fmtTickOffset: bare zero, then the shared duration format", () => {
+    expect(fmtTickOffset(0)).toBe("0");
+    expect(fmtTickOffset(1e5)).toBe("100µs");
+    expect(fmtTickOffset(1500)).toBe("1.5µs");
+    expect(fmtTickOffset(5)).toBe("5ns");
   });
 
   it("fmtAxisTick: relative mode -> offset from minTs", () => {
@@ -214,6 +310,102 @@ describe("label formatting (fmtTs parity + amendment)", () => {
   it("fmtAxisTick: absolute with no anchor falls back to relative", () => {
     const noAnchor: AxisInputs = { ...absInputs(0), clockOffsetNs: null, minTs: DAY0_NS };
     expect(fmtAxisTick(noAnchor, DAY0_NS + 2e9, false)).toBe("+2.00s");
+  });
+});
+
+describe("rulerLayout (window-relative ruler)", () => {
+  // A 500µs window that starts 2.0007s into the trace, over an 800px draw
+  // area: 8 target ticks -> a 100µs step.
+  const viewStart = 2.0007e9;
+  const viewEnd = viewStart + 5e5;
+
+  it("labels ticks as offsets from the left edge, in the zoom's unit", () => {
+    const layout = rulerLayout(viewStart, viewEnd, 800, relInputs());
+    expect(layout.interval).toBe(1e5);
+    expect(layout.ticks.map((t) => t.offsetNs)).toEqual([
+      0, 1e5, 2e5, 3e5, 4e5, 5e5,
+    ]);
+    // The 0 tick yields to the anchor beside it, and the last tick sits under
+    // the chip; the ones between carry their offsets.
+    expect(layout.ticks.map((t) => t.text)).toEqual([
+      null,
+      "100µs",
+      "200µs",
+      "300µs",
+      "400µs",
+      null,
+    ]);
+  });
+
+  it("anchors the window's absolute position at the step's precision", () => {
+    const layout = rulerLayout(viewStart, viewEnd, 800, relInputs());
+    expect(layout.anchor).toBe("+2.0007s");
+    // Zoomed a further two decades in, the anchor gains the decimals it needs.
+    const deep = rulerLayout(viewStart, viewStart + 5e3, 800, relInputs());
+    expect(deep.interval).toBe(1e3);
+    expect(deep.anchor).toBe("+2.000700s");
+  });
+
+  it("keeps the anchor in the window's unit at the trace start", () => {
+    // viewStart is 0 here: without a unit basis the anchor would read "+0ns"
+    // beside second-scale ticks.
+    const layout = rulerLayout(0, 4.574e9, 410, relInputs());
+    expect(layout.interval).toBe(1e9);
+    expect(layout.anchor).toBe("+0s");
+    expect(layout.ticks.map((t) => t.text)).toEqual([
+      null,
+      "1s",
+      "2s",
+      "3s",
+      null,
+    ]);
+  });
+
+  it("states the visible width and the step in the chip", () => {
+    const layout = rulerLayout(viewStart, viewEnd, 800, relInputs());
+    expect(layout.chip).toBe("<-> 500µs (step 100µs)");
+  });
+
+  it("date-qualifies the anchor when the absolute span crosses a day", () => {
+    const vs = DAY0_NS + 23 * HOUR_NS;
+    const layout = rulerLayout(vs, vs + 2 * HOUR_NS, 900, absInputs(0));
+    expect(layout.anchor).toMatch(/^\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    // Ticks stay relative, so they never carry a date.
+    for (const tick of layout.ticks) {
+      if (tick.text !== null) expect(tick.text).not.toMatch(/:/);
+    }
+  });
+
+  it("sheds the step, then the chip, then the anchor as the panel narrows", () => {
+    const wide = rulerLayout(viewStart, viewEnd, 800, relInputs());
+    expect(wide.chip).toContain("step");
+    const mid = rulerLayout(viewStart, viewEnd, 400, relInputs());
+    expect(mid.chip).toBe("<-> 500µs");
+    const narrow = rulerLayout(viewStart, viewEnd, 250, relInputs());
+    expect(narrow.chip).toBeNull();
+    expect(narrow.anchor).not.toBeNull();
+    const sliver = rulerLayout(viewStart, viewEnd, 120, relInputs());
+    expect(sliver.chip).toBeNull();
+    expect(sliver.anchor).toBeNull();
+  });
+
+  it("drops a colliding label but keeps its tick mark", () => {
+    // 4 ticks over 200px: the labels do not all fit beside the anchor.
+    const layout = rulerLayout(viewStart, viewEnd, 200, relInputs());
+    expect(layout.ticks.length).toBeGreaterThan(1);
+    expect(layout.ticks.some((t) => t.text === null)).toBe(true);
+    // Every tick still has a position to draw its mark at.
+    for (const tick of layout.ticks) expect(Number.isFinite(tick.x)).toBe(true);
+  });
+
+  it("maps every tick through the shared ns->x mapping", () => {
+    const drawW = 800;
+    const layout = rulerLayout(viewStart, viewEnd, drawW, relInputs());
+    for (const tick of layout.ticks) {
+      expect(tick.x).toBe(
+        nsToDrawX(viewStart + tick.offsetNs, viewStart, viewEnd, drawW),
+      );
+    }
   });
 });
 
@@ -270,38 +462,26 @@ describe("renderTimeAxis (ruler)", () => {
     expect(rec.labels.length).toBe(0);
   });
 
-  it("draws one tick+label per interval multiple at nsToDrawX, once loaded", () => {
+  it("draws a mark per tick plus the surviving labels and both chips", () => {
     const { ctx, rec } = recordingCtx();
     renderTimeAxis(ctx, geo, viewStart, viewEnd, relInputs(), true);
-    const interval = pickTickInterval(viewStart, viewEnd, geo.time.drawW);
-    const ticks = tickTimestamps(viewStart, viewEnd, interval);
-    expect(rec.labels.length).toBe(ticks.length);
-    expect(ticks.length).toBeGreaterThanOrEqual(2);
-    // Each label at its shared-mapping x, text == fmtAxisTick.
-    rec.labels.forEach((call, i) => {
-      const t = ticks[i]!;
-      expect(call.x).toBe(nsToDrawX(t, viewStart, viewEnd, geo.time.drawW));
-      expect(call.text).toBe(fmtAxisTick(relInputs(), t, false));
+    const layout = rulerLayout(viewStart, viewEnd, geo.time.drawW, relInputs());
+    const kept = layout.ticks.filter((t) => t.text !== null);
+    expect(rec.strokes).toBe(layout.ticks.length);
+    expect(kept.length).toBeGreaterThanOrEqual(2);
+    // Tick labels first, at their shared-mapping x, then the two chips.
+    expect(rec.labels.length).toBe(kept.length + 2);
+    kept.forEach((tick, i) => {
+      const call = rec.labels[i]!;
+      expect(call.text).toBe(tick.text);
+      expect(call.x).toBe(
+        nsToDrawX(viewStart + tick.offsetNs, viewStart, viewEnd, geo.time.drawW),
+      );
     });
-  });
-
-  it("date-qualifies every label when the absolute span crosses a day", () => {
-    const inputs = absInputs(0);
-    const { ctx, rec } = recordingCtx();
-    // A ~2h window straddling UTC midnight.
-    const vs = DAY0_NS + 23 * HOUR_NS;
-    const ve = DAY0_NS + 25 * HOUR_NS;
-    const g2: PanelGeometry = trackGeometry(trackById("timeline"), {
-      pw: 900,
-      scrollbarW: 0,
-      viewStart: vs,
-      viewEnd: ve,
-      dpr: 1,
-    });
-    renderTimeAxis(ctx, g2, vs, ve, inputs, true);
-    expect(rec.labels.length).toBeGreaterThan(0);
-    for (const call of rec.labels) {
-      expect(call.text).toMatch(/^\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
-    }
+    const chips = rec.labels.slice(kept.length);
+    expect(chips[0]!.text).toBe(layout.anchor);
+    expect(chips[0]!.x).toBe(0);
+    expect(chips[1]!.text).toBe(layout.chip);
+    expect(chips[1]!.x).toBe(geo.time.drawW);
   });
 });

--- a/dial9-viewer/ui/src/pages/viewer/axis.ts
+++ b/dial9-viewer/ui/src/pages/viewer/axis.ts
@@ -321,7 +321,9 @@ export function fmtWallClockLabel(
   const ss = localTz ? d.getSeconds() : d.getUTCSeconds();
   let time = pad2(hh) + ":" + pad2(mm) + ":" + pad2(ss);
   if (fracDigits > 0) {
-    const subSecNs = Math.floor(wallNs % 1e9);
+    // Euclidean remainder: a pre-epoch (negative) wall clock would otherwise
+    // pad its minus sign into the fraction ("0-1500000" -> ".0-1").
+    const subSecNs = ((Math.floor(wallNs) % 1e9) + 1e9) % 1e9;
     time += "." + String(subSecNs).padStart(9, "0").slice(0, fracDigits);
   }
   return withDate ? pad2(mo) + "-" + pad2(day) + " " + time : time;
@@ -380,9 +382,18 @@ export function fmtTickOffset(offsetNs: number): string {
 const LABEL_CHAR_W = 6;
 const LABEL_GAP = 8;
 
+/**
+ * Estimated pixel width of ruler text. The one place this estimate lives: the
+ * selection measuring bar sits in this same row and sizes itself through it,
+ * so a font change moves both together.
+ */
+export function estimateLabelWidth(text: string): number {
+  return text.length * LABEL_CHAR_W;
+}
+
 /** Half the estimated pixel width of a label. */
 export function labelHalfWidth(text: string): number {
-  return (text.length * LABEL_CHAR_W) / 2;
+  return estimateLabelWidth(text) / 2;
 }
 
 /**
@@ -445,11 +456,13 @@ export function rulerLayout(
         ? `<-> ${formatHumanDuration(viewDur)}`
         : null;
 
-  // Reserved bands: a tick label may not paint over either chip.
+  // Reserved bands: a tick label may not paint over either chip, and never
+  // past a canvas edge - a centred label at x=0 or x=drawW would be half
+  // clipped, which is what happens on a panel too narrow to carry a chip.
   let lastRight =
-    anchor === null ? -Infinity : anchor.length * LABEL_CHAR_W + LABEL_GAP;
+    anchor === null ? 0 : estimateLabelWidth(anchor) + LABEL_GAP;
   const rightLimit =
-    chip === null ? Infinity : drawW - chip.length * LABEL_CHAR_W - LABEL_GAP;
+    chip === null ? drawW : drawW - estimateLabelWidth(chip) - LABEL_GAP;
 
   const ticks: RulerTick[] = [];
   for (const offsetNs of tickOffsets(viewDur, interval)) {

--- a/dial9-viewer/ui/src/pages/viewer/axis.ts
+++ b/dial9-viewer/ui/src/pages/viewer/axis.ts
@@ -3,11 +3,25 @@
 // added) so ticks line up pixel-exact with the poll/span/CPU marks below.
 // Non-interactive; redrawn when the viewport, trace, or clock mode changes.
 //
-// Absolute-mode tick labels gain a `MM-DD ` date prefix when the visible span
-// crosses a calendar-day boundary, so ticks across a day boundary read
+// The ruler is WINDOW-RELATIVE. Ticks sit at round offsets from the left edge
+// of the visible window (0, 100µs, 200µs, ...) and carry those offsets as their
+// labels, through the viewer's one duration format. So the units follow the
+// zoom (s -> ms -> µs -> ns), labels stay short at any depth, and the tick step
+// itself reads as a duration. Two chips frame them:
+//
+//   Time | +2.000700s   0   100µs   200µs   300µs   <-> 500µs (step 100µs)
+//          ^ anchor: where the window starts        ^ width + step
+//
+// The anchor is the only absolute reading on the ruler; the at-cursor readout
+// (components/overlay) is the other place absolute time is available. Its
+// precision follows the tick step, so it always resolves finer than one tick.
+//
+// Absolute-mode anchors gain a `MM-DD ` date prefix when the visible span
+// crosses a calendar-day boundary, so a window straddling midnight reads
 // unambiguously. Relative mode has no calendar day, so it is never qualified.
 
 import { nsToDrawX } from "../../lib/canvas/index.js";
+import { formatHumanDuration } from "../../lib/trace/index.js";
 export { nsToDrawX };
 
 import type {
@@ -51,18 +65,25 @@ export function deriveAxisInputs(state: StoreState): AxisInputs {
 // ── Tick geometry ────────────────────────────────────────────────────────
 
 /**
- * The "nice" tick intervals in ns: 1µs..10s in a 1/5 progression. The
- * auto-picker snaps the raw interval up to the first of these >= it, so ticks
- * land on round durations.
+ * The "nice" tick intervals in ns: 1ns to 1h. A 1/5 progression up to 10s,
+ * then clock-friendly 30s / 1m / 5m / 10m / 30m / 1h so a long absolute span
+ * still lands on round steps. The auto-picker snaps the raw interval up to the
+ * first of these >= it, so ticks land on round durations at EVERY zoom level -
+ * including below a microsecond, where the ruler used to run out of values.
  */
 const NICE_INTERVALS: readonly number[] = [
-  1e3, 5e3, 1e4, 5e4, 1e5, 5e5, 1e6, 5e6, 1e7, 5e7, 1e8, 5e8, 1e9, 5e9, 1e10,
+  1, 5, 10, 50, 100, 500, 1e3, 5e3, 1e4, 5e4, 1e5, 5e5, 1e6, 5e6, 1e7, 5e7,
+  1e8, 5e8, 1e9, 5e9, 1e10, 3e10, 6e10, 3e11, 6e11, 1.8e12, 3.6e12,
 ];
 
 /**
  * Auto-pick the tick interval (ns) for a visible span over `drawW` px,
  * targeting ~4-16 ticks (`max(4, floor(drawW/100))`). Returns the raw interval
  * when the span is wider than the largest nice value.
+ *
+ * Snapping UP can overshoot the window - a 4.5s view on a narrow panel snaps
+ * 1.1s to 5s and leaves a ruler with one tick - so an interval that cannot fit
+ * twice steps back down to the largest nice value that does.
  */
 export function pickTickInterval(
   viewStart: number,
@@ -72,25 +93,41 @@ export function pickTickInterval(
   const viewDur = viewEnd - viewStart;
   const targetTicks = Math.max(4, Math.floor(drawW / 100));
   const rawInterval = viewDur / targetTicks;
-  return NICE_INTERVALS.find((i) => i >= rawInterval) ?? rawInterval;
+  const snapped = NICE_INTERVALS.find((i) => i >= rawInterval) ?? rawInterval;
+  if (snapped <= viewDur / 2) return snapped;
+  for (let i = NICE_INTERVALS.length - 1; i >= 0; i--) {
+    const candidate = NICE_INTERVALS[i]!;
+    if (candidate <= viewDur / 2) return candidate;
+  }
+  return snapped;
 }
 
 /**
- * The tick timestamps (ns) for a visible span at a given interval: every
- * multiple of `interval` in `[ceil(viewStart/interval)*interval, viewEnd]`.
- * Guards against a non-positive interval so a degenerate viewport can never
- * spin.
+ * The tick offsets (ns from the window's left edge) at a given interval:
+ * `0, interval, 2*interval, ...` up to the window duration. Guards against a
+ * non-positive interval or duration so a degenerate viewport can never spin.
+ *
+ * Offsets, not absolute timestamps: that is what keeps a tick label short at
+ * deep zoom, and it means the ticks stay glued to the left edge while panning.
  */
-export function tickTimestamps(
-  viewStart: number,
-  viewEnd: number,
-  interval: number,
-): number[] {
+export function tickOffsets(viewDur: number, interval: number): number[] {
   const out: number[] = [];
-  if (!(interval > 0) || viewEnd < viewStart) return out;
-  const firstTick = Math.ceil(viewStart / interval) * interval;
-  for (let t = firstTick; t <= viewEnd; t += interval) out.push(t);
+  if (!(interval > 0) || !(viewDur >= 0)) return out;
+  for (let o = 0; o <= viewDur; o += interval) out.push(o);
   return out;
+}
+
+/**
+ * The label precision (ns) for a point-in-time readout at the current zoom -
+ * the at-cursor readout and other single-timestamp labels, which have no tick
+ * step of their own. Targets ~1 screen pixel (span/1000) snapped to a nice
+ * value, so the readout resolves finer than the ruler beneath it.
+ */
+export function cursorPrecisionNs(viewStart: number, viewEnd: number): number {
+  const span = viewEnd - viewStart;
+  if (!(span > 0)) return 1;
+  const raw = span / 1000;
+  return NICE_INTERVALS.find((i) => i >= raw) ?? raw;
 }
 
 /**
@@ -182,7 +219,7 @@ export function crossesDayBoundaryNs(
 }
 
 /**
- * Whether the axis should date-qualify its labels for the current view: only
+ * Whether the axis should date-qualify its anchor for the current view: only
  * in absolute mode with resolvable wall-clock (no anchors -> relative
  * fallback, no calendar day) and only when the visible span crosses a day
  * boundary in the active tz. Computed once per render.
@@ -206,25 +243,75 @@ function pad2(n: number): string {
 }
 
 /**
- * Relative offset label with a `+` prefix: s / ms / µs / ns by magnitude.
- * `ns` here is already the offset from the trace start.
+ * Decimals needed to render a step of `stepNs` exactly in units of `unitNs`
+ * (1e9 for s, 1e6 for ms, ...), capped at 9. Zero once the step is a whole
+ * unit. The 1e-9 slack absorbs log10 rounding on exact decades.
  */
-export function fmtDuration(ns: number): string {
-  const v = ns;
-  if (v >= 1e9) return "+" + (v / 1e9).toFixed(2) + "s";
-  if (v >= 1e6) return "+" + (v / 1e6).toFixed(2) + "ms";
-  if (v >= 1e3) return "+" + (v / 1e3).toFixed(1) + "µs";
-  return "+" + v.toFixed(0) + "ns";
+export function decimalsForStep(stepNs: number, unitNs: number): number {
+  if (!(stepNs > 0)) return 0;
+  const step = stepNs / unitNs;
+  if (step >= 1) return 0;
+  return Math.min(9, Math.ceil(-Math.log10(step) - 1e-9));
+}
+
+/** Unit divisor / suffix / default decimals, by offset magnitude. */
+function durationUnit(v: number): { div: number; suffix: string; fixed: number } {
+  if (v >= 1e9) return { div: 1e9, suffix: "s", fixed: 2 };
+  if (v >= 1e6) return { div: 1e6, suffix: "ms", fixed: 2 };
+  if (v >= 1e3) return { div: 1e3, suffix: "µs", fixed: 1 };
+  return { div: 1, suffix: "ns", fixed: 0 };
+}
+
+/**
+ * Relative POSITION label with a `+` prefix: the offset from the trace start,
+ * in s / ms / µs / ns by magnitude. Unlike a duration this must stay
+ * comparable digit-by-digit as you pan, so the unit follows the magnitude and
+ * the precision follows the zoom.
+ *
+ * `precisionNs` is the step the label must resolve (the tick interval, or
+ * `cursorPrecisionNs` for a point readout): decimals are derived from it so
+ * two nearby positions never collapse to the same text. Omitted, the label
+ * keeps its magnitude-default decimals.
+ *
+ * `unitBasisNs` overrides which magnitude picks the unit, so the two ends of a
+ * range can share one unit ("+0.000s - +4.574s", not "+0ns - +4.574s").
+ */
+export function fmtDuration(
+  ns: number,
+  precisionNs?: number,
+  unitBasisNs: number = ns,
+): string {
+  const { div, suffix, fixed } = durationUnit(unitBasisNs);
+  const decimals =
+    precisionNs === undefined ? fixed : decimalsForStep(precisionNs, div);
+  return "+" + (ns / div).toFixed(decimals) + suffix;
+}
+
+/**
+ * Sub-second digits for a wall-clock label at a step of `precisionNs`: none,
+ * ms (3) or µs (6), in 3-digit groups.
+ *
+ * Capped at µs on purpose: wall-clock ns since the epoch is past 2^53, so a
+ * float64 timestamp is already quantised to a few hundred ns - printing 9
+ * digits would invent precision the value does not carry. Relative mode has no
+ * such limit and goes to single ns.
+ */
+export function wallClockFracDigits(precisionNs: number | undefined): number {
+  if (precisionNs === undefined || precisionNs >= 1e9) return 0;
+  return precisionNs >= 1e6 ? 3 : 6;
 }
 
 /**
  * Wall-clock label for a wall-clock timestamp (ns): "HH:MM:SS", or
  * "MM-DD HH:MM:SS" when `withDate` (date-qualified), in UTC or the local zone.
+ * `fracDigits` (see `wallClockFracDigits`) appends that many sub-second
+ * digits, e.g. "HH:MM:SS.001500" at 6.
  */
 export function fmtWallClockLabel(
   wallNs: number,
   localTz: boolean,
   withDate: boolean,
+  fracDigits = 0,
 ): string {
   const d = new Date(wallNs / 1e6);
   const mo = localTz ? d.getMonth() + 1 : d.getUTCMonth() + 1;
@@ -232,41 +319,165 @@ export function fmtWallClockLabel(
   const hh = localTz ? d.getHours() : d.getUTCHours();
   const mm = localTz ? d.getMinutes() : d.getUTCMinutes();
   const ss = localTz ? d.getSeconds() : d.getUTCSeconds();
-  const time = pad2(hh) + ":" + pad2(mm) + ":" + pad2(ss);
+  let time = pad2(hh) + ":" + pad2(mm) + ":" + pad2(ss);
+  if (fracDigits > 0) {
+    const subSecNs = Math.floor(wallNs % 1e9);
+    time += "." + String(subSecNs).padStart(9, "0").slice(0, fracDigits);
+  }
   return withDate ? pad2(mo) + "-" + pad2(day) + " " + time : time;
 }
 
 /**
- * Format one tick's label. Absolute mode renders wall-clock (date-qualified
- * per `withDate`); with no resolvable anchor it falls back to relative.
+ * Format one absolute POSITION (the ruler anchor, the at-cursor readout, an
+ * inspector timestamp). Absolute mode renders wall-clock (date-qualified per
+ * `withDate`); with no resolvable anchor it falls back to relative.
  * `withDate` is precomputed once per render (`isDateQualified`).
+ *
+ * `precisionNs` is the step the label must resolve - the ruler passes its tick
+ * interval, point readouts pass `cursorPrecisionNs`. Omitted, labels keep the
+ * coarse magnitude defaults. `unitBasisNs` pins the relative-mode unit (see
+ * `fmtDuration`); it does not apply to wall-clock labels.
  */
 export function fmtAxisTick(
   inputs: AxisInputs,
   ns: number,
   withDate: boolean,
+  precisionNs?: number,
+  unitBasisNs?: number,
 ): string {
   if (inputs.timeMode === "abs") {
     const wall = wallClockNs(inputs, ns);
-    if (wall != null) return fmtWallClockLabel(wall, inputs.tz === "local", withDate);
+    if (wall != null)
+      return fmtWallClockLabel(
+        wall,
+        inputs.tz === "local",
+        withDate,
+        wallClockFracDigits(precisionNs),
+      );
     // No anchor: fall back to a relative offset.
   }
-  return fmtDuration(ns - inputs.minTs);
+  return fmtDuration(
+    ns - inputs.minTs,
+    precisionNs,
+    unitBasisNs ?? ns - inputs.minTs,
+  );
+}
+
+/**
+ * A tick's own label: its offset from the window's left edge as a duration, so
+ * the unit tracks the zoom. The zero tick is bare - the anchor beside it
+ * already names that position.
+ */
+export function fmtTickOffset(offsetNs: number): string {
+  return offsetNs === 0 ? "0" : formatHumanDuration(offsetNs);
+}
+
+// ── Ruler layout ─────────────────────────────────────────────────────────
+
+// Label width estimate for the collision rules: 10px monospace is ~6px/glyph,
+// plus a gap so neighbours never touch. Estimated rather than measured so the
+// whole layout stays pure and Node-testable.
+const LABEL_CHAR_W = 6;
+const LABEL_GAP = 8;
+
+/** Half the estimated pixel width of a label. */
+export function labelHalfWidth(text: string): number {
+  return (text.length * LABEL_CHAR_W) / 2;
+}
+
+/**
+ * Draw widths below which the ruler sheds furniture rather than crowding it:
+ * no step in the chip, then no chip at all, then no anchor either (a sliver of
+ * a panel keeps bare ticks).
+ */
+const CHIP_WITH_STEP_MIN_W = 520;
+const CHIP_MIN_W = 320;
+const ANCHOR_MIN_W = 180;
+
+/** One painted tick: its x in draw-area px, and the label if one survived. */
+export interface RulerTick {
+  offsetNs: number;
+  x: number;
+  /** null when the label was dropped for a collision (the mark still draws). */
+  text: string | null;
+}
+
+/** Everything the ruler paints, resolved from the viewport. Pure. */
+export interface RulerLayout {
+  /** The picked tick step (ns). */
+  interval: number;
+  ticks: RulerTick[];
+  /** Absolute position of the window's left edge; null on a sliver panel. */
+  anchor: string | null;
+  /** Visible width (and step, when it fits); null when there is no room. */
+  chip: string | null;
+}
+
+/**
+ * Resolve the ruler for a viewport: tick step, tick positions, which tick
+ * labels survive, and the two framing chips.
+ *
+ * Label collisions are resolved left to right: a label is dropped when its
+ * estimated box would overlap the anchor, the chip, or the last label kept.
+ * The tick mark is always painted, so the grid stays complete even where the
+ * numbers thin out.
+ */
+export function rulerLayout(
+  viewStart: number,
+  viewEnd: number,
+  drawW: number,
+  inputs: AxisInputs,
+): RulerLayout {
+  const interval = pickTickInterval(viewStart, viewEnd, drawW);
+  const viewDur = viewEnd - viewStart;
+  const withDate = isDateQualified(inputs, viewStart, viewEnd);
+
+  // The anchor's unit comes from the window's far end, not from viewStart: at
+  // the trace start it would otherwise read "+0ns" beside second-scale ticks.
+  const anchor =
+    drawW >= ANCHOR_MIN_W
+      ? fmtAxisTick(inputs, viewStart, withDate, interval, viewEnd - inputs.minTs)
+      : null;
+  const chip =
+    drawW >= CHIP_WITH_STEP_MIN_W
+      ? `<-> ${formatHumanDuration(viewDur)} (step ${formatHumanDuration(interval)})`
+      : drawW >= CHIP_MIN_W
+        ? `<-> ${formatHumanDuration(viewDur)}`
+        : null;
+
+  // Reserved bands: a tick label may not paint over either chip.
+  let lastRight =
+    anchor === null ? -Infinity : anchor.length * LABEL_CHAR_W + LABEL_GAP;
+  const rightLimit =
+    chip === null ? Infinity : drawW - chip.length * LABEL_CHAR_W - LABEL_GAP;
+
+  const ticks: RulerTick[] = [];
+  for (const offsetNs of tickOffsets(viewDur, interval)) {
+    const x = nsToDrawX(viewStart + offsetNs, viewStart, viewEnd, drawW);
+    const text = fmtTickOffset(offsetNs);
+    const half = labelHalfWidth(text);
+    const fits = x - half >= lastRight && x + half <= rightLimit;
+    if (fits) lastRight = x + half + LABEL_GAP;
+    ticks.push({ offsetNs, x, text: fits ? text : null });
+  }
+  return { interval, ticks, anchor, chip };
 }
 
 // ── Canvas render ────────────────────────────────────────────────────────
 
-// Axis colours: fill, tick strokes, label text.
+// Axis colours: fill, tick strokes, tick-label text, and the brighter chip
+// text that sets the two framing readings apart from the tick offsets.
 const AXIS_BG = "#16213e";
 const TICK_STROKE = "#333";
 const LABEL_FILL = "#888";
+const CHIP_FILL = "#bbb";
 
 /**
  * Render the time axis into `ctx` (already DPR-scaled and sized to
  * `geometry.time.drawW` x `geometry.height`): a filled background, a short
- * vertical tick at each auto-picked timestamp, and the `fmtAxisTick` label
- * centred above it. Draw-area-relative x (`nsToDrawX`); the DOM gutter
- * provides the LABEL_W offset (see the file header).
+ * vertical tick at each offset, the surviving tick labels, and the anchor /
+ * width chips at the two ends. Draw-area-relative x (`nsToDrawX`); the DOM
+ * gutter provides the LABEL_W offset (see the file header).
  *
  * Called from tracks.ts `sizeTracks` for the "timeline" track, inside the
  * store's frame tick. A blank axis is painted before the trace loads / when
@@ -287,23 +498,31 @@ export function renderTimeAxis(
   ctx.fillRect(0, 0, drawW, height);
   if (!hasTrace || drawW <= 0 || viewEnd <= viewStart) return;
 
-  const interval = pickTickInterval(viewStart, viewEnd, drawW);
-  const ticks = tickTimestamps(viewStart, viewEnd, interval);
-  const withDate = isDateQualified(inputs, viewStart, viewEnd);
+  const layout = rulerLayout(viewStart, viewEnd, drawW, inputs);
 
-  ctx.fillStyle = LABEL_FILL;
   ctx.font = "10px monospace";
-  ctx.textAlign = "center";
   ctx.strokeStyle = TICK_STROKE;
-  // Tick marks span the bottom 10px; label baseline sits above them.
+  // Tick marks span the bottom 10px; every label baseline sits above them.
   const tickTop = height - 10;
   const labelY = height - 14;
-  for (const t of ticks) {
-    const x = nsToDrawX(t, viewStart, viewEnd, drawW);
+
+  ctx.fillStyle = LABEL_FILL;
+  ctx.textAlign = "center";
+  for (const tick of layout.ticks) {
     ctx.beginPath();
-    ctx.moveTo(x, tickTop);
-    ctx.lineTo(x, height);
+    ctx.moveTo(tick.x, tickTop);
+    ctx.lineTo(tick.x, height);
     ctx.stroke();
-    ctx.fillText(fmtAxisTick(inputs, t, withDate), x, labelY);
+    if (tick.text !== null) ctx.fillText(tick.text, tick.x, labelY);
+  }
+
+  ctx.fillStyle = CHIP_FILL;
+  if (layout.anchor !== null) {
+    ctx.textAlign = "left";
+    ctx.fillText(layout.anchor, 0, labelY);
+  }
+  if (layout.chip !== null) {
+    ctx.textAlign = "right";
+    ctx.fillText(layout.chip, drawW, labelY);
   }
 }

--- a/dial9-viewer/ui/src/pages/viewer/main.ts
+++ b/dial9-viewer/ui/src/pages/viewer/main.ts
@@ -27,7 +27,7 @@ import {
   spawnHistogramTooltipRows,
   tooltipRowsTemplate,
 } from "../../components/overlay/index.js";
-import { deriveAxisInputs, fmtAxisTick } from "./axis.js";
+import { cursorPrecisionNs, deriveAxisInputs, fmtAxisTick } from "./axis.js";
 import {
   cpuIntervalAt,
   cpuIntervalTooltip,
@@ -217,7 +217,16 @@ function boot(): void {
     root,
     shell.trackColumn,
     store,
-    (state, ns) => fmtAxisTick(deriveAxisInputs(state), ns, false),
+    // The ruler is window-relative, so this readout is where absolute time
+    // lives: give it a precision finer than one tick so it resolves the
+    // cursor's own position, not the tick it sits near.
+    (state, ns) =>
+      fmtAxisTick(
+        deriveAxisInputs(state),
+        ns,
+        false,
+        cursorPrecisionNs(state.viewport.viewStart, state.viewport.viewEnd),
+      ),
     (trackId, state, ns) => {
       if (trackId === "queue") {
         const bin = shell.queueTrack.spawnBinAt(ns);

--- a/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/queue-track.test.ts
@@ -280,7 +280,7 @@ describe("spawnHistogramTooltipRows", () => {
       [
         {
           label: "Duration:",
-          value: "395.40ms",
+          value: "395ms",
           hint: "(click bar to list tasks)",
         },
       ],

--- a/dial9-viewer/ui/src/pages/viewer/selection-overlay.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/selection-overlay.test.ts
@@ -3,7 +3,13 @@
 // under test is these two pure functions.
 
 import { describe, it, expect } from "vitest";
-import { activeSelectionRegion, selectionBox } from "./selection-overlay.js";
+import {
+  activeSelectionRegion,
+  measureLabelPlacement,
+  measureText,
+  measureWidth,
+  selectionBox,
+} from "./selection-overlay.js";
 import { timePanelLayout, LABEL_W } from "../../lib/canvas/layout.js";
 import type { SelectionSlice, TransientSlice } from "../../types/state.js";
 
@@ -131,5 +137,57 @@ describe("selectionBox - placement (shared ns<->x mapping)", () => {
 
   it("guarantees at least 1px width for a degenerate region", () => {
     expect(selectionBox({ startNs: 500, endNs: 500, mode: "region" }, layout).width).toBe(1);
+  });
+});
+
+describe("measuring bar", () => {
+  it("states the selection duration, and nothing for a zero-length one", () => {
+    expect(measureText({ startNs: 0, endNs: 5e5, mode: "region" })).toBe("500µs");
+    expect(measureText({ startNs: 7, endNs: 7, mode: "region" })).toBeNull();
+  });
+
+  const drawArea = { left: 100, right: 900 };
+
+  it("centres the label inside a box that can hold it", () => {
+    const labelW = measureWidth("500µs");
+    const { placement, offsetX } = measureLabelPlacement(
+      { left: 200, width: 300 },
+      drawArea,
+      labelW,
+    );
+    expect(placement).toBe("inside");
+    expect(offsetX).toBe((300 - labelW) / 2);
+  });
+
+  it("parks the label to the right of a pinched box", () => {
+    const labelW = measureWidth("500µs");
+    const { placement, offsetX } = measureLabelPlacement(
+      { left: 200, width: 4 },
+      drawArea,
+      labelW,
+    );
+    expect(placement).toBe("right");
+    expect(offsetX).toBe(8);
+  });
+
+  it("parks the label to the left when the right edge has no room", () => {
+    const labelW = measureWidth("500µs");
+    const { placement, offsetX } = measureLabelPlacement(
+      { left: 890, width: 4 },
+      drawArea,
+      labelW,
+    );
+    expect(placement).toBe("left");
+    expect(offsetX).toBe(-labelW - 4);
+  });
+
+  it("falls back to inside when neither side fits (a sliver of draw area)", () => {
+    const labelW = measureWidth("500µs");
+    const { placement } = measureLabelPlacement(
+      { left: 100, width: 4 },
+      { left: 100, right: 110 },
+      labelW,
+    );
+    expect(placement).toBe("inside");
   });
 });

--- a/dial9-viewer/ui/src/pages/viewer/selection-overlay.ts
+++ b/dial9-viewer/ui/src/pages/viewer/selection-overlay.ts
@@ -24,6 +24,7 @@
 
 import { assertInScheduledRender } from "../../store/store.js";
 import { formatHumanDuration } from "../../lib/trace/index.js";
+import { estimateLabelWidth } from "./axis.js";
 import { timePanelLayout } from "../../lib/canvas/layout.js";
 import type { TimePanelLayout } from "../../lib/canvas/layout.js";
 import { lanesScrollbarWidth } from "../../lib/canvas/track-layout.js";
@@ -111,10 +112,9 @@ export function selectionBox(region: SelectionRegion, layout: TimePanelLayout): 
   return { left: Math.min(x1, x2), width: Math.max(1, Math.abs(x2 - x1)) };
 }
 
-// Measuring-bar metrics: the label's own box (10px monospace at ~6px/glyph
-// plus padding and borders) and the gap it keeps from the box edge when it has
-// to sit outside.
-const MEASURE_CHAR_W = 6;
+// Measuring-bar metrics: the label's padding and borders on top of the ruler's
+// own text-width estimate (axis.ts owns that, since the bar shares the ruler's
+// row and font), plus the gap it keeps from the box edge when it sits outside.
 const MEASURE_PAD_W = 10;
 const MEASURE_GAP = 4;
 
@@ -131,7 +131,7 @@ export function measureText(region: SelectionRegion): string | null {
 
 /** Estimated width (CSS px) of the measuring bar for `text`. */
 export function measureWidth(text: string): number {
-  return text.length * MEASURE_CHAR_W + MEASURE_PAD_W;
+  return estimateLabelWidth(text) + MEASURE_PAD_W;
 }
 
 /** Where the measuring bar sits relative to the selection box. */
@@ -234,6 +234,9 @@ export function mountSelectionOverlay(
     // then the shared layout - identical inputs to the lanes/overlay.
     const pw = trackColumn.clientWidth;
     const scrollbarW = lanesScrollbarWidth(trackColumn);
+    // Read with the other geometry, BEFORE any style write: a rect read after
+    // a write forces a synchronous layout, and this runs every drag frame.
+    const laneTop = timeLaneTop(trackColumn);
     const { viewStart, viewEnd } = state.viewport;
     if (viewEnd <= viewStart) {
       el.style.display = "none";
@@ -254,7 +257,7 @@ export function mountSelectionOverlay(
     el.style.height = `${trackColumn.scrollHeight}px`;
     el.style.display = "block";
 
-    el.style.setProperty(LANE_TOP_PROP, `${timeLaneTop(trackColumn)}px`);
+    el.style.setProperty(LANE_TOP_PROP, `${laneTop}px`);
     const rail = ensureChild(el, RAIL_CLASS);
     const measure = ensureChild(el, MEASURE_CLASS);
     const text = measureText(region);

--- a/dial9-viewer/ui/src/pages/viewer/selection-overlay.ts
+++ b/dial9-viewer/ui/src/pages/viewer/selection-overlay.ts
@@ -1,6 +1,7 @@
 // The selection overlay: the blue (region) / teal (zoom) box drawn over the
 // lanes during a Shift/Alt drag or a keyboard selection, plus the persistent box
-// for a retained region.
+// for a retained region, and the measuring bar that states how long the
+// selection is.
 //
 // A store render surface, not a handler: the pointer / keyboard machines write
 // `transient.drag` / `transient.keyboardSelection` (and, on a region confirm,
@@ -11,8 +12,18 @@
 //
 // A Shift region stays boxed until the sidebar clears `selection.sidebarRange`.
 // The transient drag/keyboard box takes precedence while a selection is in flight.
+//
+// The measuring bar sits in the time-lane row of the box: a rail spanning the
+// box (the box's own side borders read as its end caps) with the duration on
+// top, so a marquee answers "how long is this" while you drag. It lives here
+// rather than in the axis canvas because tracks.ts does not subscribe to
+// `transient` - repainting every track on each mousemove to move one label
+// would be the wrong trade. The box itself starts at the column's top (above
+// the ruler, at the hint strip), so the bar is offset down to the ruler row
+// through the `--d9-lane-top` custom property.
 
 import { assertInScheduledRender } from "../../store/store.js";
+import { formatHumanDuration } from "../../lib/trace/index.js";
 import { timePanelLayout } from "../../lib/canvas/layout.js";
 import type { TimePanelLayout } from "../../lib/canvas/layout.js";
 import { lanesScrollbarWidth } from "../../lib/canvas/track-layout.js";
@@ -20,6 +31,10 @@ import type { ViewerStore } from "../../store/store.js";
 import type { SelectionSlice, TransientSlice } from "../../types/state.js";
 
 const OVERLAY_CLASS = "d9-selection-overlay";
+const RAIL_CLASS = "d9-selection-rail";
+const MEASURE_CLASS = "d9-selection-measure";
+const LANE_TOP_PROP = "--d9-lane-top";
+const TIMELINE_TRACK_SELECTOR = '[data-track-id="timeline"]';
 const ZOOM_MODIFIER = "zoom";
 
 /** Which encoding the box uses: region (blue) or zoom (teal). */
@@ -96,6 +111,75 @@ export function selectionBox(region: SelectionRegion, layout: TimePanelLayout): 
   return { left: Math.min(x1, x2), width: Math.max(1, Math.abs(x2 - x1)) };
 }
 
+// Measuring-bar metrics: the label's own box (10px monospace at ~6px/glyph
+// plus padding and borders) and the gap it keeps from the box edge when it has
+// to sit outside.
+const MEASURE_CHAR_W = 6;
+const MEASURE_PAD_W = 10;
+const MEASURE_GAP = 4;
+
+/**
+ * The measuring bar's text: the selection's duration, or null for a
+ * zero-length selection (a collapsed keyboard cursor or a retained point) -
+ * there is no span to measure, so no bar is drawn.
+ */
+export function measureText(region: SelectionRegion): string | null {
+  const durationNs = region.endNs - region.startNs;
+  if (!(durationNs > 0)) return null;
+  return formatHumanDuration(durationNs);
+}
+
+/** Estimated width (CSS px) of the measuring bar for `text`. */
+export function measureWidth(text: string): number {
+  return text.length * MEASURE_CHAR_W + MEASURE_PAD_W;
+}
+
+/** Where the measuring bar sits relative to the selection box. */
+export type MeasurePlacement = "inside" | "right" | "left";
+
+/**
+ * Place the measuring bar for a box: centred inside when the box is wide
+ * enough to hold it, else parked just outside the edge that has room (right
+ * first, then left), else centred inside anyway so a pinched selection at the
+ * panel edge still shows its duration.
+ *
+ * `offsetX` is CSS `left` RELATIVE TO THE BOX (the bar is a child of it), so it
+ * is negative when the bar sits to the left. Pure - the placement rule is the
+ * part worth testing.
+ */
+export function measureLabelPlacement(
+  box: SelectionBox,
+  drawArea: { left: number; right: number },
+  labelW: number,
+): { placement: MeasurePlacement; offsetX: number } {
+  if (labelW + 2 * MEASURE_GAP <= box.width) {
+    return { placement: "inside", offsetX: (box.width - labelW) / 2 };
+  }
+  if (box.left + box.width + MEASURE_GAP + labelW <= drawArea.right) {
+    return { placement: "right", offsetX: box.width + MEASURE_GAP };
+  }
+  if (box.left - MEASURE_GAP - labelW >= drawArea.left) {
+    return { placement: "left", offsetX: -labelW - MEASURE_GAP };
+  }
+  return { placement: "inside", offsetX: (box.width - labelW) / 2 };
+}
+
+/**
+ * The time-axis row's offset (px) inside the track column - the row the
+ * measuring bar belongs in. The column starts with the hint strip, so this is
+ * not zero. Layout-relative (plus scrollTop) so it stays glued to the ruler
+ * when the column scrolls; 0 when the track is absent (pre-trace).
+ */
+export function timeLaneTop(trackColumn: HTMLElement): number {
+  const track = trackColumn.querySelector<HTMLElement>(TIMELINE_TRACK_SELECTOR);
+  if (track === null) return 0;
+  return (
+    track.getBoundingClientRect().top -
+    trackColumn.getBoundingClientRect().top +
+    trackColumn.scrollTop
+  );
+}
+
 export interface MountedSelectionOverlay {
   dispose(): void;
 }
@@ -110,6 +194,16 @@ export function mountSelectionOverlay(
   trackColumn: HTMLElement,
   store: ViewerStore,
 ): MountedSelectionOverlay {
+  function ensureChild(parent: HTMLElement, cls: string): HTMLElement {
+    let child = parent.querySelector<HTMLElement>(`.${cls}`);
+    if (child === null) {
+      child = parent.ownerDocument.createElement("div");
+      child.className = cls;
+      parent.appendChild(child);
+    }
+    return child;
+  }
+
   function ensureEl(): HTMLElement {
     let el = trackColumn.querySelector<HTMLElement>(`.${OVERLAY_CLASS}`);
     if (el === null) {
@@ -118,6 +212,8 @@ export function mountSelectionOverlay(
       el.setAttribute("aria-hidden", "true");
       trackColumn.appendChild(el);
     }
+    ensureChild(el, RAIL_CLASS);
+    ensureChild(el, MEASURE_CLASS);
     return el;
   }
 
@@ -157,6 +253,27 @@ export function mountSelectionOverlay(
     el.style.top = "0px";
     el.style.height = `${trackColumn.scrollHeight}px`;
     el.style.display = "block";
+
+    el.style.setProperty(LANE_TOP_PROP, `${timeLaneTop(trackColumn)}px`);
+    const rail = ensureChild(el, RAIL_CLASS);
+    const measure = ensureChild(el, MEASURE_CLASS);
+    const text = measureText(region);
+    if (text === null) {
+      rail.hidden = true;
+      measure.hidden = true;
+      return;
+    }
+    const { placement, offsetX } = measureLabelPlacement(
+      box,
+      { left: layout.labelW, right: layout.labelW + layout.drawW },
+      measureWidth(text),
+    );
+    measure.textContent = text;
+    measure.style.left = `${offsetX}px`;
+    measure.hidden = false;
+    // The rail only reads as a measuring bar when the label breaks it in the
+    // middle; a parked label would leave a bare line.
+    rail.hidden = placement !== "inside";
   }
 
   // Subscribe-only, like the lanes canvas and the crosshair overlay: the first

--- a/dial9-viewer/ui/src/pages/viewer/spans-model.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/spans-model.test.ts
@@ -446,7 +446,7 @@ describe("spanLabelModel + focusInfoLine", () => {
     const label = spanLabelModel("1", data);
     expect(label?.name).toBe("auth");
     expect(label?.rows).toEqual([
-      { key: "latency", display: "1.50ms", copy: "1500000" },
+      { key: "latency", display: "1.5ms", copy: "1500000" },
     ]);
   });
 

--- a/dial9-viewer/ui/src/pages/viewer/spans-track.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/spans-track.test.ts
@@ -197,7 +197,7 @@ describe("drawSpansCanvas duration axis", () => {
 
     drawSpansCanvas(ctx, model, emptyData, stateWithFocus(null), 400, canvasH, 0, 400, colorOf);
 
-    expect(labels.map((label) => label.text)).toEqual(["120.0µs", "180.0µs"]);
+    expect(labels.map((label) => label.text)).toEqual(["120µs", "180µs"]);
     expect(labels.every((label) => label.y >= 9 && label.y <= canvasH - 2)).toBe(true);
   });
 
@@ -207,7 +207,7 @@ describe("drawSpansCanvas duration axis", () => {
 
     drawSpansCanvas(ctx, model, emptyData, stateWithFocus(null), 400, 120, 0, 400, colorOf);
 
-    expect(labels.map((label) => label.text)).toEqual(["150.0µs"]);
+    expect(labels.map((label) => label.text)).toEqual(["150µs"]);
   });
 });
 

--- a/dial9-viewer/ui/src/pages/viewer/status-bar.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/status-bar.test.ts
@@ -92,7 +92,19 @@ describe("statusViewModel (selection + range + progress bindings)", () => {
 
   it("renders the visible range as offsets + duration off the trace start", () => {
     const vm = statusViewModel(loadedState());
-    expect(vm.viewRangeLabel).toMatch(/^view \+1\.00s - \+2\.00s \(/);
+    // Both ends carry the zoom's precision (a 1s window resolves to ms), so a
+    // deep zoom no longer prints the same offset twice.
+    expect(vm.viewRangeLabel).toBe("view +1.000s - +2.000s (1s)");
+  });
+
+  it("keeps the two ends distinct at deep zoom", () => {
+    const s = loadedState();
+    // A 140µs window 2.28s in: at a fixed 2 decimals both ends read "+2.29s".
+    s.viewport = { ...s.viewport, viewStart: 2.286886e9, viewEnd: 2.287026e9 };
+    const vm = statusViewModel(s);
+    const [, start, , end] = vm.viewRangeLabel.split(" ");
+    expect(start).not.toBe(end);
+    expect(vm.viewRangeLabel).toContain("(140µs)");
   });
 
   it("reflects a live selection and segment progress together", () => {

--- a/dial9-viewer/ui/src/pages/viewer/status-bar.ts
+++ b/dial9-viewer/ui/src/pages/viewer/status-bar.ts
@@ -11,6 +11,7 @@ import { html, render, nothing, type TemplateResult } from "lit-html";
 import type { ViewerStore } from "../../store/store.js";
 import type { StoreState, SegmentsSlice } from "../../types/state.js";
 import { formatHumanDuration } from "../../lib/trace/index.js";
+import { cursorPrecisionNs, fmtDuration } from "./axis.js";
 import { mountCopyLink } from "../../lib/url/index.js";
 import type { CopyLinkHandle } from "../../lib/url/index.js";
 
@@ -36,11 +37,6 @@ export interface StatusViewModel {
 }
 
 const KEY_HINTS = "/ search · n/p POI · f fit · z undo zoom · g goto · ? help";
-
-/** Relative offset from the trace start, e.g. `+1.23s`. */
-function relOffset(ns: number, minTs: number): string {
-  return `+${((ns - minTs) / 1e9).toFixed(2)}s`;
-}
 
 /** Selection line: the primary highlighted entity, or "No selection". */
 export function selectionState(sel: StoreState["selection"]): StatusSelection {
@@ -86,8 +82,14 @@ export function segmentProgress(segments: SegmentsSlice): StatusProgress {
 export function statusViewModel(state: StoreState): StatusViewModel {
   const hasTrace = state.trace.trace !== null;
   const { viewStart, viewEnd, minTs } = state.viewport;
+  // Both ends carry the zoom's precision (a fixed 2 decimals collapsed the
+  // range to the same reading twice at depth) in the unit of the later end, so
+  // the two offsets stay comparable digit by digit.
+  const precisionNs = cursorPrecisionNs(viewStart, viewEnd);
+  const unitBasisNs = viewEnd - minTs;
   const viewRangeLabel = hasTrace
-    ? `view ${relOffset(viewStart, minTs)} - ${relOffset(viewEnd, minTs)} ` +
+    ? `view ${fmtDuration(viewStart - minTs, precisionNs, unitBasisNs)} - ` +
+      `${fmtDuration(viewEnd - minTs, precisionNs, unitBasisNs)} ` +
       `(${formatHumanDuration(Math.max(0, viewEnd - viewStart))})`
     : "no trace loaded";
   return {

--- a/dial9-viewer/ui/src/pages/viewer/toolbar.test.ts
+++ b/dial9-viewer/ui/src/pages/viewer/toolbar.test.ts
@@ -79,7 +79,7 @@ describe("file-info stats line", () => {
       recordMinTs: 0,
       recordMaxTs: 3e9,
     });
-    expect(text).toContain("3.00s");
+    expect(text).toContain("3s");
   });
 });
 

--- a/dial9-viewer/ui/src/styles/viewer.css
+++ b/dial9-viewer/ui/src/styles/viewer.css
@@ -1869,6 +1869,39 @@ body {
     border-color: rgba(0, 188, 180, 0.6);
 }
 
+/* The measuring bar, in the time-lane row at the top of the selection box: a
+   rail spanning the box (its side borders are the end caps) with the duration
+   sitting on top, breaking the line. The label is a child of the box, so its
+   `left` is box-relative and may be negative when it parks outside a pinched
+   selection. */
+.d9-selection-rail {
+    position: absolute;
+    top: calc(var(--d9-lane-top, 0px) + 15px);
+    left: 0;
+    right: 0;
+    height: 0;
+    border-top: 1px solid rgba(66, 133, 244, 0.6);
+}
+.d9-selection-overlay.zoom .d9-selection-rail {
+    border-top-color: rgba(0, 188, 180, 0.6);
+}
+.d9-selection-measure {
+    position: absolute;
+    top: calc(var(--d9-lane-top, 0px) + 6px);
+    height: 13px;
+    padding: 0 4px;
+    font: 10px monospace;
+    line-height: 13px;
+    color: var(--d9-fg);
+    background: rgba(22, 33, 62, 0.92);
+    border: 1px solid rgba(66, 133, 244, 0.6);
+    border-radius: 3px;
+    white-space: nowrap;
+}
+.d9-selection-overlay.zoom .d9-selection-measure {
+    border-color: rgba(0, 188, 180, 0.6);
+}
+
 /* Floating viewport controls: zoom in / out / fit, bottom-right glass
    panel. Fixed so it stays in the corner while the track column scrolls; its
    buttons stopPropagation so a click is never treated as a lane click. */

--- a/dial9-viewer/ui/src/types/flamegraph_histogram.d.ts
+++ b/dial9-viewer/ui/src/types/flamegraph_histogram.d.ts
@@ -36,12 +36,6 @@ declare module "*/flamegraph_histogram.js" {
   }
 
   /**
-   * Format a nanosecond duration as a short axis/tooltip label
-   * ("500µs", "1.5ms", "2s"). Empty string for non-finite/negative input.
-   */
-  export function fmtDurationNs(ns: number | string): string;
-
-  /**
    * Validate + sort the backend histogram ascending by `lo_ns`, dropping
    * malformed entries (non-finite / negative / hi<=lo). Non-array -> [].
    */

--- a/dial9-viewer/ui/src/types/format.d.ts
+++ b/dial9-viewer/ui/src/types/format.d.ts
@@ -3,9 +3,11 @@
 
 declare module "*/format.js" {
   /**
-   * Format a duration in nanoseconds as a human-friendly string
-   * ("500ns", "1.5µs", "123.46ms", "5m 12.0s", "2d 4h 30m").
-   * Non-finite or negative input renders as "0ns".
+   * Format a duration in nanoseconds as a human-friendly string: 3 significant
+   * digits (at most 2 decimals) in the unit that keeps the mantissa under 1000
+   * ("100ps", "500ns", "1.5µs", "123ms", "30s"), switching to the composite
+   * form at a minute and above ("5m 12.0s", "2d 4h 30m"). Non-finite or
+   * negative input renders as "0ns". The viewer's ONE duration format.
    */
   export function formatHumanDuration(ns: number): string;
 

--- a/dial9-viewer/ui/src/types/span_explorer.d.ts
+++ b/dial9-viewer/ui/src/types/span_explorer.d.ts
@@ -121,8 +121,6 @@ declare module "*/span_explorer.js" {
 
   // ── Formatting ──
 
-  /** Duration to a compact unit-suffixed string; "—" for null/invalid. */
-
   /** Percentile rank (0..100) to "pNN"/"pNN.N"; keeps tail precision. */
   export function fmtPercentile(p: number | null | undefined): string;
 

--- a/dial9-viewer/ui/src/types/span_explorer.d.ts
+++ b/dial9-viewer/ui/src/types/span_explorer.d.ts
@@ -122,7 +122,6 @@ declare module "*/span_explorer.js" {
   // ── Formatting ──
 
   /** Duration to a compact unit-suffixed string; "—" for null/invalid. */
-  export function fmtNs(ns: number | string | null | undefined): string;
 
   /** Percentile rank (0..100) to "pNN"/"pNN.N"; keeps tail precision. */
   export function fmtPercentile(p: number | null | undefined): string;

--- a/dial9-viewer/ui/tests/core/format.test.ts
+++ b/dial9-viewer/ui/tests/core/format.test.ts
@@ -84,6 +84,15 @@ describe("formatHumanDuration", () => {
     expect(formatHumanDuration(59_000_000_000)).toBe("59s");
   });
 
+  it("59.94 s keeps the seconds reading", () => {
+    expect(formatHumanDuration(59_940_000_000)).toBe("59.9s");
+  });
+  it("a seconds reading that rounds to a minute becomes that minute", () => {
+    // Not "60s" (a reading the seconds branch must never produce), and not
+    // "0m 60.0s" (what formatting the raw value would give).
+    expect(formatHumanDuration(59_960_000_000)).toBe("1m 0.0s");
+  });
+
   // Minutes (>= 60s)
   it("60 s -> 1m 0.0s", () => {
     expect(formatHumanDuration(60_000_000_000)).toBe("1m 0.0s");

--- a/dial9-viewer/ui/tests/core/format.test.ts
+++ b/dial9-viewer/ui/tests/core/format.test.ts
@@ -23,45 +23,65 @@ const { formatHumanDuration, formatHumanBytes, formatFieldValue } =
   };
 
 describe("formatHumanDuration", () => {
-  // Sub-microsecond -> ns
+  // Sub-nanosecond -> ps (a divided duration can land here)
   it("zero", () => {
     expect(formatHumanDuration(0)).toBe("0ns");
   });
+  it("0.1 ns -> ps", () => {
+    expect(formatHumanDuration(0.1)).toBe("100ps");
+  });
+  it("half a picosecond keeps 2 decimals at the ladder floor", () => {
+    expect(formatHumanDuration(0.0005)).toBe("0.5ps");
+  });
+
+  // Sub-microsecond -> ns
   it("500 ns", () => {
     expect(formatHumanDuration(500)).toBe("500ns");
   });
   it("999 ns", () => {
     expect(formatHumanDuration(999)).toBe("999ns");
   });
+  it("100 ns keeps its own unit rather than 0.1µs", () => {
+    expect(formatHumanDuration(100)).toBe("100ns");
+  });
 
   // Microseconds
   it("1 µs", () => {
-    expect(formatHumanDuration(1_000)).toBe("1.0µs");
+    expect(formatHumanDuration(1_000)).toBe("1µs");
   });
   it("1.5 µs", () => {
     expect(formatHumanDuration(1_500)).toBe("1.5µs");
   });
+  it("12.345 µs -> 3 significant digits", () => {
+    expect(formatHumanDuration(12_345)).toBe("12.3µs");
+  });
+  it("rounding up to 1000 promotes a unit", () => {
+    expect(formatHumanDuration(999.6)).toBe("1µs");
+  });
   it("just under 1 ms", () => {
-    expect(formatHumanDuration(999_999)).toBe("1000.0µs");
+    expect(formatHumanDuration(999_999)).toBe("1ms");
   });
 
   // Milliseconds
   it("1 ms", () => {
-    expect(formatHumanDuration(1_000_000)).toBe("1.00ms");
+    expect(formatHumanDuration(1_000_000)).toBe("1ms");
   });
   it("123 ms", () => {
-    expect(formatHumanDuration(123_456_789)).toBe("123.46ms");
+    expect(formatHumanDuration(123_456_789)).toBe("123ms");
   });
   it("999 ms", () => {
-    expect(formatHumanDuration(999_000_000)).toBe("999.00ms");
+    expect(formatHumanDuration(999_000_000)).toBe("999ms");
   });
 
   // Seconds
   it("1 s", () => {
-    expect(formatHumanDuration(1_000_000_000)).toBe("1.00s");
+    expect(formatHumanDuration(1_000_000_000)).toBe("1s");
+  });
+  it("1.5 s", () => {
+    expect(formatHumanDuration(1_500_000_000)).toBe("1.5s");
   });
   it("59 s", () => {
-    expect(formatHumanDuration(59_000_000_000)).toBe("59.00s");
+    expect(formatHumanDuration(59_000_000_000)).toBe("59s");
   });
 
   // Minutes (>= 60s)
@@ -128,13 +148,13 @@ describe("formatHumanBytes", () => {
 
 describe("formatFieldValue", () => {
   it("ns unit", () => {
-    expect(formatFieldValue(1_500_000, "ns")).toBe("1.50ms");
+    expect(formatFieldValue(1_500_000, "ns")).toBe("1.5ms");
   });
   it("us unit", () => {
-    expect(formatFieldValue(1_500, "us")).toBe("1.50ms");
+    expect(formatFieldValue(1_500, "us")).toBe("1.5ms");
   });
   it("ms unit", () => {
-    expect(formatFieldValue(1.5, "ms")).toBe("1.50ms");
+    expect(formatFieldValue(1.5, "ms")).toBe("1.5ms");
   });
   it("s unit", () => {
     expect(formatFieldValue(90, "s")).toBe("1m 30.0s");
@@ -153,10 +173,10 @@ describe("formatFieldValue", () => {
 
   // Decoded I64 fields arrive as BigInt and Varint fields as strings.
   it("BigInt value", () => {
-    expect(formatFieldValue(1_500_000n, "ns")).toBe("1.50ms");
+    expect(formatFieldValue(1_500_000n, "ns")).toBe("1.5ms");
   });
   it("string value", () => {
-    expect(formatFieldValue("1500000", "ns")).toBe("1.50ms");
+    expect(formatFieldValue("1500000", "ns")).toBe("1.5ms");
   });
   it("BigInt bytes", () => {
     expect(formatFieldValue(12_884_901_888n, "bytes")).toBe("12.00 GiB");


### PR DESCRIPTION
## Summary
The time lane ignored zoom. Zoom into a 1ms window and every tick on the ruler read the same thing (`+5.00s`, or `23:00:00` in absolute mode), so you could not tell where you were. Below a microsecond the ticks disappeared entirely.

It also never said how wide the window was. Answering "is this poll 10ms or 100ms?" meant picking two tick labels and subtracting them by eye. Selecting a region with Shift+drag drew a box with no number in it, so a marquee could not measure anything either.

Durations elsewhere in the viewer were inconsistent: the same 1ms could read `1.0µs`-style in one place and `1000.0µs` in another, and nothing ever went below a nanosecond.

### What this solves

- Every tick label tells you where you are, at any zoom.
- The lane states its own width and tick step, so the scale is readable without arithmetic.
- A selection reports its duration while you drag it.
- One duration format everywhere: 3 significant digits, at most 2 decimals, and the unit always carries the magnitude. 1000ns is `1µs`, 100ns stays `100ns`, 0.1ns is `100ps`.

https://github.com/user-attachments/assets/1329bdd8-9cfa-4970-b202-fad378b9782b


