### PR TITLE
feat(cpu): add system info as segement metadata

### DIFF
--- a/dial9/examples/cpu_profile_workload.rs
+++ b/dial9/examples/cpu_profile_workload.rs
@@ -12,9 +12,11 @@
 // Example prints the deprecated `CpuSampleEvent::worker_id` for illustration.
 #![allow(deprecated)]
 
-use dial9::analysis::analysis_events::{CpuSampleSource, Dial9Event, WorkerId};
+use dial9::analysis::{
+    TraceReader,
+    analysis_events::{CpuSampleSource, Dial9Event, WorkerId},
+};
 use dial9::cpu::CpuProfilingConfig;
-use dial9::format::Decoder;
 use dial9::{Dial9HandleTokioExt, RecorderPerfExt, TokioAttachOptions};
 use dial9::{DiskBuffer, recorder};
 use std::time::Duration;
@@ -43,7 +45,7 @@ fn main() {
     // base_path is a directory: the writer produces cpu_profile_trace/trace.0.bin,
     // which the background worker can detect, symbolize, and gzip-compress.
     let trace_dir = "cpu_profile_trace";
-    let segment_path = "cpu_profile_trace/trace.0.bin";
+    let segment_path = "cpu_profile_trace/trace.0.bin.gz";
 
     let writer = DiskBuffer::builder()
         .base_path(trace_dir)
@@ -87,39 +89,35 @@ fn main() {
 
     // Read back and report
     eprintln!("\n=== Reading trace from {segment_path} ===");
-    let data = std::fs::read(segment_path).unwrap();
-    let mut decoder = Decoder::new(&data).unwrap();
+    let trace = TraceReader::new(segment_path).unwrap();
 
     let mut cpu_samples = 0usize;
     let mut polls = 0usize;
     let mut samples_by_worker: std::collections::HashMap<WorkerId, usize> =
         std::collections::HashMap::new();
 
-    decoder
-        .for_each_event(|raw| {
-            let ev: Dial9Event = raw.deserialize().expect("deserialize");
-            match &ev {
-                Dial9Event::CpuSampleEvent(e) if e.source == CpuSampleSource::CpuProfile => {
-                    cpu_samples += 1;
-                    *samples_by_worker.entry(e.worker_id).or_default() += 1;
-                    if cpu_samples <= 10 {
-                        eprintln!(
-                            "  CpuSample: worker={} t={}ns source={:?} frames={}",
-                            e.worker_id,
-                            e.timestamp_ns,
-                            e.source,
-                            e.callchain.len()
-                        );
-                        for (i, addr) in e.callchain.iter().take(8).enumerate() {
-                            eprintln!("    [{i}] {addr:#x}");
-                        }
+    for ev in &trace.all_events {
+        match ev {
+            Dial9Event::CpuSampleEvent(e) if e.source == CpuSampleSource::CpuProfile => {
+                cpu_samples += 1;
+                *samples_by_worker.entry(e.worker_id).or_default() += 1;
+                if cpu_samples <= 10 {
+                    eprintln!(
+                        "  CpuSample: worker={} t={}ns source={:?} frames={}",
+                        e.worker_id,
+                        e.timestamp_ns,
+                        e.source,
+                        e.callchain.len()
+                    );
+                    for (i, addr) in e.callchain.iter().take(8).enumerate() {
+                        eprintln!("    [{i}] {addr:#x}");
                     }
                 }
-                Dial9Event::PollStartEvent(_) => polls += 1,
-                _ => {}
             }
-        })
-        .unwrap();
+            Dial9Event::PollStartEvent(_) => polls += 1,
+            _ => {}
+        }
+    }
 
     eprintln!("\nPoll starts: {polls}");
     eprintln!("CPU samples: {cpu_samples}");

--- a/examples/android_build.sh
+++ b/examples/android_build.sh
@@ -23,7 +23,7 @@ usage() {
 			    FEATURES="" \\
 			    "${0}"
 			or:
-			    CARGO_PKG="dial9-tokio-telemetry" \\
+			    CARGO_PKG="dial9" \\
 			    EXAMPLE="cpu_profile_workload" \\
 			    FEATURES="-Fcpu-profiling" \\
 			    "${0}"
@@ -106,7 +106,7 @@ cat <<-'EOF' >&2
 	You may also pull the files from there by running:
 
 	    adb pull \
-	        /data/local/tmp/cpu_profile_trace.0.bin.gz \
+	        /data/local/tmp/cpu_profile_trace/trace.0.bin.gz \
 	        ~/Downloads/cpu_profile_trace_"$(date +"%Y-%m-%d_%H-%M-%S")".bin.gz \
 	    ;
 EOF

--- a/perf-self-profile/src/cpu_source.rs
+++ b/perf-self-profile/src/cpu_source.rs
@@ -6,7 +6,7 @@
 //! - [`CpuProfiler`] — process-wide frequency-based CPU sampling.
 //! - [`SchedProfiler`] — per-worker-thread context-switch capture.
 
-use crate::{EventSource, PerfSampler, SamplerConfig, SamplingMode, is_ctimer_active};
+use crate::{EventSource, PerfSampler, SamplerConfig, SamplingMode, is_ctimer_active, sys};
 use dial9_core::encoder::{Encodable, ThreadLocalEncoder};
 use dial9_core::source::{FlushContext, Source};
 use dial9_trace_format::types::{EventEncoder, FieldType};
@@ -428,6 +428,7 @@ impl Source for CpuProfiler {
             "cpu.profile.backend".to_string(),
             self.effective_backend.to_string(),
         ));
+        out.extend(sys::system_metadata());
         // When ctimer is the effective backend, it always samples thread CPU time
         // (CLOCK_THREAD_CPUTIME_ID), regardless of what EventSource was
         // originally requested. Report the *effective* source honestly.

--- a/perf-self-profile/src/sys.rs
+++ b/perf-self-profile/src/sys.rs
@@ -23,6 +23,14 @@ pub(crate) use linux::offline_symbolize::write_symbol_data;
     all(target_os = "android", target_arch = "aarch64")
 ))]
 pub(crate) use linux::symbolize_one_shot;
+#[cfg(all(
+    feature = "cpu-profiling",
+    any(
+        target_os = "linux",
+        all(target_os = "android", target_arch = "aarch64")
+    )
+))]
+pub(crate) use linux::system_metadata;
 #[cfg(any(
     target_os = "linux",
     all(target_os = "android", target_arch = "aarch64")
