### PR TITLE
fix(taskdump): remove unreleased capture changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - The viewer attaches each captured task stack to the idle gap it describes.
-  The Tokio telemetry integration now requires Tokio 1.53.
 - *(viewer)* inlined frames no longer render upside down. Both the server-side
   aggregation path and `symbolizeChain` flattened an address's inline group
   outermost-first inside a leaf→root callchain, so every inline edge appeared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Task dumps no longer skip every other idle-point capture on Tokio 1.53+, and
-  the viewer attaches each captured stack to the idle gap it describes. The
-  Tokio telemetry integration now requires Tokio 1.53.
+- The viewer attaches each captured task stack to the idle gap it describes.
+  The Tokio telemetry integration now requires Tokio 1.53.
 - *(viewer)* inlined frames no longer render upside down. Both the server-side
   aggregation path and `symbolizeChain` flattened an address's inline group
   outermost-first inside a leaf→root callchain, so every inline edge appeared

--- a/dial9-tokio-telemetry/Cargo.toml
+++ b/dial9-tokio-telemetry/Cargo.toml
@@ -24,7 +24,7 @@ unexpected_cfgs = { level = "warn", check-cfg = [
 missing_debug_implementations = "warn"
 
 [dependencies]
-tokio = { version = "1.53.0", features = [
+tokio = { version = "1.52.0", features = [
     "rt",
     "macros",
     "time",
@@ -142,7 +142,7 @@ metrique-timesource = { version = "0.1", features = [
 ] }
 metrique-writer = { version = "0.1", features = ["test-util"] }
 metrique = { version = "0.1.29", features = ["local-format"] }
-tokio = { version = "1.53.0", features = ["test-util"] }
+tokio = { version = "1.52.0", features = ["test-util"] }
 proptest = "1"
 tempfile = "3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/dial9-tokio-telemetry/src/task_dumped.rs
+++ b/dial9-tokio-telemetry/src/task_dumped.rs
@@ -18,11 +18,13 @@
 //!
 //! # Capture mechanics
 //!
-//! If the current poll returns `Pending`, a fresh capture is taken via
-//! [`tokio::runtime::dump::trace_with`] so that the next poll's sampling
-//! decision has fresh data. The capture runs a second `poll` of the inner
-//! future under the real waker inside `trace_with`, preserving registrations
-//! made by the future without scheduling an extra wake on Tokio 1.53 and later.
+//! After a normal poll returns `Pending`, capture runs a second `poll` of the
+//! inner future under the real waker inside [`tokio::runtime::dump::trace_with`].
+//! Tokio may defer a wake for each captured leaf. To avoid a wake-and-capture
+//! loop, the poll immediately following a capture polls the future normally
+//! but skips capture, retaining any un-emitted frames and their timestamp.
+//! On Tokio versions without capture-induced wakes, this also skips capture
+//! on the next real wake; it never skips the normal poll.
 //!
 //! # Allocation
 //!
@@ -88,6 +90,8 @@ pin_project! {
         sample_mean_ns: u64,
         // Per-task PRNG for drawing exponential gaps.
         rng: SplitMix64,
+        // Skip the next capture, but not the normal poll, to break capture-wake loops.
+        just_captured: bool,
         // Whether task dumps are configured for this recorder. `None` until the
         // first poll reads the per-thread config. The wrapping thread may lack
         // it (e.g. an explicit handle spawned from elsewhere), but the polling
@@ -108,6 +112,7 @@ impl<F> TaskDumped<F> {
             next_sample_ns: 0,
             sample_mean_ns: 0,
             rng: SplitMix64::new(0),
+            just_captured: false,
             enabled: None,
         }
     }
@@ -145,6 +150,7 @@ impl<F: Future> Future for TaskDumped<F> {
         // Fast path: forward without any capture work when either task dumps
         // are disabled, or telemetry as a whole is paused.
         if !enabled || !this.handle.is_enabled() {
+            *this.just_captured = false;
             if this.frames.has_data() {
                 this.frames.clear();
                 *this.pending_capture_ts = None;
@@ -180,6 +186,9 @@ impl<F: Future> Future for TaskDumped<F> {
                 *this.pending_capture_ts = None;
             }
             Poll::Pending => {
+                if std::mem::take(this.just_captured) {
+                    return Poll::Pending;
+                }
                 let repoll_result = this.frames.capture(this.inner.as_mut(), cx);
                 // In rare circumstances, repoll will now be ready.
                 if repoll_result.is_ready() {
@@ -187,6 +196,7 @@ impl<F: Future> Future for TaskDumped<F> {
                     *this.pending_capture_ts = None;
                     return repoll_result;
                 }
+                *this.just_captured = true;
                 let capture_ts = crate::telemetry::recorder::poll_start_ts_monotonic();
                 *this.pending_capture_ts = NonZeroU64::new(capture_ts);
             }

--- a/dial9-tokio-telemetry/tests/task_dump.rs
+++ b/dial9-tokio-telemetry/tests/task_dump.rs
@@ -8,7 +8,7 @@ use dial9_tokio_telemetry::telemetry::{
     recorder,
 };
 use serde::Deserialize;
-use std::future::Future;
+use std::future::{Future, poll_fn};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -90,10 +90,9 @@ fn task_dump_emitted_for_long_sleep() {
     }
 }
 
-/// Tokio 1.53 stopped waking a task from `trace_with`. Each real poll that
-/// reaches a new idle point must therefore refresh the pending capture.
+/// Skipping one capture must not suppress captures for the rest of the task.
 #[test]
-fn task_dump_captures_each_sequential_idle() {
+fn task_dump_resumes_capture_after_skip() {
     let (capture, batches) = capture_processor();
 
     let recorder = recorder(MemoryBuffer::new(CAPTURE_BUFFER_SIZE).unwrap())
@@ -116,8 +115,9 @@ fn task_dump_captures_each_sequential_idle() {
     rt.block_on(async {
         handle
             .spawn(async {
-                tokio::time::sleep(Duration::from_millis(5)).await;
-                tokio::time::sleep(Duration::from_millis(5)).await;
+                for _ in 0..3 {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                }
             })
             .await
             .unwrap();
@@ -132,10 +132,61 @@ fn task_dump_captures_each_sequential_idle() {
         .iter()
         .filter(|e| matches!(e, DumpEvent::TaskDumpEvent { .. }))
         .count();
-    assert_eq!(
-        dump_count, 2,
-        "each sequential idle point should produce a fresh task dump"
+    // Without capture-induced wakes, the second idle is skipped. With them,
+    // the extra polls consume the skip and all three idles can be captured.
+    assert!(
+        (2..=3).contains(&dump_count),
+        "capture must resume after a skipped poll; got {dump_count} dumps"
     );
+}
+
+fn assert_idle_task_does_not_spin(multi_thread: bool) {
+    let (capture, _batches) = capture_processor();
+    let recorder = recorder(MemoryBuffer::new(CAPTURE_BUFFER_SIZE).unwrap())
+        .with_custom_pipeline(|p| p.pipe(capture))
+        .build();
+    let options = TokioAttachOptions::builder()
+        .task_tracking_enabled(true)
+        .maybe_task_dump_config(Some(TaskDumpConfig::builder().rng_seed(42).build()))
+        .build();
+    let rt = if multi_thread {
+        common::attach(&recorder, 2, options)
+    } else {
+        common::attach_current_thread(&recorder, options)
+    };
+
+    let handle = Dial9TokioHandle::current();
+    let result = rt.block_on(async {
+        handle
+            .spawn(async {
+                let sleep = tokio::time::sleep(Duration::from_millis(50));
+                tokio::pin!(sleep);
+                let mut polls = 0;
+                poll_fn(|cx| {
+                    polls += 1;
+                    // Includes capture re-polls and allows a few spurious
+                    // wakes, but fails promptly on a wake-and-capture loop.
+                    assert!(polls <= 10, "task-dump capture keeps polling an idle task");
+                    sleep.as_mut().poll(cx)
+                })
+                .await;
+            })
+            .await
+    });
+
+    drop(rt);
+    recorder.graceful_shutdown(Duration::from_secs(1));
+    result.expect("idle task must complete without a capture loop");
+}
+
+#[test]
+fn task_dump_does_not_spin_current_thread() {
+    assert_idle_task_does_not_spin(false);
+}
+
+#[test]
+fn task_dump_does_not_spin_multi_thread() {
+    assert_idle_task_does_not_spin(true);
 }
 
 /// A task spawned directly through Tokio should not produce task dumps.

--- a/dial9/Cargo.toml
+++ b/dial9/Cargo.toml
@@ -47,7 +47,7 @@ dial9-metrique = { workspace = true, optional = true }
 dial9-viewer = { workspace = true, optional = true, default-features = false }
 anyhow = { version = "1", optional = true }
 
-tokio = { version = "1.53.0", optional = true, default-features = false, features = [
+tokio = { version = "1.52.0", optional = true, default-features = false, features = [
     "rt",
     "rt-multi-thread",
 ] }


### PR DESCRIPTION
## Changes

- Restore `just_captured` logic for capture skips.
- Test against capture loops.
- Recover `1.52.0` as the minimum Tokio version (as `1.53.0` is not strictly needed anymore, and that Cargo.toml version would introduce https://github.com/tokio-rs/tokio/issues/8434 for people currently locked at 1.52 that would be unaffected otherwise).
- Remove these changes from the `Unreleased` section in the changelog.