@@ -42,6 +50,14 @@ mod unsupported;
     all(target_os = "android", target_arch = "aarch64")
 )))]
 pub(crate) use unsupported::symbolize_one_shot;
+#[cfg(all(
+    feature = "cpu-profiling",
+    not(any(
+        target_os = "linux",
+        all(target_os = "android", target_arch = "aarch64")
+    ))
+))]
+pub(crate) use unsupported::system_metadata;
 #[cfg(not(any(
     target_os = "linux",
     all(target_os = "android", target_arch = "aarch64")

--- a/perf-self-profile/src/sys/linux.rs
+++ b/perf-self-profile/src/sys/linux.rs
@@ -5,6 +5,11 @@ mod perf_sampler;
 mod ring_buffer;
 mod sampler;
 mod symbolize;
+#[cfg(feature = "cpu-profiling")]
+mod system_metadata;
+
+#[cfg(feature = "cpu-profiling")]
+pub(crate) use system_metadata::system_metadata;
 
 /// Upper bound of userspace virtual addresses. Addresses at or above this limit
 /// are kernel addresses.

--- a/perf-self-profile/src/sys/linux/system_metadata.rs
+++ b/perf-self-profile/src/sys/linux/system_metadata.rs
@@ -1,0 +1,174 @@
+use std::ffi::CStr;
+use std::io::{self, ErrorKind};
+use std::mem::MaybeUninit;
+use std::sync::OnceLock;
+
+pub(crate) fn system_metadata() -> Vec<(String, String)> {
+    static SYSTEM_METADATA: OnceLock<Vec<(String, String)>> = OnceLock::new();
+
+    SYSTEM_METADATA.get_or_init(collect_system_metadata).clone()
+}
+
+fn collect_system_metadata() -> Vec<(String, String)> {
+    let mut out = Vec::new();
+
+    match uname_metadata() {
+        Ok(entries) => out.extend(entries),
+        Err(e) => tracing::warn!("failed to read uname metadata: {e}"),
+    }
+
+    match std::fs::read_to_string("/proc/cpuinfo").and_then(|value| {
+        parse_cpu_model(&value).ok_or_else(|| {
+            io::Error::new(
+                ErrorKind::InvalidData,
+                "no supported CPU model field in /proc/cpuinfo",
+            )
+        })
+    }) {
+        Ok(model) => out.push(("cpu.profile.cpu_model".to_string(), model)),
+        Err(e) => tracing::warn!("failed to read CPU model from /proc/cpuinfo: {e}"),
+    }
+
+    match std::fs::read_to_string("/proc/meminfo")
+        .and_then(|value| parse_total_memory_bytes(&value))
+    {
+        Ok(total_bytes) => out.push((
+            "cpu.profile.memory_total_bytes".to_string(),
+            total_bytes.to_string(),
+        )),
+        Err(e) => tracing::warn!("failed to read total memory from /proc/meminfo: {e}"),
+    }
+
+    out
+}
+
+fn uname_metadata() -> io::Result<[(String, String); 4]> {
+    let mut utsname = MaybeUninit::<libc::utsname>::uninit();
+    // SAFETY: `utsname.as_mut_ptr()` points to valid storage for uname
+    // to initialize.
+    let rc = unsafe { libc::uname(utsname.as_mut_ptr()) };
+    if rc != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: uname returned success and initialized `utsname`.
+    let utsname = unsafe { utsname.assume_init() };
+
+    Ok([
+        (
+            "cpu.profile.machine_hostname".to_string(),
+            uname_field(&utsname.nodename)?,
+        ),
+        (
+            "cpu.profile.machine_architecture".to_string(),
+            uname_field(&utsname.machine)?,
+        ),
+        (
+            "cpu.profile.kernel_release".to_string(),
+            uname_field(&utsname.release)?,
+        ),
+        (
+            "cpu.profile.kernel_version".to_string(),
+            uname_field(&utsname.version)?,
+        ),
+    ])
+}
+
+fn uname_field(field: &[libc::c_char]) -> io::Result<String> {
+    // SAFETY: fields populated by uname are null-terminated C strings.
+    let value = unsafe { CStr::from_ptr(field.as_ptr()) };
+
+    value
+        .to_str()
+        .map(str::to_owned)
+        .map_err(|err| io::Error::new(ErrorKind::InvalidData, err))
+}
+
+fn parse_cpu_model(contents: &str) -> Option<String> {
+    ["model name", "Processor", "Hardware"]
+        .into_iter()
+        .find_map(|wanted| {
+            contents.lines().find_map(|line| {
+                let (key, value) = line.split_once(':')?;
+                let value = value.trim();
+                (key.trim() == wanted && !value.is_empty()).then(|| value.to_string())
+            })
+        })
+}
+
+fn parse_total_memory_bytes(contents: &str) -> io::Result<u64> {
+    let value = contents
+        .lines()
+        .find_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            (key.trim() == "MemTotal").then_some(value.trim())
+        })
+        .ok_or_else(|| {
+            io::Error::new(
+                ErrorKind::InvalidData,
+                "MemTotal missing from /proc/meminfo",
+            )
+        })?;
+
+    let mut parts = value.split_whitespace();
+    let kibibytes = parts
+        .next()
+        .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "MemTotal has no value"))?
+        .parse::<u64>()
+        .map_err(|e| io::Error::new(ErrorKind::InvalidData, e))?;
+    if parts.next() != Some("kB") || parts.next().is_some() {
+        return Err(io::Error::new(
+            ErrorKind::InvalidData,
+            "MemTotal must contain a value followed by kB",
+        ));
+    }
+
+    kibibytes
+        .checked_mul(1024)
+        .ok_or_else(|| io::Error::new(ErrorKind::InvalidData, "MemTotal overflows bytes"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_model_uses_common_architecture_specific_fields() {
+        let cpuinfo = r#"
+Processor   : ARMv8 Processor rev 1 (v8l)
+Hardware    : Generic DT based system
+model name  : Neoverse-N1
+"#;
+        assert_eq!(parse_cpu_model(cpuinfo).as_deref(), Some("Neoverse-N1"));
+
+        let cpuinfo = "processor : 0\nHardware : BCM2835\n";
+        assert_eq!(parse_cpu_model(cpuinfo).as_deref(), Some("BCM2835"));
+    }
+
+    #[test]
+    fn uname_metadata_contains_hostname_and_architecture() {
+        let metadata = uname_metadata().unwrap();
+
+        for key in [
+            "cpu.profile.machine_hostname",
+            "cpu.profile.machine_architecture",
+        ] {
+            let value = metadata
+                .iter()
+                .find_map(|(candidate, value)| (candidate == key).then_some(value))
+                .unwrap_or_else(|| panic!("missing {key}"));
+            assert!(!value.is_empty(), "{key} must not be empty");
+        }
+    }
+
+    #[test]
+    fn mem_total_kibibytes_are_converted_to_bytes() {
+        let meminfo = "MemFree: 1024 kB\nMemTotal: 16343428 kB\n";
+        assert_eq!(parse_total_memory_bytes(meminfo).unwrap(), 16_735_670_272);
+    }
+
+    #[test]
+    fn malformed_mem_total_is_rejected() {
+        let error = parse_total_memory_bytes("MemTotal: unlimited kB\n").unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::InvalidData);
+    }
+}

--- a/perf-self-profile/src/sys/unsupported.rs
+++ b/perf-self-profile/src/sys/unsupported.rs
@@ -10,6 +10,11 @@ fn unsupported<T>() -> io::Result<T> {
     ))
 }
 
+#[cfg(feature = "cpu-profiling")]
+pub(crate) fn system_metadata() -> Vec<(String, String)> {
+    Vec::new()
+}
+
 /// Stub `PerfSampler` for non-Linux platforms.
 ///
 /// All constructors return [`io::ErrorKind::Unsupported`].


### PR DESCRIPTION
Closes #879

Adds some linux and android system information to segment metadata in cpu profiling. Metadata that cannot be read or parsed is logged and omitted from the trace.

New fields:

| Field | Source | Example from my Docker setup | Example from Android |
| --- | --- | --- | --- |
| cpu.profile.cpu_model | /proc/cpuinfo (`model name`, `Processor`, or `Hardware`) | Skipped, arm64 kernels don't expose a CPU model name in /proc/cpuinfo  | <- same |
| cpu.profile.kernel_release | uname.release | `6.10.14-linuxkit` | `5.15.123-android13-3-28579584` |
| cpu.profile.kernel_version | uname.version | `#1 SMP Sat May 17 08:28:57 UTC 2025` | `#1 SMP PREEMPT Fri Jul 5 17:55:35 KST 2024` |
| cpu.profile.machine_hostname | uname.nodename | `6830cf53fb83` | `localhost` |
| cpu.profile.machine_architecture | uname.machine | `aarch64` | `aarch64` |
| cpu.profile.memory_total_bytes | /proc/meminfo (`MemTotal`) | `13584277504` | `5691387904` |

Also updates the android example build script (dial9_tokio_telemetry -> dial9) and fixes the trace reading in `cpu_profile_workload_example`
